### PR TITLE
refactored plus

### DIFF
--- a/src/main/scala/com/twitter/algebird/RightFolded.scala
+++ b/src/main/scala/com/twitter/algebird/RightFolded.scala
@@ -21,7 +21,7 @@ package com.twitter.algebird
  * Also, you must start on the right, with a value, and all subsequent RightFolded must
  * be RightFoldedToFold objects or zero
  *
- * If you add to Folded values together, you always get the one on the left,
+ * If you add two Folded values together, you always get the one on the left,
  * so this forms a kind of reset of the fold.
  */
 object RightFolded {


### PR DESCRIPTION
## motivation

I was reading algebird and had some trouble understanding what exactly was going on in plus, although the behavior is fairly simple, so I refactored it.
## plus behavior

There are three different subclasses of RightFolded, and the two arguments to plus can be either of the two. There are nine different possible combinations, because left and right are not interchangeable.  Assuming the current version is correct, my refactoring must have the same behavior for all nine of those cases.
## covering all nine cases

The left RightFolded reduces to three cases.  In two of those cases, RightFoldedValue (RFV) and RightFoldedZero (RFZ), we don't care what the value of the right RightFolded is, because it does the same thing every time.  For RFZ, we always want the right value (if right is also RFZ, it doesn't matter which we hand back), and for RFV, we always want the left value.  The only cases that remain are the left is RightFoldedToFold (RFTF) cases, where each of those cases is distinct, so I separated those out each to their own call.  Hence, there are 6 cases which are covered by the first two case statements, and 3 cases which are covered individually by the nested case statement.
## different behavior

No behavior has changed.
## comment change

Fixed a typo.
