### PR TITLE
removed message digest field in HyperLogLog

### DIFF
--- a/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -28,8 +28,11 @@ import java.util.Arrays
  * Philippe Flajolet and Éric Fusy and Olivier Gandouet and Frédéric Meunier
  */
 object HyperLogLog {
-  val md = java.security.MessageDigest.getInstance("MD5")
-  def hash(input : Array[Byte]) : Array[Byte] = md.digest(input)
+
+  def hash(input : Array[Byte]) : Array[Byte] = {
+    val md = java.security.MessageDigest.getInstance("MD5")
+    md.digest(input)
+  }
 
   implicit def int2Bytes(i : Int) = {
     val buf = new Array[Byte](4)


### PR DESCRIPTION
I was getting spurious test failures (NullPointerExceptions) on the calls to "digest". Took a look at the API and I think you're actually supposed to call "reset" after updating the digest with any data (http://docs.oracle.com/javase/6/docs/api/java/security/MessageDigest.html). Also, apparently digest/update calls to MessageDigest aren't thread-safe, so I think it's fine if we create the instance inside the hash method to avoid those problems. People can always write their own versions of the method if that's not performant enough for them.
