### PR TITLE
Makes normal usage of HyperLogLog as fast as the builder

### DIFF
--- a/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -122,7 +122,6 @@ case class HLLItem(size : Int, j : Int, rhow : Byte) extends HLL {
  */
 case class HLLInstance(v : IndexedSeq[Byte]) extends HLL {
   lazy val zeroCnt = v.count { _ == 0 }
-  lazy val isZero = zeroCnt == v.size
 
   def +(other : HLL) : HLL = {
     other match {
@@ -141,26 +140,6 @@ case class HLLInstance(v : IndexedSeq[Byte]) extends HLL {
   // Named from the parameter in the paper, probably never useful to anyone
   // except HyperLogLogMonoid
   lazy val z : Double = 1.0 / (v.map { mj => HyperLogLog.twopow(-mj) }.sum)
-}
-
-/* If you have a list of items to create at once and speed is absolutely of the essence
- * You can use this class which internally uses a mutable buffer.
- * Is always CUMULATIVE. Allocate a new one for each new set you are considering
- */
-class HLLInstanceBuilder(val bits: Int) {
-  lazy val v = new Array[Byte](1 << bits)
-
-  def add(example: Array[Byte]): HLLInstanceBuilder = {
-    val hashed = HyperLogLog.hash(example)
-    val (j,rhow) = HyperLogLog.jRhoW(hashed, bits)
-    v(j) = rhow max v(j)
-    this
-  }
-
-  def build(): HLLInstance = {
-    new HLLInstance(v.toIndexedSeq)
-  }
-
 }
 
 /*

--- a/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -33,12 +33,6 @@ class HyperLogLogTest extends Specification {
     hll.estimateSize(hll.sum(it.map { hll(_) }))
   }
 
-  def approxCountBuilder[T <% Array[Byte]](bits : Int, it : Iterable[T]) = {
-    val hllBuilder = it.foldLeft(new HLLInstanceBuilder(bits)) { (left, right) => left.add(right) }
-    val hll = new HyperLogLogMonoid(bits)
-    hll.estimateSize(hllBuilder.build())
-  }
-
   def aveErrorOf(bits : Int) : Double = 1.04/scala.math.sqrt(1 << bits)
 
   def exactIntersect[T](it : Seq[Iterable[T]]) : Int = {
@@ -55,13 +49,11 @@ class HyperLogLogTest extends Specification {
     val data = (0 to 10000).map { i => r.nextInt(1000) }
     val exact = exactCount(data).toDouble
     scala.math.abs(exact - approxCount(bits, data)) / exact must be_<(2.5 * aveErrorOf(bits))
-    scala.math.abs(exact - approxCountBuilder(bits, data)) / exact must be_<(2.5 * aveErrorOf(bits))
   }
   def testLong(bits : Int) {
     val data = (0 to 10000).map { i => r.nextLong }
     val exact = exactCount(data).toDouble
     scala.math.abs(exact - approxCount(bits, data)) / exact must be_<(2.5 * aveErrorOf(bits))
-    scala.math.abs(exact - approxCountBuilder(bits, data)) / exact must be_<(2.5 * aveErrorOf(bits))
   }
   def testLongIntersection(bits : Int, sets : Int) {
     val data : Seq[Iterable[Int]] = (0 until sets).map { idx =>


### PR DESCRIPTION
My benchmarks show that the normal usage of HyperLogLogMonoid.apply(x)

and then calling plus on created instances is now just as fast as using the builder.

This is important because the builder code doesn't fit cleanly into scalding or summingbird's model of how to work with Monoids.

I actually wonder if we should remove the builder code node, but I'll leave that the Ashu to decide.
