### PR TITLE
Adds RightFolded2, which can be useful for parallel SGD on hadoop

### DIFF
--- a/src/main/scala/com/twitter/algebird/RightFolded.scala
+++ b/src/main/scala/com/twitter/algebird/RightFolded.scala
@@ -28,13 +28,13 @@ object RightFolded {
   def monoid[In,Out](foldfn : (In,Out) => Out) =
     new Monoid[RightFolded[In,Out]] {
 
-    lazy val zero = RightFoldedZero[In,Out]()
+    val zero = RightFoldedZero
 
     def plus(left : RightFolded[In,Out], right : RightFolded[In,Out]) = left match {
       case RightFoldedValue(_) => left
-      case RightFoldedZero() => right
+      case RightFoldedZero => right
       case RightFoldedToFold(lList) => right match {
-        case RightFoldedZero() => RightFoldedToFold(lList)
+        case RightFoldedZero => RightFoldedToFold(lList)
         case RightFoldedValue(vr) => RightFoldedValue(lList.foldRight(vr)(foldfn))
         case RightFoldedToFold(rList) => RightFoldedToFold(lList ++ rList)
       }
@@ -42,7 +42,7 @@ object RightFolded {
   }
 }
 
-sealed abstract class RightFolded[In,Out]
-case class RightFoldedZero[In,Out]() extends RightFolded[In,Out]
-case class RightFoldedValue[In,Out](v : Out) extends RightFolded[In,Out]
-case class RightFoldedToFold[In,Out](in : List[In]) extends RightFolded[In,Out]
+sealed abstract class RightFolded[+In,+Out]
+case object RightFoldedZero extends RightFolded[Nothing,Nothing]
+case class RightFoldedValue[+Out](v : Out) extends RightFolded[Nothing,Out]
+case class RightFoldedToFold[+In](in : List[In]) extends RightFolded[In,Nothing]

--- a/src/main/scala/com/twitter/algebird/RightFolded2.scala
+++ b/src/main/scala/com/twitter/algebird/RightFolded2.scala
@@ -1,0 +1,92 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird
+
+/**
+ * This monoid takes a list of values of type In or Out,
+ * and folds to the right all the Ins into Out values, leaving
+ * you with a list of Out values, then finally, maps those outs
+ * onto Acc, where there is a group, and adds all the Accs up.
+ * So, if you have a list:
+ * I I I O I O O I O I O
+ * the monoid is equivalent to the computation:
+ *
+ * map(fold(List(I,I,I),O)) + map(fold(List(I),O)) + map(fold(List(),O)) +
+ *   map(fold(List(I),O)) + map(fold(List(I),O))
+ *
+ * This models a version of the map/reduce paradigm, where the fold happens
+ * on the mappers for each group on Ins, and then they are mapped to Accs,
+ * sent to a single reducer and all the Accs are added up.
+ */
+object RightFolded2 {
+  def monoid[In,Out:Group](foldfn : (In,Out) => Out) =
+    new RightFolded2Monoid[In,Out,Out](foldfn, identity _)
+
+  def monoid[In,Out,Acc:Group](trans: (Out) => Acc)(foldfn: (In,Out) => Out) =
+    new RightFolded2Monoid[In,Out,Acc](foldfn, trans)
+}
+
+class RightFolded2Monoid[In,Out,Acc](foldfn: (In,Out) => Out, accfn: (Out) => Acc)
+  (implicit grpAcc: Group[Acc])
+  extends Monoid[RightFolded2[In,Out,Acc]] {
+  val zero = RightFoldedZero2
+
+  def init(i: Out) = RightFoldedValue2[In,Out,Acc](i, accfn(i), Nil)
+  def toFold(v: In) = RightFoldedToFold2(List(v))
+
+  protected def doFold(vals: List[In], init: Out, acc: Acc) : (Out,Acc) = {
+    val newV = vals.foldRight(init)(foldfn)
+    val delta = grpAcc.plus(accfn(newV), grpAcc.negate(accfn(init)))
+    (newV, grpAcc.plus(delta, acc))
+  }
+
+  def plus(left: RightFolded2[In,Out,Acc], right : RightFolded2[In,Out,Acc]) = left match {
+    case RightFoldedValue2(leftV,leftAcc,leftRvals) => {
+      right match {
+        case RightFoldedZero2 => left
+        case RightFoldedToFold2(in) => RightFoldedValue2(leftV, leftAcc, leftRvals ++ in)
+        case RightFoldedValue2(rightV,rightAcc,rightRvals) => {
+          if (leftRvals.isEmpty) {
+            // This is the case of two initial values next to each other, return the left:
+            val newAcc = grpAcc.plus(leftAcc, rightAcc)
+            RightFoldedValue2(leftV, newAcc, rightRvals)
+          }
+          else {
+            val (newV, newRightAcc) = doFold(leftRvals, rightV, rightAcc)
+            // Now actually add the left value, with the right:
+            val newAcc = grpAcc.plus(leftAcc, newRightAcc)
+            RightFoldedValue2(leftV, newAcc, rightRvals)
+          }
+        }
+      }
+    }
+    case RightFoldedZero2 => right
+    case RightFoldedToFold2(lList) => right match {
+      case RightFoldedZero2 => left
+      case RightFoldedToFold2(rList) => RightFoldedToFold2(lList ++ rList)
+      case RightFoldedValue2(vr,accr,valsr) => {
+        val (newV, newAcc) = doFold(lList, vr, accr)
+        RightFoldedValue2(newV, newAcc, valsr)
+      }
+    }
+  }
+}
+
+sealed abstract class RightFolded2[+In,+Out,+Acc]
+case object RightFoldedZero2 extends RightFolded2[Nothing,Nothing,Nothing]
+case class RightFoldedValue2[+In,+Out,+Acc](v: Out, acc: Acc, rvals: List[In]) extends RightFolded2[In,Out,Acc]
+case class RightFoldedToFold2[+In](in: List[In]) extends RightFolded2[In,Nothing,Nothing]

--- a/src/test/scala/com/twitter/algebird/RightFolded2Test.scala
+++ b/src/test/scala/com/twitter/algebird/RightFolded2Test.scala
@@ -1,0 +1,83 @@
+package com.twitter.algebird
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Gen.oneOf
+import org.scalacheck.Gen
+
+import scala.annotation.tailrec
+
+object RightFolded2Test extends Properties("RightFolded2Monoid") with BaseProperties {
+
+  def monFold(i: Int, l: Long) = l + i.toLong
+  def mapFn(l : Long) = l/2
+
+  implicit val rightFoldedMonoid = RightFolded2.monoid[Int,Long,Long](mapFn)(monFold)
+
+  def rightFolded2Value[In,Out,Acc]
+    (implicit arbout: Arbitrary[Out], mon: RightFolded2Monoid[In,Out,Acc]) :
+    Gen[RightFoldedValue2[In,Out,Acc]] =
+     for(v <- arbout.arbitrary) yield mon.init(v)
+
+  def rightFolded2ToFold[In,Out,Acc]
+    (implicit arbin: Arbitrary[In], mon: RightFolded2Monoid[In,Out,Acc]) :
+    Gen[RightFoldedToFold2[In]] =
+     for(v <- arbin.arbitrary) yield mon.toFold(v)
+
+  implicit def rightFolded2[In,Out,Acc]
+    (implicit arbin: Arbitrary[In], arbout: Arbitrary[Out], mon: RightFolded2Monoid[In,Out,Acc])
+      : Arbitrary[RightFolded2[In,Out,Acc]] =
+     Arbitrary { oneOf(rightFolded2Value[In,Out,Acc], rightFolded2ToFold[In,Out,Acc]) }
+
+  property("RightFolded2 is a monoid") = monoidLaws[RightFolded2[Int,Long,Long]]
+
+  // Make a list of lists such that the all but the last element satisfies the predicate
+  // and joining the lists returns the original list
+  @tailrec
+  def chunk[T](items: List[T], acc: List[List[T]] = Nil)(pred: T => Boolean): List[List[T]] = {
+    val (headL, tailL) = items.span(pred)
+    if(tailL.isEmpty) {
+      if(!headL.isEmpty) (headL :: acc).reverse else acc.reverse
+    }
+    else {
+      val newAcc = (headL :+ (tailL.head))::acc
+      chunk(tailL.tail, newAcc)(pred)
+    }
+  }
+  // The last element in this list must be a rightFoldedValue
+  def fold[In,Out,Acc](l: List[RightFolded2[In,Out,Acc]]) (foldfn: (In,Out) => Out) : Option[Out] = {
+    l.last match {
+      case RightFoldedValue2(v,_,_) => {
+        Some(l.dropRight(1)
+          .flatMap { _.asInstanceOf[RightFoldedToFold2[In]].in }
+          .foldRight(v)(foldfn))
+      }
+      case _ => None
+    }
+  }
+  def sum[In,Out,Acc:Group](l:List[RightFolded2[In,Out,Acc]])
+    (foldfn: (In,Out) => Out)(mapfn: (Out) => Acc) : Acc = {
+    def notIsVal(rf : RightFolded2[In,Out,Acc]) = rf match {
+      case RightFoldedValue2(_,_,_) => false
+      case _ => true
+    }
+    val chunks = chunk(l)(notIsVal)
+
+    val grp = implicitly[Group[Acc]]
+    val vals = chunks.map { fold(_)(foldfn).map(mapfn).getOrElse(grp.zero) }
+    grp.sum(vals)
+  }
+
+  def accOf[In,Out,Acc](rfv: RightFolded2[In,Out,Acc]): Option[Acc] = {
+    rfv match {
+      case RightFoldedValue2(_,acc,_) => Some(acc)
+      case _ => None
+    }
+  }
+
+  property("RightFolded2 sum works as expected") = forAll { (ls : List[RightFolded2[Int,Long,Long]]) =>
+    val accSum = accOf(rightFoldedMonoid.sum(ls)).getOrElse(0L)
+    (sum(ls)(monFold)(mapFn) == accSum)
+  }
+}

--- a/src/test/scala/com/twitter/algebird/RightFoldedTest.scala
+++ b/src/test/scala/com/twitter/algebird/RightFoldedTest.scala
@@ -1,0 +1,24 @@
+package com.twitter.algebird
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Gen.oneOf
+
+object RightFoldedTest extends Properties("RightFoldedMonoid") with BaseProperties {
+
+  implicit def rightFoldedValue[Out:Arbitrary] : Arbitrary[RightFoldedValue[Out]] =
+    Arbitrary {
+     for(v <- implicitly[Arbitrary[Out]].arbitrary) yield RightFoldedValue(v)
+    }
+  implicit def rightFoldedToFold[In:Arbitrary] : Arbitrary[RightFoldedToFold[In]] =
+    Arbitrary {
+     for(v <- implicitly[Arbitrary[In]].arbitrary) yield RightFoldedToFold(List(v))
+    }
+  implicit def rightFolded[In:Arbitrary, Out:Arbitrary] : Arbitrary[RightFolded[In,Out]] =
+     Arbitrary { oneOf(rightFoldedValue[Out].arbitrary, rightFoldedToFold[In].arbitrary) }
+
+  implicit val rightFoldedMonoid = RightFolded.monoid[Int,Long] { (i,l) => l + i.toLong }
+
+  property("RightFolded is a monoid") = monoidLaws[RightFolded[Int,Long]]
+}


### PR DESCRIPTION
This might mostly  be useful as an example of how a fairly general computation can be expressed as a monoid.  The application to SGD is the following: you fold samples into initial values of weights, and then after you finish folding, you average the weights found in each block of SGD.

This is an approach Jimmy Lin uses, and I off hand mentioned at Hadoop summit that this could be expressed as a monoid (without any particular evidence).  Here is the evidence.
