### PR TITLE
Aggregator trait provides a generic mapPlusMap-like abstraction

### DIFF
--- a/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -1,6 +1,6 @@
 package com.twitter.algebird
 
-trait Aggregator[A,B,C] extends Function1[TraversableOnce[A], C]{
+trait Aggregator[A,B,C] extends Function1[TraversableOnce[A], C] with java.io.Serializable {
   def prepare(input : A) : B
   def reduce(l : B, r : B) : B
   def present(reduction : B) : C


### PR DESCRIPTION
A common, but inconsistent, pattern that we're seeing is to have methods for preparing members of the monoid from simple objects like numbers and strings, and sometimes methods for presenting the results of computations on the members (that is, ways of getting simple objects back out).

Some examples currently: AveragedValue (which has a companion object for preparation, no method for presentation), DecayedValue (ditto), HLL (companion object for preparation, method on the monoid for presentation), CountMin (methods on the monoid for preparation, methods on the members for presentation)...

Aggregator is a first attempt to standardize all of this as a higher-level API built on top of algebird's abstract algebra. It aims to be suitable for use in Scalding or similar frameworks along with mapReduceMap-type aggregation APIs, encapsulated in a simple aggregate() call along the same lines as plus().

Averager is provided as a minimal example. If you think this is a good idea, I'm happy to provide implementations for the other monoids mentioned.
