### PR TITLE
Add murmurhash to hyperloglog

### DIFF
--- a/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -29,9 +29,11 @@ import java.util.Arrays
  */
 object HyperLogLog {
 
-  def hash(input : Array[Byte]) : Array[Byte] = {
-    val md = java.security.MessageDigest.getInstance("MD5")
-    md.digest(input)
+  lazy val hash = {
+    /** This seed could be anything */
+    val seed = 123456789
+    val r = new scala.util.Random(seed)
+    MurmurHash128(r.nextLong)
   }
 
   implicit def int2Bytes(i : Int) = {


### PR DESCRIPTION
This is probably a breaking change, correct? What do you think of creating a Hasher trait and refactoring the HyperLogLog code to accept an implicit hasher, with the old md5 as default?
