### PR TITLE
Add a DecayedMap class and monoid.

### DIFF
--- a/src/main/scala/com/twitter/algebird/DecayedMap.scala
+++ b/src/main/scala/com/twitter/algebird/DecayedMap.scala
@@ -1,0 +1,59 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird
+
+/**
+ * Represents a map whose values decay over time.
+ * Similar in spirit to {@link DecayedValue}
+ */
+object DecayedMap extends java.io.Serializable {
+
+  def build[K](innerMap: Map[K, Double], time: Double, halfLife: Double) = {
+    DecayedMap(innerMap, time * scala.math.log(2.0) / halfLife)
+  }
+
+  def scale[K](newm: DecayedMap[K], oldm : DecayedMap[K], eps : Double) = {
+    val oldScaledMap = oldm.innerMap.map { case(key: K, value: Double) =>
+      (key, scala.math.exp(oldm.scaledTime - newm.scaledTime) * value)
+    }
+
+    val newMap = Monoid.plus(newm.innerMap, oldScaledMap)
+      .filter { case(key: K, value: Double) => value > eps }
+
+    DecayedMap(newMap, newm.scaledTime)
+  }
+
+  def monoidWithEpsilon[K](eps : Double) = new Monoid[DecayedMap[K]] {
+    override val zero = DecayedMap(Map[K, Double](), Double.NegativeInfinity)
+    override def plus(left : DecayedMap[K], right : DecayedMap[K]) = {
+      if (left < right) {
+        //left is older:
+        scale(right, left, eps)
+      }
+      else {
+        // right is older
+        scale(left, right, eps)
+      }
+    }
+  }
+}
+
+case class DecayedMap[K](innerMap: Map[K, Double], scaledTime: Double) extends Ordered[DecayedMap[K]] {
+  def compare(that: DecayedMap[K]): Int = {
+    scaledTime.compareTo(that.scaledTime)
+  }
+}

--- a/src/test/scala/com/twitter/algebird/DecayedMapTest.scala
+++ b/src/test/scala/com/twitter/algebird/DecayedMapTest.scala
@@ -1,0 +1,39 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird
+
+import org.specs._
+
+class DecayedMapTest extends Specification {
+  "A DecayedMap monoid" should {
+    implicit val dmMonoid = DecayedMap.monoidWithEpsilon[Int](0.01)
+
+    "decay two maps properly" in {
+      val dm1 = DecayedMap.build(Map(1 -> 1.0), 0.0, 1.0)
+      val dm2 = DecayedMap.build(Map(1 -> 1.0), 1.0, 1.0)
+      val dmOut = Monoid.plus(dm1, dm2)
+      dmOut.innerMap must_== Map(1 -> 1.5)
+    }
+
+    "remove elements that are less than epsilon" in {
+      val dm1 = DecayedMap.build(Map(2 -> 0.01), 0.0, 1.0)
+      val dm2 = DecayedMap.build(Map(1 -> 1.0), 1.0, 1.0)
+      val dmOut = Monoid.plus(dm1, dm2)
+      dmOut.innerMap must_== Map(1 -> 1.0)
+    }
+  }
+}


### PR DESCRIPTION
I need the notion of a map whose values are doubles that exponentially decay over time. Here is one way to do it. 

An alternative would be to extend the DecayedValue class to accept any type of value (not just double) which implements a scalable trait that could look like this:

``` scala
trait Scalable[V] {
  def scale(newV: V, oldV: V, epsilon: Double): V
}
```

Let me know if you think this is ok, or if you would rather have the alternative.
