### PR TITLE
HyperLogLog refactoring + sparse vector implementation

### DIFF
--- a/src/main/scala/com/twitter/algebird/OrderedSemigroup.scala
+++ b/src/main/scala/com/twitter/algebird/OrderedSemigroup.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package com.twitter.algebird
 
 // To use the MaxSemigroup wrap your item in a Max object
-case class Max[@specialized(Byte,Int,Long,Float,Double) +T](get: T)
+case class Max[+T](get: T)
 
 object Max {
   implicit def semigroup[T](implicit ord:Ordering[T]) =
@@ -24,7 +24,7 @@ object Max {
 }
 
 // To use the MinSemigroup wrap your item in a Min object
-case class Min[@specialized(Byte,Int,Long,Float,Double) +T](get: T)
+case class Min[+T](get: T)
 
 object Min {
   implicit def semigroup[T](implicit ord:Ordering[T]) =


### PR DESCRIPTION
This is a reimplementation of HyperLogLog using sparse vectors in place of single items.  It should be _much_ more space efficient in applications that involve lots of small datasets with tight error bounds.

Many functions in the HyperLogLogMonoid class have been factored out into HLL (but with the public endpoints left in place for backward compatibility).
