### PR TITLE
rename cassandra's MurmurHash

### DIFF
--- a/src/main/java/com/twitter/algebird/CassandraMurmurHash.java
+++ b/src/main/java/com/twitter/algebird/CassandraMurmurHash.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.utils;
+package com.twitter.algebird;
 
 import java.nio.ByteBuffer;
 
@@ -31,7 +31,7 @@ import java.nio.ByteBuffer;
  * Andrzej Bialecki (ab at getopt org).
  * </p>
  */
-public class MurmurHash
+public class CassandraMurmurHash
 {
     public static int hash32(ByteBuffer data, int offset, int length, int seed)
     {

--- a/src/main/scala/com/twitter/algebird/MurmurHash.scala
+++ b/src/main/scala/com/twitter/algebird/MurmurHash.scala
@@ -4,7 +4,7 @@ import java.nio._
 
 case class MurmurHash128(seed : Long) {
   def apply(buffer : ByteBuffer, offset : Int, length : Int) : (Long,Long) = {
-    val longs = org.apache.cassandra.utils.MurmurHash.hash3_x64_128(buffer, offset, length, seed)
+    val longs = CassandraMurmurHash.hash3_x64_128(buffer, offset, length, seed)
     (longs(0), longs(1))
   }
 


### PR DESCRIPTION
This was causing class version issues with builds that also included org.apache.cassandra.
