### PR TITLE
Adds MurmurHashable128 and util-hashing dependency.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
+  "com.twitter" %% "util-hashing" % "6.0.5" exclude("com.twitter", "util-core"),
   "org.scalacheck" %% "scalacheck" % "1.10.0" % "test",
   "org.scala-tools.testing" % "specs_2.9.0-1" % "1.6.8" % "test"
 )

--- a/src/main/java/com/twitter/algebird/CassandraMurmurHash.java
+++ b/src/main/java/com/twitter/algebird/CassandraMurmurHash.java
@@ -184,8 +184,6 @@ public class CassandraMurmurHash
 
         for(int i = 0; i < nblocks; i++)
         {
-            int i_8 = i << 4;
-
             long k1 = getblock(key, offset, i*2+0);
             long k2 = getblock(key, offset, i*2+1);
 

--- a/src/main/scala/com/twitter/algebird/MurmurHash.scala
+++ b/src/main/scala/com/twitter/algebird/MurmurHash.scala
@@ -1,6 +1,6 @@
 package com.twitter.algebird
 
-import java.nio._
+import java.nio.ByteBuffer
 import com.twitter.hashing.Hashable
 
 object MurmurHashable128 {
@@ -60,7 +60,7 @@ object MurmurHashable128 {
   def onString(seed: Long = defaultSeed): MurmurHashable128[String] = apply(seed) { s => generateBuffer(s.getBytes) }
 }
 
-class MurmurHashable128[T](seed: Long) extends Hashable[T, (Long, Long)] {
+abstract class MurmurHashable128[T](seed: Long) extends Hashable[T, (Long, Long)] {
   // The returned ByteBuffer needs to store all data from idx 0 to
   // "position".
   def getByteBuffer(t: T): ByteBuffer

--- a/src/main/scala/com/twitter/algebird/MurmurHash.scala
+++ b/src/main/scala/com/twitter/algebird/MurmurHash.scala
@@ -1,35 +1,95 @@
 package com.twitter.algebird
 
 import java.nio._
+import com.twitter.hashing.Hashable
 
-case class MurmurHash128(seed : Long) {
-  def apply(buffer : ByteBuffer, offset : Int, length : Int) : (Long,Long) = {
-    val longs = CassandraMurmurHash.hash3_x64_128(buffer, offset, length, seed)
-    (longs(0), longs(1))
+object MurmurHashable128 {
+  val defaultSeed = 1234567891234567891L
+  private def generateBuffer(bytes: Array[Byte]): ByteBuffer = {
+    val buf = ByteBuffer.wrap(bytes)
+    buf.position(bytes.size)
+    buf
   }
-
-  def apply(bytes : Array[Byte]) : (Long, Long) = apply(ByteBuffer.wrap(bytes), 0, bytes.length)
-  def apply(maxBytes : Int, fn : ByteBuffer => Unit) : (Long, Long) = {
+  private def generateBuffer(maxBytes: Int)(fn: ByteBuffer => Unit): ByteBuffer = {
     val buffer = ByteBuffer.allocate(maxBytes)
     fn(buffer)
-    apply(buffer, 0, maxBytes)
+    buffer
   }
-  def apply(array : Array[Char]) : (Long, Long) = apply(array.size * 2, {_.asCharBuffer.put(array)}) 
-  def apply(array : Array[Short]) : (Long, Long) = apply(array.size * 2, {_.asShortBuffer.put(array)})
-  def apply(array : Array[Int]) : (Long, Long) = apply(array.size * 4, {_.asIntBuffer.put(array)})
-  def apply(array : Array[Float]) : (Long, Long) = apply(array.size * 4, {_.asFloatBuffer.put(array)})
-  def apply(array : Array[Long]) : (Long, Long) = apply(array.size * 8, {_.asLongBuffer.put(array)})
-  def apply(array : Array[Double]) : (Long, Long) = apply(array.size * 8, {_.asDoubleBuffer.put(array)})
+  def apply[T](seed: Long)(fn: T => ByteBuffer) =
+    new MurmurHashable128[T](seed) {
+      override def getByteBuffer(t: T) = fn(t)
+    }
+  def onByteArray(seed: Long = defaultSeed): MurmurHashable128[Array[Byte]] =
+    apply(seed) { generateBuffer(_) }
+  def onCharArray(seed: Long = defaultSeed): MurmurHashable128[Array[Char]] =
+    apply(seed) { arr =>
+      generateBuffer(arr.size * 2) { _.asCharBuffer.put(arr) }
+    }
+  def onShortArray(seed: Long = defaultSeed): MurmurHashable128[Array[Short]] =
+    apply(seed) { arr =>
+      generateBuffer(arr.size * 2) { _.asShortBuffer.put(arr) }
+    }
+  def onIntArray(seed: Long = defaultSeed): MurmurHashable128[Array[Int]] =
+    apply(seed) { arr =>
+      generateBuffer(arr.size * 4) { _.asIntBuffer.put(arr) }
+    }
+  def onFloatArray(seed: Long = defaultSeed): MurmurHashable128[Array[Float]] =
+    apply(seed) { arr =>
+      generateBuffer(arr.size * 4) { _.asFloatBuffer.put(arr) }
+    }
+  def onLongArray(seed: Long = defaultSeed): MurmurHashable128[Array[Long]] =
+    apply(seed) { arr =>
+      generateBuffer(arr.size * 8) { _.asLongBuffer.put(arr) }
+    }
+  def onDoubleArray(seed: Long = defaultSeed): MurmurHashable128[Array[Double]] =
+    apply(seed) { arr =>
+      generateBuffer(arr.size * 8) { _.asDoubleBuffer.put(arr) }
+    }
+  def onChar(seed: Long = defaultSeed): MurmurHashable128[Char] =
+    apply(seed) { value => generateBuffer(2) { _.asCharBuffer.put(value) } }
+  def onShort(seed: Long = defaultSeed): MurmurHashable128[Short] =
+    apply(seed) { value => generateBuffer(2) { _.asShortBuffer.put(value) } }
+  def onInt(seed: Long = defaultSeed): MurmurHashable128[Int] =
+    apply(seed) { value => generateBuffer(4) { _.asIntBuffer.put(value) } }
+  def onFloat(seed: Long = defaultSeed): MurmurHashable128[Float] =
+    apply(seed) { value => generateBuffer(4) { _.asFloatBuffer.put(value) } }
+  def onLong(seed: Long = defaultSeed): MurmurHashable128[Long] =
+    apply(seed) { value => generateBuffer(8) { _.asLongBuffer.put(value) } }
+  def onDouble(seed: Long = defaultSeed): MurmurHashable128[Double] =
+    apply(seed) { value => generateBuffer(8) { _.asDoubleBuffer.put(value) } }
+  def onString(seed: Long = defaultSeed): MurmurHashable128[String] = apply(seed) { s => generateBuffer(s.getBytes) }
+}
 
-  def apply(value : Char) : (Long, Long)= apply(2, {_.asCharBuffer.put(value)})
-  def apply(value : Short) : (Long, Long) = apply(2, {_.asShortBuffer.put(value)})
-  def apply(value : Int) : (Long, Long) = apply(4, {_.asIntBuffer.put(value)})
-  def apply(value : Float) : (Long, Long) = apply(4, {_.asFloatBuffer.put(value)})
-  def apply(value : Long) : (Long, Long) = apply(8, {_.asLongBuffer.put(value)})
-  def apply(value : Double) : (Long, Long) = apply(8, {_.asDoubleBuffer.put(value)})
+class MurmurHashable128[T](seed: Long) extends Hashable[T, (Long, Long)] {
+  // The returned ByteBuffer needs to store all data from idx 0 to
+  // "position".
+  def getByteBuffer(t: T): ByteBuffer
 
-  def apply(string : CharSequence) : (Long, Long) = apply(string.length * 2, {buffer =>
-    val charBuffer = buffer.asCharBuffer
-    0.to(string.length - 1).foreach{i => charBuffer.put(string.charAt(i))}
-  })
+  override def apply(t: T): (Long, Long) = {
+    val buf = getByteBuffer(t)
+    val longs = CassandraMurmurHash.hash3_x64_128(buf, 0, buf.position, seed)
+    (longs(0), longs(1))
+  }
+  def withSeed(newSeed: Long) = MurmurHashable128(newSeed) { t: T => this.getByteBuffer(t) }
+}
+
+// TODO: Once util-bijection is published, define each of these using
+// a Bijection[T,Array[Byte]].
+
+case class MurmurHash128(seed: Long) {
+  def apply(bytes: Array[Byte]): (Long, Long) = MurmurHashable128.onByteArray(seed)(bytes)
+  def apply(array: Array[Char]): (Long, Long) = MurmurHashable128.onCharArray(seed)(array)
+  def apply(array: Array[Short]): (Long, Long) = MurmurHashable128.onShortArray(seed)(array)
+  def apply(array: Array[Int]): (Long, Long) = MurmurHashable128.onIntArray(seed)(array)
+  def apply(array: Array[Float]): (Long, Long) = MurmurHashable128.onFloatArray(seed)(array)
+  def apply(array: Array[Long]): (Long, Long) = MurmurHashable128.onLongArray(seed)(array)
+  def apply(array: Array[Double]): (Long, Long) = MurmurHashable128.onDoubleArray(seed)(array)
+
+  def apply(value: Char): (Long, Long) = MurmurHashable128.onChar(seed)(value)
+  def apply(value: Short): (Long, Long) = MurmurHashable128.onShort(seed)(value)
+  def apply(value: Int): (Long, Long) = MurmurHashable128.onInt(seed)(value)
+  def apply(value: Float): (Long, Long) = MurmurHashable128.onFloat(seed)(value)
+  def apply(value: Long): (Long, Long) = MurmurHashable128.onLong(seed)(value)
+  def apply(value: Double): (Long, Long) = MurmurHashable128.onDouble(seed)(value)
+  def apply(string: String): (Long, Long) = MurmurHashable128.onString(seed)(string)
 }

--- a/src/test/scala/com/twitter/algebird/MetricProperties.scala
+++ b/src/test/scala/com/twitter/algebird/MetricProperties.scala
@@ -78,7 +78,7 @@ trait MetricProperties {
     isNonNegative[T] && isEqualIffZero[T](eqfn) && isSymmetric[T] && satisfiesTriangleInequality[T]
 
   // TODO: these are copied elsewhere in the tests. Move them to a common place
-  def beCloseTo(a: Double, b: Double, eps: Double = 1e-10) =  a == b || (math.abs(a - b) / math.abs(a)) < eps || (a.isInfinite && b.isInfinite)
+  def beCloseTo(a: Double, b: Double, eps: Double = 1e-6) =  a == b || (math.abs(a - b) / math.abs(a)) < eps || (a.isInfinite && b.isInfinite)
   def beGreaterThan(a: Double, b: Double, eps: Double = 1e-10) = a > b - eps || (a.isInfinite && b.isInfinite)
   def defaultEqFn[T](a: T, b: T): Boolean = a == b
 }

--- a/src/test/scala/com/twitter/algebird/MinHasherTest.scala
+++ b/src/test/scala/com/twitter/algebird/MinHasherTest.scala
@@ -28,7 +28,6 @@ class MinHasherTest extends Specification {
     val exact = exactSimilarity(set1, set2)
     val sim = approxSimilarity(mh, set1, set2)
     val error = math.abs(exact - sim)
-    println(exact, sim, error)
     error must be_<[Double](epsilon)
   }
 

--- a/src/test/scala/com/twitter/algebird/MurmurHashTest.scala
+++ b/src/test/scala/com/twitter/algebird/MurmurHashTest.scala
@@ -1,0 +1,17 @@
+package com.twitter.algebird
+
+import java.nio.ByteBuffer
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
+
+object MurmurHashableLaws extends Properties("MurmurHashable128")
+with BaseProperties {
+  property("on bytes matches the CassandraMurmurHash") =
+    forAll { (seed: Long, bytes: Array[Byte]) =>
+      val ourHash = MurmurHashable128.onByteArray(seed)(bytes)
+      val buf = ByteBuffer.wrap(bytes)
+      val longs = CassandraMurmurHash.hash3_x64_128(buf, 0, bytes.size, seed)
+      ourHash == (longs(0), longs(1))
+    }
+}

--- a/src/test/scala/com/twitter/algebird/SummingQueueTest.scala
+++ b/src/test/scala/com/twitter/algebird/SummingQueueTest.scala
@@ -26,12 +26,13 @@ object SummingQueueTest extends Properties("SummingQueue") {
 
   val sb = SummingQueue[Int](3)
   property("puts are like sums") = forAll { (items: List[Int]) =>
+    sb.flush // sb is stateful! Empty before beginning test iteration.
     Semigroup.sumOption(items) ==
       (Monoid.plus(Monoid.sum(items.map { sb(_) }), sb.flush))
   }
   property("puts return None sometimes") = forAll { (items: List[Int]) =>
     // Should be: true, true, true, false, true, true, true, false
-    sb.flush
+    sb.flush // sb is stateful! Empty before beginning test iteration.
     val empties = items.map { sb.put(_).isEmpty }
     val correct = Stream
       .continually( Stream(true, true, true, false) )


### PR DESCRIPTION
This pull request introduces `com.twitter/util-hashing` as a dependency into Algebird, blowing up the jar size by a massive 64k. For you worried aesthetes/goat lovers, `util-hashing` is in maven central and has no extra dependencies.

@johnynek and I rewrote `MurmurHash128` in terms of a new `MurmurHashable128` class.

We also fixed a couple of busted tests and removed an errant println.