### PR TITLE
Relax precision for flaky HyperLogLog tests.

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -50,12 +50,12 @@ class HyperLogLogTest extends Specification {
   def test(bits : Int) {
     val data = (0 to 10000).map { i => r.nextInt(1000) }
     val exact = exactCount(data).toDouble
-    scala.math.abs(exact - approxCount(bits, data)) / exact must be_<(2.5 * aveErrorOf(bits))
+    scala.math.abs(exact - approxCount(bits, data)) / exact must be_<(3.5 * aveErrorOf(bits))
   }
   def testLong(bits : Int) {
     val data = (0 to 10000).map { i => r.nextLong }
     val exact = exactCount(data).toDouble
-    scala.math.abs(exact - approxCount(bits, data)) / exact must be_<(2.5 * aveErrorOf(bits))
+    scala.math.abs(exact - approxCount(bits, data)) / exact must be_<(3.5 * aveErrorOf(bits))
   }
   def testLongIntersection(bits : Int, sets : Int) {
     val data : Seq[Iterable[Int]] = (0 until sets).map { idx =>


### PR DESCRIPTION
These tests were failing very often for me. This should deal with that.
