### PR TITLE
added constructors for MinHasher and subclasses that allow the number of...

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
@@ -15,7 +15,7 @@ object MinHasherTest extends Properties("MinHasher") {
   implicit val mhMonoid = new MinHasher32(0.5, 512)
   implicit val mhGen = Arbitrary { for(
       v <- choose(0,10000)
-    ) yield (MinHashSignature(mhMonoid.init(v)))
+    ) yield (mhMonoid.init(v))
   }
 
   property("MinHasher is a Monoid") = monoidLawsEq[MinHashSignature]{(a,b) => a.bytes.toList == b.bytes.toList}


### PR DESCRIPTION
... hashes and number of bands to be input, instead of relying on these being computed from a threshold. motivation: we had a need to guarantee the exact bytes in the hashes for backwards compatibility with previously generated and stored hashes. relying on the same numbers being computed from a Double constructor argument seemed somewhat risky.
