### PR TITLE
SketchMap doesn't use Implicit Monoid on V

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -138,12 +138,6 @@ case class SketchMap[K, V](
 )(implicit ordering: Ordering[V], monoid: Monoid[V]) extends java.io.Serializable {
 
   /**
-   * Redefine the AdaptiveMatrix Monoid so it takes the implicit Monoid from
-   * the SketchMap.
-   */
-  private implicit val valuesTableMonoid: Monoid[AdaptiveMatrix[V]] = AdaptiveMatrix.monoid[V]
-
-  /**
    * All of the Heavy Hitter frequencies calculated all at once.
    */
   private val heavyHittersMapping: Map[K, V] = calculateHeavyHittersMapping(heavyHitterKeys, valuesTable)


### PR DESCRIPTION
SketchMap doesn't properly use the implicit monoid.

This pull request fixes this issue. Added a test to verify.
