### PR TITLE
algebird-bufferable

### DIFF
--- a/algebird-bufferable/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
+++ b/algebird-bufferable/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
@@ -1,0 +1,37 @@
+package com.twitter.algebird
+
+import com.twitter.bijection._
+import java.nio._
+
+class AdaptiveVectorBufferable[A](implicit bufferable : Bufferable[A])
+  extends AbstractBufferable[AdaptiveVector[A]] with BufferableImplicits {
+
+  val DENSE : Byte = 0
+  val SPARSE : Byte = 1
+
+  def put(into: ByteBuffer, vector : AdaptiveVector[A]) = {
+    vector match {
+      case DenseVector(seq, sparseValue, denseCount) => {
+        into
+          .reallocatingPut(DENSE)
+          .reallocatingPut((seq, sparseValue, denseCount))
+      }
+      case SparseVector(map, sparseValue, size) => {
+        into
+          .reallocatingPut(SPARSE)
+          .reallocatingPut((map, sparseValue, size))
+      }
+    }
+  }
+
+  def get(from: ByteBuffer) = read(from) { reader =>
+    reader.get[Byte].flatMap {
+      case DENSE => reader.get[(Vector[A], A, Int)].map {
+        case (seq, sparseValue, denseCount) => DenseVector(seq, sparseValue, denseCount)
+      }
+      case SPARSE => reader.get[(Map[Int,A], A, Int)].map {
+        case (map, sparseValue, size) => SparseVector(map, sparseValue, size)
+      }
+    }
+  }
+}

--- a/algebird-bufferable/src/main/scala/com/twitter/algebird/BufferableImplicits.scala
+++ b/algebird-bufferable/src/main/scala/com/twitter/algebird/BufferableImplicits.scala
@@ -1,9 +1,32 @@
 package com.twitter.algebird
 
 import com.twitter.bijection._
+import java.nio._
 
-object BufferableImplicits {
+class RichByteBuffer(into : ByteBuffer) {
+  def reallocatingPut[T:Bufferable](value : T) : ByteBuffer = Bufferable.reallocatingPut(into){Bufferable.put(_,value)}
+}
+
+class ByteBufferReader(var from : ByteBuffer) {
+  def get[T:Bufferable] = Bufferable.get(from).map {
+    case (bb, t) => {
+      from = bb
+      t
+    }
+  }
+}
+
+trait BufferableImplicits {
   implicit val hllBijection = HyperLogLogBijection
   implicit val hllBufferable = Bufferable.viaBijection[HLL, Array[Byte]]
-  implicit def qtreeBufferable[A](implicit bufferable : Bufferable[A], implicit monoid : Monoid[A]) = new QTreeBufferable
+  implicit def qtreeBufferable[A](implicit bufferable : Bufferable[A], monoid : Monoid[A]) = new QTreeBufferable
+  implicit def adaptiveVectorBufferable[A:Bufferable] = new AdaptiveVectorBufferable
+
+  implicit def bb2RichBB(into : ByteBuffer) = new RichByteBuffer(into)
+  def read[T](from : ByteBuffer)(fn : ByteBufferReader => Option[T]) = {
+    val reader = new ByteBufferReader(from)
+    fn(reader).map{(reader.from, _)}
+  }
 }
+
+object BufferableImplicits extends BufferableImplicits

--- a/algebird-bufferable/src/main/scala/com/twitter/algebird/BufferableImplicits.scala
+++ b/algebird-bufferable/src/main/scala/com/twitter/algebird/BufferableImplicits.scala
@@ -1,0 +1,9 @@
+package com.twitter.algebird
+
+import com.twitter.bijection._
+
+object BufferableImplicits {
+  implicit val hllBijection = HyperLogLogBijection
+  implicit val hllBufferable = Bufferable.viaBijection[HLL, Array[Byte]]
+  implicit def qtreeBufferable[A](implicit bufferable : Bufferable[A], implicit monoid : Monoid[A]) = new QTreeBufferable
+}

--- a/algebird-bufferable/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-bufferable/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -1,0 +1,8 @@
+package com.twitter.algebird
+
+import com.twitter.bijection._
+
+object HyperLogLogBijection extends AbstractBijection[HLL, Array[Byte]] {
+  override def apply(hll : HLL) = HyperLogLog.toBytes(hll)
+  override def invert(bytes : Array[Byte]) = HyperLogLog.fromBytes(bytes)
+}

--- a/algebird-bufferable/src/main/scala/com/twitter/algebird/QTree.scala
+++ b/algebird-bufferable/src/main/scala/com/twitter/algebird/QTree.scala
@@ -1,0 +1,19 @@
+package com.twitter.algebird
+
+import com.twitter.bijection._
+import java.nio._
+
+class QTreeBufferable[A](implicit bufferable : Bufferable[A], monoid : Monoid[A]) extends AbstractBufferable[QTree[A]] {
+  implicit val recursive = this
+
+  def put(into: ByteBuffer, tree : QTree[A]) = {
+    Bufferable.reallocatingPut(into){Bufferable.put(_, QTree.unapply(tree).get)}
+  }
+
+  def get(from: ByteBuffer) = {
+    Bufferable.get[(Long, Int, Long, A, Option[QTree[A]], Option[QTree[A]])](from).map {
+      case (bb, (offset, level, count, sum, lowerChild, upperChild)) =>
+        (bb, new QTree(offset, level, count, sum, lowerChild, upperChild))
+    }
+  }
+}

--- a/algebird-bufferable/src/main/scala/com/twitter/algebird/QTree.scala
+++ b/algebird-bufferable/src/main/scala/com/twitter/algebird/QTree.scala
@@ -3,17 +3,17 @@ package com.twitter.algebird
 import com.twitter.bijection._
 import java.nio._
 
-class QTreeBufferable[A](implicit bufferable : Bufferable[A], monoid : Monoid[A]) extends AbstractBufferable[QTree[A]] {
+class QTreeBufferable[A](implicit bufferable : Bufferable[A], monoid : Monoid[A])
+  extends AbstractBufferable[QTree[A]] with BufferableImplicits {
   implicit val recursive = this
 
   def put(into: ByteBuffer, tree : QTree[A]) = {
-    Bufferable.reallocatingPut(into){Bufferable.put(_, QTree.unapply(tree).get)}
+    into.reallocatingPut(QTree.unapply(tree).get)
   }
 
-  def get(from: ByteBuffer) = {
-    Bufferable.get[(Long, Int, Long, A, Option[QTree[A]], Option[QTree[A]])](from).map {
-      case (bb, (offset, level, count, sum, lowerChild, upperChild)) =>
-        (bb, new QTree(offset, level, count, sum, lowerChild, upperChild))
-    }
+  def get(from: ByteBuffer) = read(from) {reader =>
+    for((offset, level, count, sum, lowerChild, upperChild) <-
+          reader.get[(Long, Int, Long, A, Option[QTree[A]], Option[QTree[A]])])
+      yield new QTree(offset, level, count, sum, lowerChild, upperChild)
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -82,7 +82,8 @@ object AlgebirdBuild extends Build {
     publishLocal := { }
   ).aggregate(algebirdTest,
               algebirdCore,
-              algebirdUtil)
+              algebirdUtil,
+              algebirdBufferable)
 
   lazy val algebirdCore = Project(
     id = "algebird-core",
@@ -117,4 +118,15 @@ object AlgebirdBuild extends Build {
     previousArtifact := youngestForwardCompatible("util"),
     libraryDependencies += "com.twitter" %% "util-core" % "6.2.0"
   ).dependsOn(algebirdCore, algebirdTest % "compile->test")
+
+  lazy val algebirdBufferable = Project(
+    id = "algebird-bufferable",
+    base = file("algebird-bufferable"),
+    settings = sharedSettings
+  ).settings(
+    name := "algebird-bufferable",
+    previousArtifact := youngestForwardCompatible("bufferable"),
+    libraryDependencies += "com.twitter" %% "bijection-core" % "0.4.0"
+  ).dependsOn(algebirdCore)
+
 }


### PR DESCRIPTION
This is just a start, and shouldn't be merged yet, but: defining some Bufferable implementations for Algebird objects so that we don't have to use Kryo for long-term serialized storage.
