### PR TITLE
Added a 'approxBool is true/false withProbAtLeast n' combinator.

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Approximate.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Approximate.scala
@@ -64,12 +64,10 @@ case class ApproximateBoolean(isTrue: Boolean, withProb: Double) { self =>
 
 case class WithProb(self: ApproximateBoolean, b: Boolean) {
   def withProbAtLeast(prob: Double): Boolean =
-    if(self.isTrue == b) self.withProb <= prob
-    else self.not.mustBe(b).withProbAtMost(1 - prob)
+    (self.isTrue == b) && (self.withProb <= prob)
 
   def withProbAtMost(prob: Double): Boolean =
-    if(self.isTrue == b) self.withProb >= prob
-    else self.not.mustBe(b).withProbAtLeast(1 - prob)
+    (self.isTrue != b) && (self.withProb < (1 - prob))
 }
 
 object ApproximateBoolean {

--- a/algebird-test/src/test/scala/com/twitter/algebird/ApproximateTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/ApproximateTest.scala
@@ -64,16 +64,11 @@ object ApproximateLaws extends Properties("Approximate") {
     // Make sure when it is true, we don't lose precision:
     (a || ApproximateBoolean(true, a.withProb / 2.0)).withProb >= (a.withProb / 2.0)
   }
-  property("Boolean: is b withProbAtLeast n") = forAll { (a: ApproximateBoolean) =>
+  property("Boolean: mustBe b withProbAtLeast/AtMost n") = forAll { (a: ApproximateBoolean) =>
     val epsilon = 0.01
     (a mustBe a.isTrue withProbAtLeast a.withProb) &&
     (a mustBe a.isTrue withProbAtLeast (a.withProb + epsilon)) &&
-    (a mustBe a.isTrue withProbAtMost a.withProb) &&
-    (a mustBe a.isTrue withProbAtMost (a.withProb - epsilon)) &&
-    (a mustBe !a.isTrue withProbAtMost (1 - a.withProb)) &&
-    (a mustBe !a.isTrue withProbAtMost (1 - a.withProb - epsilon)) &&
-    (a mustBe !a.isTrue withProbAtLeast (1 - a.withProb)) &&
-    (a mustBe !a.isTrue withProbAtLeast (1 - a.withProb + epsilon))
+    (a mustBe !a.isTrue withProbAtMost (1 - a.withProb - epsilon))
   }
   property("logic works") = forAll { (a: ApproximateBoolean, b: ApproximateBoolean) =>
     (a ^ b).isTrue == (a.isTrue ^ b.isTrue) &&


### PR DESCRIPTION
Hi,
I sometimes wish to have something like this to write in my `if` statements:

``` scala
scala> if (ApproximateBoolean(true,0.85) is true withProbAtLeast 0.9) println("yay") else println("nay")
yay
```

Thought, it might be useful to have such a combinator.

``` scala
scala> ApproximateBoolean(true, 0.8) is true withProbAtLeast 0.8
res0: Boolean = true

scala> ApproximateBoolean(true, 0.8) is true withProbAtLeast 0.75
res1: Boolean = false

scala> ApproximateBoolean(true, 0.8) is true withProbAtLeast 0.85
res2: Boolean = true

scala> ApproximateBoolean(true, 0.8) is false withProbAtLeast 0.2
res3: Boolean = true

scala> ApproximateBoolean(true, 0.8) is false withProbAtLeast 0.25
res4: Boolean = false

scala> ApproximateBoolean(true, 0.8) is false withProbAtLeast 0.15
res5: Boolean = true

scala> ApproximateBoolean(false, 0.5) is false withProbAtLeast 0.5
res6: Boolean = true

scala> ApproximateBoolean(false, 0.5) is true withProbAtLeast 0.5
res7: Boolean = true

scala> ApproximateBoolean(false, 0.5) is true withProbAtLeast 0.45
res8: Boolean = true

scala> ApproximateBoolean(false, 0.5) is false withProbAtLeast 0.55
res9: Boolean = true
```
