### PR TITLE
Moving Trampoline flatMap impl into trait.

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/monad/Trampoline.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/monad/Trampoline.scala
@@ -21,7 +21,7 @@ import com.twitter.algebird.Monad
 // A simple trampoline implementation which we copied for the State monad
 sealed trait Trampoline[+A] {
   def map[B](fn: A => B): Trampoline[B]
-  def flatMap[B](fn: A => Trampoline[B]): Trampoline[B]
+  def flatMap[B](fn: A => Trampoline[B]): Trampoline[B] = FlatMapped(this, fn)
   /**
    * get triggers the computation which is run exactly once
    */
@@ -30,12 +30,10 @@ sealed trait Trampoline[+A] {
 
 final case class Done[A](override val get: A) extends Trampoline[A] {
   def map[B](fn: A => B) = Done(fn(get))
-  def flatMap[B](fn: A => Trampoline[B]) = FlatMapped(this, fn)
 }
 
 final case class FlatMapped[C, A](start: Trampoline[C], fn: C => Trampoline[A]) extends Trampoline[A] {
   def map[B](fn: A => B) = FlatMapped(this, { (a: A) => Done(fn(a)) })
-  def flatMap[B](fn: A => Trampoline[B]) = FlatMapped(this, fn)
   lazy val get = Trampoline.run(this)
 }
 


### PR DESCRIPTION
Trivial change to move a bit of duplicated code up into the trait. Passes all tests.
