### PR TITLE
Abstract 'create' methods into their own trait

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -66,14 +66,6 @@ trait Aggregator[-A,B,+C] extends java.io.Serializable { self =>
     }
 }
 
-/**
-  * Factory trait for creating instances of O
-  */
-trait Creatable[I, O] {
-  def createCreatable(i: I): O = batchCreateCreatable(Seq(i))
-  def batchCreateCreatable(is: Seq[I]): O
-}
-
 trait MonoidAggregator[-A,B,+C] extends Aggregator[A,B,C] {
   def monoid : Monoid[B]
   final def reduce(l : B, r : B) : B = monoid.plus(l, r)

--- a/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -66,6 +66,14 @@ trait Aggregator[-A,B,+C] extends Function1[TraversableOnce[A], C] with java.io.
     }
 }
 
+/**
+  * Factory trait for creating instances of O
+  */
+trait Creatable[I, O] {
+  def createCreatable(i: I): O = batchCreateCreatable(Seq(i))
+  def batchCreateCreatable(is: Seq[I]): O
+}
+
 trait MonoidAggregator[-A,B,+C] extends Aggregator[A,B,C] {
   def monoid : Monoid[B]
   final def reduce(l : B, r : B) : B = monoid.plus(l, r)

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -68,7 +68,7 @@ object BloomFilter{
  * http://en.wikipedia.org/wiki/Bloom_filter
  *
  */
-case class BloomFilterMonoid(numHashes: Int, width: Int, seed: Int) extends Monoid[BF]{
+case class BloomFilterMonoid(numHashes: Int, width: Int, seed: Int) extends Monoid[BF] with Creatable[String, BF] {
   val hashes: BFHash = BFHash(numHashes, width, seed)
 
   val zero: BF = BFZero(hashes, width)
@@ -81,11 +81,14 @@ case class BloomFilterMonoid(numHashes: Int, width: Int, seed: Int) extends Mono
    */
   def plus(left: BF, right: BF): BF = left ++ right
 
+  override def createCreatable(i: String): BF = create(i)
+
+  def batchCreateCreatable(is: Seq[String]): BF = create(is: _*)
+
   /**
    * Create a bloom filter with one item.
    */
   def create(item: String): BF = BFItem(item, hashes, width)
-
 
   /**
    * Create a bloom filter with multiple items.
@@ -320,7 +323,7 @@ case class BFHash(numHashes: Int, width: Int, seed: Long = 0L) extends Function1
       val y = math.abs(x).toInt // y may be negative (Interger.MIN_VALUE)
       y & 0x7fffffff // no change for positive numbers, converts Interger.MIN_VALUE to positive number
     }
-	
+
     val upper = toNonNegativeInt(x >> 32)
     val lower = toNonNegativeInt((x << 32) >> 32)
     (upper, lower)

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -70,7 +70,7 @@ import scala.collection.immutable.SortedSet
  *                  (heavyHittersPct * totalCount) times in the stream.
  */
 class CountMinSketchMonoid(eps : Double, delta : Double, seed : Int,
-                           heavyHittersPct : Double = 0.01) extends Monoid[CMS] {
+                           heavyHittersPct : Double = 0.01) extends Monoid[CMS] with Creatable[Long, CMS] {
 
   assert(0 < eps && eps < 1, "eps must lie in (0, 1)")
   assert(0 < delta && delta < 1, "delta must lie in (0, 1)")
@@ -108,6 +108,9 @@ class CountMinSketchMonoid(eps : Double, delta : Double, seed : Int,
   def create(data : Seq[Long]) : CMS = {
     data.foldLeft(zero) { case (acc, x) => plus(acc, create(x)) }
   }
+
+  override def createCreatable(i: Long): CMS = create(i)
+  def batchCreateCreatable(is: Seq[Long]): CMS = create(is)
 }
 
 object CMS {

--- a/algebird-core/src/main/scala/com/twitter/algebird/Createable.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Createable.scala
@@ -1,0 +1,9 @@
+package com.twitter.algebird
+
+/**
+  * Factory trait for creating instances of O.
+  */
+trait Creatable[I, O] {
+  def createCreatable(i: I): O = batchCreateCreatable(Seq(i))
+  def batchCreateCreatable(is: Seq[I]): O
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -88,7 +88,7 @@ object HyperLogLog {
     loop(0, 0)
   }
 
-  /** The value 'w' is equal to <w_bits ... w_n>. The function rho counts the number of leading 
+  /** The value 'w' is equal to <w_bits ... w_n>. The function rho counts the number of leading
    *  zeroes in 'w'. We can calculate rho(w) at once with the method rhoW.
    */
   def rhoW(bsl: BitSetLite, bits: Int): Byte = {
@@ -100,10 +100,10 @@ object HyperLogLog {
   }
 
   /** We are computing j and \rho(w) from the paper,
-   *  sorry for the name, but it allows someone to compare to the paper extremely low probability 
+   *  sorry for the name, but it allows someone to compare to the paper extremely low probability
    *  rhow (position of the leftmost one bit) is > 127, so we use a Byte to store it
-   *  Given a hash <w_0, w_1, w_2 ... w_n> the value 'j' is equal to <w_0, w_1 ... w_(bits-1)> and 
-   *  the value 'w' is equal to <w_bits ... w_n>. The function rho counts the number of leading 
+   *  Given a hash <w_0, w_1, w_2 ... w_n> the value 'j' is equal to <w_0, w_1 ... w_(bits-1)> and
+   *  the value 'w' is equal to <w_bits ... w_n>. The function rho counts the number of leading
    *  zeroes in 'w'. We can calculate rho(w) at once with the method rhoW.
    */
   def jRhoW(in: Array[Byte], bits: Int): (Int, Byte) = {
@@ -347,7 +347,7 @@ case class DenseHLL(bits : Int, v : IndexedSeq[Byte]) extends HLL {
  * Error is about 1.04/sqrt(2^{bits}), so you want something like 12 bits for 1% error
  * which means each HLLInstance is about 2^{12} = 4kb per instance.
  */
-class HyperLogLogMonoid(val bits : Int) extends Monoid[HLL] {
+class HyperLogLogMonoid(val bits : Int) extends Monoid[HLL] with Creatable[Array[Byte], HLL] {
   import HyperLogLog._
 
   assert(bits > 3, "Use at least 4 bits (2^(bits) = bytes consumed)")
@@ -367,6 +367,9 @@ class HyperLogLogMonoid(val bits : Int) extends Monoid[HLL] {
       items.foreach { _.updateInto(buffer) }
       Some(DenseHLL(bits, buffer.toIndexedSeq))
     }
+
+  override def createCreatable(example : Array[Byte]) : HLL = create(example)
+  def batchCreateCreatable(is: Seq[Array[Byte]]): HLL = batchCreate(is)
 
   def create(example : Array[Byte]) : HLL = {
     val hashed = hash(example)

--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -29,7 +29,7 @@ import scala.collection.breakOut
  */
 class SketchMapMonoid[K, V](width: Int, depth: Int, seed: Int, heavyHittersCount: Int)
                            (implicit serialization: K => Array[Byte], valueOrdering: Ordering[V], monoid: Monoid[V])
-extends Monoid[SketchMap[K, V]] {
+extends Monoid[SketchMap[K, V]] with Creatable[(K,V), SketchMap[K,V]] {
   /**
    * Hashes an arbitrary key type to one that the Sketch Map can use.
    */
@@ -86,6 +86,9 @@ extends Monoid[SketchMap[K, V]] {
       if(buffer.size > 1) sumBuffer //don't bother to sum if there is only one item.
       Some(buffer(0))
     }
+
+  override def createCreatable(i: (K,V)): SketchMap[K, V] = create(i)
+  def batchCreateCreatable(is: Seq[(K,V)]): SketchMap[K, V] = create(is)
 
   /**
    * Create a Sketch Map sketch out of a single key/value pair.

--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -58,7 +58,7 @@ class SketchMapMonoid[K, V](val params: SketchMapParams[K])
   }
 
   override def createCreatable(i: (K,V)): SketchMap[K, V] = create(i)
-  override def batchCreateCreatable(is: Seq[(K,V)]): SketchMap[K, V] = create(is)
+  def batchCreateCreatable(is: Seq[(K,V)]): SketchMap[K, V] = create(is)
 
   /**
    * Create a Sketch Map sketch out of a single key/value pair.


### PR DESCRIPTION
@johnynek proposed that  algebird could have the following trait [1]:

```scala
trait Preparer[I, O] {
  def create(in: Seq[I]): O
}
```

This would formalize the usage of ```create``` in BloomFilter, CountMinSketch, HyperLogLog, SketchMap and the proposed SketchMap1 (#251)

This class likely belongs in Aggregator.scala

[1] https://github.com/twitter/algebird/pull/251#discussion_r9051358
