### PR TITLE
Fix SketchMapMonoid zero

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -46,7 +46,7 @@ class SketchMapMonoid[K, V](val params: SketchMapParams[K])
   /**
    * A zero Sketch Map is one with zero elements.
    */
-  val zero: SketchMap[K, V] = SketchMap[K, V](AdaptiveMatrix.monoid.zero, Nil, monoid.zero)
+  val zero: SketchMap[K, V] = SketchMap(AdaptiveMatrix.fill(params.depth, params.width)(monoid.zero), Nil, monoid.zero)
 
   override def plus(left: SketchMap[K, V], right: SketchMap[K, V]): SketchMap[K, V] = {
     val newValuesTable = Monoid.plus(left.valuesTable, right.valuesTable)


### PR DESCRIPTION
So, I will add some tests to make sure that this is an issue but I was round-tripping the monoid zero and getting errors, and it looks like this change in the old to new transition is causing them. I'm not sure how we wouldn't run into this in our tests though?! I'll add a failing test but I was hoping @cheecheeo might be able to opine
