### PR TITLE
remove unnecessary implicit requirement

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -189,14 +189,12 @@ object SketchMap {
    * serialization from K to Array[Byte] for hashing, an ordering for V, and a
    * monoid for V.
    */
-  def monoid[K, V](params: SketchMapParams[K])(implicit serialization: K => Array[Byte], valueOrdering: Ordering[V], monoid: Monoid[V]): SketchMapMonoid[K, V] = {
+  def monoid[K, V](params: SketchMapParams[K])(implicit valueOrdering: Ordering[V], monoid: Monoid[V]): SketchMapMonoid[K, V] =
     new SketchMapMonoid(params)(valueOrdering, monoid)
-  }
 
   def aggregator[K, V](params: SketchMapParams[K])
-                      (implicit serialization: K => Array[Byte], valueOrdering: Ordering[V], monoid: Monoid[V]): SketchMapAggregator[K, V] = {
+                      (implicit valueOrdering: Ordering[V], monoid: Monoid[V]): SketchMapAggregator[K, V] =
     SketchMapAggregator(params, SketchMap.monoid(params))
-  }
 }
 
 case class SketchMap[K, V](

--- a/algebird-test/src/test/scala/com/twitter/algebird/SketchMapTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SketchMapTest.scala
@@ -127,7 +127,7 @@ class SketchMapTest extends Specification {
       // are the smallest numbers).
       val smallerOrdering: Ordering[Long] = Ordering.by[Long, Long] { -_ }
 
-      val monoid = SketchMap.monoid[Int, Long](PARAMS)(implicitly[Int => Array[Byte]], smallerOrdering, smallerMonoid)
+      val monoid = SketchMap.monoid[Int, Long](PARAMS)(smallerOrdering, smallerMonoid)
 
       val sm1 = monoid.create((100, 10L))
       monoid.heavyHitters(sm1) must be_==(List((100, 10L)))


### PR DESCRIPTION
With the SketchMap refactoring there are some implicits that aren't used, because SketchMapParam requires the serialization with it.
