### PR TITLE
MapMonoid culls empty values

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/MapMonoidTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MapMonoidTest.scala
@@ -1,0 +1,17 @@
+package com.twitter.algebird
+
+import org.scalacheck.{Arbitrary, Gen, Properties}
+import org.scalacheck.Prop._
+
+object MapMonoidTest extends Properties("MapMonoid") {
+  import BaseProperties._
+  import Monoid._
+
+  property("MapAlgebra.sparseEquiv is correct") =
+    forAll { entries: Set[Int] =>
+      val map1 = entries.map { i => (i, i) }.toMap
+      val map2 = map1.mapValues { -_ }
+      val map3 = Monoid.plus(map1, map2)
+      map3.size == map1.size && map3.size == map2.size && map3.filterNot { _._2 == 0 }.size == 0
+    }
+}


### PR DESCRIPTION
This just adds a failing test. This was an optimization (and not an unreasonable one), though it changes how users should think about the output of MapMonoid. It does not seem expected that the result of Monoid.plus could result in the key NOT being available, which is exactly what is now possible.

I feel like we should remove this, and add the ability to cull zeros for MapMonoid is so desired. Open to other suggestions.
