### PR TITLE
Make the AsyncListSum be immutable again, identical performance to its m...

### DIFF
--- a/algebird-util/src/main/scala/com/twitter/algebird/util/summer/AsyncListSum.scala
+++ b/algebird-util/src/main/scala/com/twitter/algebird/util/summer/AsyncListSum.scala
@@ -27,8 +27,6 @@ import scala.collection.breakOut
  * @author Ian O Connell
  */
 
-
-
 class AsyncListSum[Key, Value](bufferSize: BufferSize,
                                           override val flushFrequency: FlushFrequency,
                                           override val softMemoryFlush: MemoryFlushPercent,
@@ -49,7 +47,7 @@ class AsyncListSum[Key, Value](bufferSize: BufferSize,
       case _ => false
     }
 
-    def dump: (Int, Iterable[Value]) = (size, privBuf)
+    lazy val toSeq = privBuf.reverse
   }
 
 
@@ -71,9 +69,8 @@ class AsyncListSum[Key, Value](bufferSize: BufferSize,
         val retV = queueMap.remove(k)
 
         if(retV != null) {
-          val (numElements, buf) = retV.dump
-          val newRemaining = elementsInCache.addAndGet(numElements * -1)
-          sg.sumOption(buf).map(v => (k, v))
+          val newRemaining = elementsInCache.addAndGet(retV.size * -1)
+          sg.sumOption(retV.toSeq).map(v => (k, v))
         }
         else None
       }(breakOut)


### PR DESCRIPTION
...utable version now in benchmarks.

fixes #307 

Creating Thyme instances and warming busywork methods...done in 5.36 s
Warming up benchmarking...done in 4.51 s
Warming up head-to-head benchmarking...done in 4.36 s
Warming up computational complexity benchmarking...done in 3.75 s
Total number of input keys: 1000
Num input tuples: 10000
Buffer size is: BufferSize(1000)
========= STARTING BenchmarkHLL(0,0,true) ================
(13,Benchmark comparison (in 9.502 s): AsyncListSum Vs AsyncListSumImmutable
    AsyncListSum vs AsyncListSumImmutable
Not significantly different (p ~= 0.2015)
  Time ratio:    1.00951   95% CI 0.99473 - 1.02429   (n=20)
    AsyncListSum             29.84 ms   95% CI 29.53 ms - 30.15 ms
    AsyncListSumImmutable    30.13 ms   95% CI 29.82 ms - 30.44 ms
Warning: order-of-evaluation effects in timing (p ~= 0.0207) of up to 7.595%)
(13,Benchmark comparison (in 7.132 s): AsyncListSumImmutable Vs AsyncListSum
    AsyncListSumImmutable vs AsyncListSum
Not significantly different (p ~= 0.7817)
  Time ratio:    0.99518   95% CI 0.96053 - 1.02982   (n=20)
    AsyncListSumImmutable    29.68 ms   95% CI 28.95 ms - 30.41 ms
    AsyncListSum             29.53 ms   95% CI 28.81 ms - 30.26 ms)
========= FINISHED BenchmarkHLL(0,0,true) ================

Total number of input keys: 1000
Num input tuples: 10000
Buffer size is: BufferSize(1000)
Sketchmap width: 2000
Sketchmap depth: 5
========= STARTING BenchmarkSketchMap(0,0,true) ================
(13,Benchmark comparison (in 67.48 s): AsyncListSum Vs AsyncListSumImmutable
    AsyncListSum vs AsyncListSumImmutable
Not significantly different (p ~= 0.2024)
  Time ratio:    1.00148   95% CI 0.99919 - 1.00376   (n=20)
    AsyncListSum             274.0 ms   95% CI 273.6 ms - 274.5 ms
    AsyncListSumImmutable    274.4 ms   95% CI 274.0 ms - 274.9 ms
  Individual benchmarks not fully consistent with head-to-head (p ~= 3.866e-05)
    AsyncListSum             282.1 ms   95% CI 277.7 ms - 286.4 ms
    AsyncListSumImmutable    274.7 ms   95% CI 274.5 ms - 274.8 ms)
(13,Benchmark comparison (in 66.76 s): AsyncListSumImmutable Vs AsyncListSum
    AsyncListSumImmutable vs AsyncListSum
Not significantly different (p ~= 0.6573)
  Time ratio:    0.99839   95% CI 0.99115 - 1.00563   (n=20)
    AsyncListSumImmutable    276.0 ms   95% CI 274.6 ms - 277.4 ms
    AsyncListSum             275.5 ms   95% CI 274.1 ms - 276.9 ms)
========= FINISHED BenchmarkSketchMap(0,0,true) ================
