### PR TITLE
Little commit fixing up some spacing per our norms:

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Semigroup.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Semigroup.scala
@@ -27,8 +27,8 @@ import scala.annotation.{implicitNotFound, tailrec}
  *   This is a class with a plus method that is associative: a+(b+c) = (a+b)+c
  */
 @implicitNotFound(msg = "Cannot find Semigroup type class for ${T}")
-trait Semigroup[@specialized(Int,Long,Float,Double) T] extends java.io.Serializable {
-  def plus(l : T, r : T) : T
+trait Semigroup[@specialized(Int, Long, Float, Double) T] extends java.io.Serializable {
+  def plus(l: T, r: T): T
   /**
    * override this if there is a faster way to do this sum than reduceLeftOption on plus
    */
@@ -41,13 +41,13 @@ abstract class AbstractSemigroup[T] extends Semigroup[T]
 
 /** Either semigroup is useful for error handling.
  * if everything is correct, use Right (it's right, get it?), if something goes
- * wrong, use Left.  plus does the normal thing for plus(Right,Right), or plus(Left,Left),
+ * wrong, use Left.  plus does the normal thing for plus(Right, Right), or plus(Left, Left),
  * but if exactly one is Left, we return that value (to keep the error condition).
  * Typically, the left value will be a string representing the errors.
  */
-class EitherSemigroup[L,R](implicit semigroupl : Semigroup[L], semigroupr : Semigroup[R]) extends Semigroup[Either[L,R]] {
+class EitherSemigroup[L, R](implicit semigroupl: Semigroup[L], semigroupr: Semigroup[R]) extends Semigroup[Either[L, R]] {
 
-  override def plus(l : Either[L,R], r : Either[L,R]) = {
+  override def plus(l: Either[L, R], r: Either[L, R]) = {
     if(l.isLeft) {
       // l is Left, r may or may not be:
       if(r.isRight) {
@@ -72,12 +72,12 @@ class EitherSemigroup[L,R](implicit semigroupl : Semigroup[L], semigroupr : Semi
 
 object Semigroup extends GeneratedSemigroupImplicits with ProductSemigroups {
   // This pattern is really useful for typeclasses
-  def plus[T](l : T, r : T)(implicit semi : Semigroup[T]) = semi.plus(l,r)
+  def plus[T](l: T, r: T)(implicit semi: Semigroup[T]) = semi.plus(l, r)
   // Left sum: (((a + b) + c) + d)
-  def sumOption[T](iter: TraversableOnce[T])(implicit sg: Semigroup[T]) : Option[T] =
+  def sumOption[T](iter: TraversableOnce[T])(implicit sg: Semigroup[T]): Option[T] =
     sg.sumOption(iter)
 
-  def from[T](associativeFn: (T,T) => T): Semigroup[T] = new Semigroup[T] { def plus(l:T, r:T) = associativeFn(l,r) }
+  def from[T](associativeFn: (T, T) => T): Semigroup[T] = new Semigroup[T] { def plus(l:T, r:T) = associativeFn(l, r) }
 
   /** Same as v + v + v .. + v (i times in total)
    * requires i > 0, wish we had PositiveBigInt as a class
@@ -88,7 +88,7 @@ object Semigroup extends GeneratedSemigroupImplicits with ProductSemigroups {
   }
 
   @tailrec
-  private def intTimesRec[T](i: BigInt, v: T, pow: Int, vaccMemo: (T,Vector[T]))(implicit sg: Semigroup[T]): T = {
+  private def intTimesRec[T](i: BigInt, v: T, pow: Int, vaccMemo: (T, Vector[T]))(implicit sg: Semigroup[T]): T = {
     if(i == 0) {
       vaccMemo._1
     }
@@ -130,31 +130,31 @@ object Semigroup extends GeneratedSemigroupImplicits with ProductSemigroups {
     }
   }
 
-  implicit val nullSemigroup : Semigroup[Null] = NullGroup
-  implicit val unitSemigroup : Semigroup[Unit] = UnitGroup
-  implicit val boolSemigroup : Semigroup[Boolean] = BooleanField
-  implicit val jboolSemigroup : Semigroup[JBool] = JBoolField
-  implicit val intSemigroup : Semigroup[Int] = IntRing
-  implicit val jintSemigroup : Semigroup[JInt] = JIntRing
-  implicit val shortSemigroup : Semigroup[Short] = ShortRing
-  implicit val jshortSemigroup : Semigroup[JShort] = JShortRing
-  implicit val longSemigroup : Semigroup[Long] = LongRing
-  implicit val bigIntSemigroup : Semigroup[BigInt] = BigIntRing
-  implicit val jlongSemigroup : Semigroup[JLong] = JLongRing
-  implicit val floatSemigroup : Semigroup[Float] = FloatField
-  implicit val jfloatSemigroup : Semigroup[JFloat] = JFloatField
-  implicit val doubleSemigroup : Semigroup[Double] = DoubleField
-  implicit val jdoubleSemigroup : Semigroup[JDouble] = JDoubleField
-  implicit val stringSemigroup : Semigroup[String] = StringMonoid
-  implicit def optionSemigroup[T : Semigroup] : Semigroup[Option[T]] = new OptionMonoid[T]
-  implicit def listSemigroup[T] : Semigroup[List[T]] = new ListMonoid[T]
-  implicit def seqSemigroup[T] : Semigroup[Seq[T]] = new SeqMonoid[T]
-  implicit def indexedSeqSemigroup[T : Semigroup]: Semigroup[IndexedSeq[T]] = new IndexedSeqSemigroup[T]
-  implicit def jlistSemigroup[T] : Semigroup[JList[T]] = new JListMonoid[T]
-  implicit def setSemigroup[T] : Semigroup[Set[T]] = new SetMonoid[T]
-  implicit def mapSemigroup[K,V:Semigroup]: Semigroup[Map[K,V]] = new MapMonoid[K,V]
-  implicit def scMapSemigroup[K,V:Semigroup]: Semigroup[ScMap[K,V]] = new ScMapMonoid[K,V]
-  implicit def jmapSemigroup[K,V : Semigroup] : Semigroup[JMap[K, V]] = new JMapMonoid[K,V]
-  implicit def eitherSemigroup[L : Semigroup, R : Semigroup] : Semigroup[Either[L,R]] = new EitherSemigroup[L,R]
-  implicit def function1Semigroup[T] : Semigroup[Function1[T,T]] = new Function1Monoid[T]
+  implicit val nullSemigroup: Semigroup[Null] = NullGroup
+  implicit val unitSemigroup: Semigroup[Unit] = UnitGroup
+  implicit val boolSemigroup: Semigroup[Boolean] = BooleanField
+  implicit val jboolSemigroup: Semigroup[JBool] = JBoolField
+  implicit val intSemigroup: Semigroup[Int] = IntRing
+  implicit val jintSemigroup: Semigroup[JInt] = JIntRing
+  implicit val shortSemigroup: Semigroup[Short] = ShortRing
+  implicit val jshortSemigroup: Semigroup[JShort] = JShortRing
+  implicit val longSemigroup: Semigroup[Long] = LongRing
+  implicit val bigIntSemigroup: Semigroup[BigInt] = BigIntRing
+  implicit val jlongSemigroup: Semigroup[JLong] = JLongRing
+  implicit val floatSemigroup: Semigroup[Float] = FloatField
+  implicit val jfloatSemigroup: Semigroup[JFloat] = JFloatField
+  implicit val doubleSemigroup: Semigroup[Double] = DoubleField
+  implicit val jdoubleSemigroup: Semigroup[JDouble] = JDoubleField
+  implicit val stringSemigroup: Semigroup[String] = StringMonoid
+  implicit def optionSemigroup[T: Semigroup]: Semigroup[Option[T]] = new OptionMonoid[T]
+  implicit def listSemigroup[T]: Semigroup[List[T]] = new ListMonoid[T]
+  implicit def seqSemigroup[T]: Semigroup[Seq[T]] = new SeqMonoid[T]
+  implicit def indexedSeqSemigroup[T: Semigroup]: Semigroup[IndexedSeq[T]] = new IndexedSeqSemigroup[T]
+  implicit def jlistSemigroup[T]: Semigroup[JList[T]] = new JListMonoid[T]
+  implicit def setSemigroup[T]: Semigroup[Set[T]] = new SetMonoid[T]
+  implicit def mapSemigroup[K, V:Semigroup]: Semigroup[Map[K, V]] = new MapMonoid[K, V]
+  implicit def scMapSemigroup[K, V:Semigroup]: Semigroup[ScMap[K, V]] = new ScMapMonoid[K, V]
+  implicit def jmapSemigroup[K, V: Semigroup]: Semigroup[JMap[K, V]] = new JMapMonoid[K, V]
+  implicit def eitherSemigroup[L: Semigroup, R: Semigroup]: Semigroup[Either[L, R]] = new EitherSemigroup[L, R]
+  implicit def function1Semigroup[T]: Semigroup[Function1[T, T]] = new Function1Monoid[T]
 }


### PR DESCRIPTION
No space before : for type,

space after "," between types, but not before
