### PR TITLE
Updated Maven section to updated version 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Discussion occurs primarily on the [Algebird mailing list](https://groups.google
 
 ## Maven
 
-Algebird modules are available on maven central. The current groupid and version for all modules is, respectively, `"com.twitter"` and  `0.6.0`.
+Algebird modules are available on maven central. The current groupid and version for all modules is, respectively, `"com.twitter"` and  `0.7.0`.
 
 Current published artifacts are
 


### PR DESCRIPTION
Algebird module is available for `0.7.0`. README Documentation listed 0.6.0
