### PR TITLE
Make trait public that should never have been private

### DIFF
--- a/algebird-util/src/main/scala/com/twitter/algebird/util/summer/AsyncSummer.scala
+++ b/algebird-util/src/main/scala/com/twitter/algebird/util/summer/AsyncSummer.scala
@@ -51,7 +51,7 @@ trait AsyncSummerProxy[T, +M <: Iterable[T]] extends AsyncSummer[T, M] {
   override def cleanup: Future[Unit] = self.cleanup
 }
 
-private[summer] trait WithFlushConditions[T, M <: Iterable[T]] extends AsyncSummer[T, M] {
+trait WithFlushConditions[T, M <: Iterable[T]] extends AsyncSummer[T, M] {
   protected var lastDump: Long = System.currentTimeMillis
   protected def softMemoryFlush: MemoryFlushPercent
   protected def flushFrequency: FlushFrequency


### PR DESCRIPTION
Simple change, trait is useful for defining summers outside this code so shouldn't have been private.
