### PR TITLE
Add Fold trait for composable incremental processing (for develop branch)

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Fold.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Fold.scala
@@ -1,0 +1,319 @@
+/*
+Copyright 2014 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.algebird
+
+import java.io.Serializable
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.Builder
+
+/**
+ * Folds are first-class representations of "Traversable.foldLeft." They have the nice property that
+ * they can be fused to work in parallel over an input sequence.
+ *
+ * A Fold accumulates inputs (I) into some internal type (X), converting to a defined output type
+ * (O) when done.  We use existential types to hide internal details and to allow for internal and
+ * external (X and O) types to differ for "map" and "join."
+ * 
+ * In discussing this type we draw parallels to Function1 and related types. You can think of a
+ * fold as a function "Seq[I] => O" but in reality we do not have to materialize the input sequence
+ * at once to "run" the fold.
+ *
+ * The traversal of the input data structure is NOT done by Fold itself. Instead we expose some
+ * methods like "overTraversable" that know how to iterate through various sequence types and drive
+ * the fold. We also expose some internal state so library authors can fold over their own types.
+ *  
+ * See the companion object for constructors. 
+ */
+sealed trait Fold[-I, +O] extends Serializable {
+  /**
+   * Users can ignore this type.
+   *  
+   * The internal accumulator type. No one outside this Fold needs to know what this is, and that's
+   * a good thing. It keeps type signatures sane and makes this easy to use for the amount of
+   * flexibility it provides.
+   */
+  type X
+
+  /**
+   * Users can ignore this method.  It is exposed so library authors can run folds over their own
+   * sequence types.
+   * 
+   * "build" constructs a FoldState, which tells us how to run the fold.  It is expected that we can
+   * run the same Fold many times over different data structures, but we must build a new FoldState
+   * every time.
+   * 
+   * See FoldState for information on how to use this for your own sequence types.
+   */
+  def build(): FoldState[X, I, O]
+
+  /**
+   * Transforms the output of the Fold after iteration is complete. This is analogous to
+   * "Future.map" or "Function1.compose."
+   */
+  def map[P](f: O => P): Fold[I, P] = {
+    val self = this
+    new Fold[I, P] {
+      type X = self.X
+      override def build: FoldState[X, I, P] =
+        self.build.map(f)
+    }
+  }
+
+  /**
+   * Joins two folds into one and combines the results. The fused fold accumulates with both at the
+   * same time and combines at the end.
+   */
+  def joinWith[I2 <: I, P, Q](other: Fold[I2, P])(f: (O, P) => Q): Fold[I2, Q] = {
+    val self = this
+    new Fold[I2, Q] {
+      type X = (self.X, other.X)
+      override def build(): FoldState[X, I2, Q] = {
+        val first = self.build()
+        val second = other.build()
+        new FoldState(
+          { case ((x, y), i) => (first.add(x, i), second.add(y, i)) },
+          (first.start, second.start),
+          { case (x, y) => f(first.end(x), second.end(y)) }
+        )
+      }
+    }
+  }
+
+  /**
+   * Convenient shorthand for joining Folds without combining at the end.
+   */
+  def join[I2 <: I, P](other: Fold[I2, P]): Fold[I2, (O, P)] =
+    joinWith(other) { case (o, p) => (o, p) }
+
+  /**
+   * Transforms the input of the fold before every accumulation. (The name comes from "contravariant
+   * map.") This is analogous to "Function1.andThen." 
+   */
+  def contramap[H](f: H => I): Fold[H, O] = {
+    val self = this
+    new Fold[H, O] {
+      type X = self.X
+      override def build(): FoldState[X, H, O] = {
+        self.build().contramap(f)
+      }
+    }
+  }
+
+  /**
+   * Trivially runs a Fold over an empty sequence.
+   */
+  def overEmpty: O = {
+    // build is a "def" so we construct the state once and use the pieces to run the fold
+    val state = build()
+    state.end(state.start)
+  }
+
+  /**
+   * Trivially runs a Fold over a single element sequence.
+   */
+  def overSingleton(i: I): O = {
+    val state = build()
+    state.end(state.add(state.start, i))
+  }
+
+  /**
+   * Runs a Fold over a Traversable.
+   */
+  def overTraversable(is: TraversableOnce[I]): O = {
+    val state = build()
+    state.end(is.foldLeft(state.start)(state.add))
+  }
+}
+
+/**
+ * A FoldState defines a left fold with a "hidden" accumulator type. It is exposed so
+ * library authors can run Folds over their own sequence types.
+ * 
+ * The fold can be executed correctly according to the properties of "add" and your traversed
+ * data structure. For example, the "add" function of a monoidal fold will be associative. A
+ * FoldState is valid for only one iteration because the accumulator (seeded by "start"  may be
+ * mutable.
+ * 
+ * The three components of a fold are
+ *   add: (X, I) => X - updates and returns internal state for every input I
+ *   start: X - the initial state
+ *   end: X => O - transforms internal state to a final result
+ * 
+ * Folding over Seq(x, y) would produce the result
+ *   end(add(add(start, x), y))
+ */
+final class FoldState[X, -I, +O] private[algebird] (
+  val add: (X, I) => X,
+  val start: X,
+  val end: X => O
+) extends Serializable {
+  /**
+   * Transforms the output type of the FoldState (see Fold.map).
+   */
+  def map[P](f: O => P): FoldState[X, I, P] =
+    new FoldState(add, start, end andThen f)
+
+  /**
+   * Transforms the input type of the FoldState (see Fold.contramap).
+   */
+  def contramap[H](f: H => I): FoldState[X, H, O] =
+    new FoldState({ (x, h) => add(x, f(h)) }, start, end)
+}
+
+/**
+ * Methods to create and run Folds.
+ * 
+ * The Folds defined here are immutable and serializable, which we expect by default. It is
+ * important that you as a user indicate mutability or non-serializability when defining new Folds.
+ * Additionally, it is recommended that "end" functions not mutate the accumulator in order to
+ * support scans (producing a stream of intermediate outputs by calling "end" at each step).
+ */
+object Fold {
+  /**
+   * Turn a common Scala foldLeft into a Fold.
+   * The accumulator MUST be immutable and serializable.
+   */
+  def foldLeft[I, O](o: O)(add: (O, I) => O): Fold[I, O] =
+    fold[O, I, O](add, o, { o => o })
+
+  /**
+   * A general way of defining Folds that supports a separate accumulator type.
+   * The accumulator MUST be immutable and serializable.
+   */
+  def fold[M, I, O](add: (M, I) => M, start: M, end: M => O): Fold[I, O] =
+    new Fold[I, O] {
+      type X = M
+      override def build(): FoldState[X, I, O] =
+        new FoldState(add, start, end)
+    }
+
+  /**
+   * A general way of defining Folds that supports constructing mutable or non-serializable
+   * accumulators.
+   */
+  def foldMutable[M, I, O](add: (M, I) => M, start: Unit => M, end: M => O): Fold[I, O] =
+    new Fold[I, O] {
+      type X = M
+      override def build(): FoldState[X, I, O] =
+        new FoldState(add, start(), end)
+    }
+
+  /**
+   * Simple Fold that collects elements into a container.
+   */
+  def container[I, C[_]](implicit cbf: CanBuildFrom[C[I], I, C[I]]): Fold[I, C[I]] =
+    Fold.foldMutable[Builder[I, C[I]], I, C[I]] (
+      { case (b, i) => b += i },
+      { _ => cbf.apply },
+      { _.result }
+    )
+
+  /**
+   * An even simpler Fold that collects into a Seq.  Shorthand for "container[I, Seq];" fewer type
+   * arguments, better type inferrence.
+   */
+  def seq[I]: Fold[I, Seq[I]] =
+    container[I, Seq]
+
+  /**
+   * A Fold that does no work and returns a constant.  Analogous to Function1 const:
+   *   def const[A, B](b: B): (A => B) = { _ => b }
+   */
+  def const[O](value: O): Fold[Any, O] =
+    Fold.foldLeft(value) { case (u, _) => u }
+
+  /**
+   * A Fold that runs the given side effect for every element.
+   */
+  def foreach[I](e: I => Unit): Fold[I, Unit] =
+    Fold.foldLeft(()) { case (_, i) => e(i) }
+
+  /**
+   * A Fold that returns the first value in a sequence.
+   */
+  def first[I]: Fold[I, Option[I]] =
+    Fold.foldLeft[I, Option[I]](None) {
+      case (None, i) => Some(i)
+      case (x, _) => x
+    }
+
+  /**
+   * A Fold that returns the last value in a sequence.
+   */
+  def last[I]: Fold[I, Option[I]] =
+    Fold.foldLeft[I, Option[I]](None) { case (_, i) => Some(i) }
+
+  /**
+   * A Fold that returns the max value in a sequence. (Biased to earlier equal values.)
+   */
+  def max[I](implicit ordering: Ordering[I]): Fold[I, Option[I]] =
+    Fold.foldLeft[I, Option[I]](None) {
+      case (None, i) => Some(i)
+      case (Some(y), i) if (ordering.compare(y, i) < 0) => Some(i)
+      case (x, _) => x
+    }
+
+  /**
+   * A Fold that returns a min value in a sequence. (Biased to earlier equal values.)
+   */
+  def min[I](implicit ordering: Ordering[I]): Fold[I, Option[I]] =
+    Fold.foldLeft[I, Option[I]](None) {
+      case (None, i) => Some(i)
+      case (Some(y), i) if (ordering.compare(y, i) > 0) => Some(i)
+      case (x, _) => x
+    }
+
+  /**
+   * A Fold that returns the sum of a numeric sequence. Does not protect against overflow.
+   */
+  def sum[I](implicit numeric: Numeric[I]): Fold[I, I] =
+    Fold.foldLeft(numeric.zero) { case (x, i) => numeric.plus(x, i) }
+
+  /**
+   * A Fold that returns the product of a numeric sequence. Does not protect against overflow.
+   */
+  def product[I](implicit numeric: Numeric[I]): Fold[I, I] =
+    Fold.foldLeft(numeric.one) { case (x, i) => numeric.times(x, i) }
+
+  /**
+   * A Fold that returns the length of a sequence.
+   */
+  def size: Fold[Any, Long] =
+    Fold.foldLeft(0L) { case (x, _) => x + 1 }
+
+  /**
+   * A Fold that returns "true" if all elements of the sequence statisfy the predicate.
+   * Note this does not short-circuit enumeration of the sequence. 
+   */
+  def forall[I](pred: I => Boolean): Fold[I, Boolean] =
+    foldLeft(true) { (b, i) => b && pred(i) }
+
+  /**
+   * A Fold that returns "true" if any element of the sequence statisfies the predicate.
+   * Note this does not short-circuit enumeration of the sequence. 
+   */
+  def exists[I](pred: I => Boolean): Fold[I, Boolean] =
+    foldLeft(false) { (b, i) => b || pred(i) }
+
+  /**
+   * A Fold that counts the number of elements satisfying the predicate.
+   */
+  def count[I](pred: I => Boolean): Fold[I, Long] =
+    foldLeft(0L) {
+      case (c, i) if pred(i) => c + 1L
+      case (c, _) => c
+    }
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/FoldTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/FoldTest.scala
@@ -1,0 +1,122 @@
+package com.twitter.algebird
+
+import org.specs2.mutable._
+
+class FoldTest extends Specification {
+
+  sealed trait Case[I, O] {
+    def expected: O
+    def runCase(fold: Fold[I, O]): O
+  }
+  case class Zero[I, O](expected: O) extends Case[I, O] {
+    override def runCase(fold: Fold[I, O]) = fold.overEmpty
+  }
+  case class One[I, O](in: I, expected: O) extends Case[I, O] {
+    override def runCase(fold: Fold[I, O]) = fold.overSingleton(in)
+  }
+  case class Many[I, O](in: Traversable[I], expected: O) extends Case[I, O] {
+    override def runCase(fold: Fold[I, O]) = fold.overTraversable(in)
+  }
+
+  def run[I, O](fold: Fold[I, O], cases: Case[I, O]*): Unit =
+    cases.foreach { c => assert(c.runCase(fold) === c.expected) }
+
+  "Fold" should {
+
+    "foldLeft" in {
+      run[String, String](
+        Fold.foldLeft("") { (a, b) => a ++ b },
+        Zero(""),
+        One("1", "1"),
+        Many(Seq("1", "2", "3"), "123")
+      )
+    }
+
+    "seq" in {
+      run[Int, Seq[Int]](
+        Fold.seq,
+        Zero(Seq.empty),
+        One(1, Seq(1)),
+        Many(Seq(1, 2, 3), Seq(1, 2, 3)),
+        Many(Seq(2, 1, 3), Seq(2, 1, 3))
+      )
+    }
+
+    "const" in {
+      run[Int, String](
+        Fold.const("42"),
+        Zero("42"),
+        One(1, "42"),
+        Many(Seq(1, 2, 3), "42")
+      )
+    }
+
+    "first" in {
+      run[String, Option[String]](
+        Fold.first,
+        Zero(None),
+        One("1", Some("1")),
+        Many(Seq("1", "2", "3"), Some("1"))
+      )
+    }
+
+    "last" in {
+      run[String, Option[String]](
+        Fold.last,
+        Zero(None),
+        One("1", Some("1")),
+        Many(Seq("1", "2", "3"), Some("3"))
+      )
+    }
+
+    "max" in {
+      run[Int, Option[Int]](
+        Fold.max,
+        Zero(None),
+        One(1, Some(1)),
+        Many(Seq(1, 2, 3), Some(3)),
+        Many(Seq(1, 3, 2), Some(3))
+      )
+    }
+
+    "min" in {
+      run[Int, Option[Int]](
+        Fold.min,
+        Zero(None),
+        One(1, Some(1)),
+        Many(Seq(1, 2, 3), Some(1)),
+        Many(Seq(2, 1, 3), Some(1))
+      )
+    }
+
+    "sum" in {
+      run[Int, Int](
+        Fold.sum,
+        Zero(0),
+        One(1, 1),
+        Many(Seq(1, 2, 3), 6),
+        Many(Seq(2, 1, 3), 6)
+      )
+    }
+
+    "size" in {
+      run[String, Long](
+        Fold.size,
+        Zero(0),
+        One("1", 1),
+        Many(Seq("1", "2", "3"), 3)
+      )
+    }
+
+    "average" in {
+      run[Int, Double](
+        Fold.sum[Int].joinWith(Fold.size) { (s, c) => s.toDouble / c },
+        One(1, 1.0),
+        Many(Seq(1, 2, 3), 2.0),
+        Many(Seq(2, 1, 3), 2.0)
+      )
+    }
+
+  }
+
+}


### PR DESCRIPTION
Problem

(Little-f) folds are a standard part of a Scala-programmer's toolkit.  Most sequence-like data
structures support them directly (Traversable, com.twitter.concurrent.Spool), and some suggest a natural implementation (com.twitter.io.Reader).  Consider calculating a message digest over these structures
(simplified):

```
import java.security.MessageDigest

def digestSeq(bs: Seq[Buf]): Array[Byte] =
  (bs.foldLeft(new MessageDigest) { case (md, buf) => md.update(buf) }).digest

def digestSpool(bs: Spool[Buf]): Future[Array[Byte]] =
  spool.foldLeft(new MessageDigest) { case (md, buf) => md.update(buf) } map { _.digest }

def digestReader(reader: Reader): Future[Array[Byte]] =
  // ... some recursive flatMapping and mapping ...
```

This is noisy - we can imagine separate mapping, accumulating, and iterating concerns and express
it this way:

```
val digest: Fold[Buf, Array[Byte]] =
  Fold.foldMutable(
    case (md, buf) => md.update(buf)
    { _ => new MessageDigest }
    { _.digest }
  )

def digestSeq(bs: Seq[Buf]): Array[Byte] =
  digest.overTraversable(bs)

def digestSpool(bs: Spool[Buf]): Future[Array[Byte]] =
  digest.overSpool(bs)

def digestReader(reader: Reader): Future[Array[Byte]] =
  digest.overReader(bs)
```

Now what if we wanted to perform another operation over the stream, say, "Aggregation":

```
import java.security.MessageDigest

type Aggregation
def emptyAgg: Aggregation
def updateAgg(agg: Aggregation, buf: Buf): Aggregation

def digestAndAggregateSeq(bs: Seq[Buf]): (Array[Byte], Aggregation) = {
  val (md, agg) =
    (bs.foldLeft((new MessageDigest, emptyAgg)) { case ((md, agg), buf) =>
      (md.update(buf), updateAgg(agg, buf)
    })
  (md.digest, agg)
}

// Spool impl is equally complicated
```

We have to explicitly fuse the second fold.  Instead we could do this:

```
val aggregate =
  Fold.fold(
    updateAgg _,
    emptyAgg,
    id
  )

val digestAndAggregate = digest join aggregate

def digestAndAggregateSeq(bs: Seq[Buf]): (Digest, Aggregation) =
  digestAndAggregate.overTraverable(bs)

def digestAndAggregateSpool(bs: Spool[Buf]): (Digest, Aggregation) =
  digestAndAggregate.overSpool(bs)
```

Much simpler!

Solution

This RB introduces the Fold[I, O] type, following libraries like
https://hackage.haskell.org/package/foldl .  (We emphasize that the ideas here are not novel to the
world, and not even novel to algebird - see Aggregation.)

Simplified:

```
trait Fold[I, O] {
  // Produces a new Fold that transforms the output of this Fold
  def map[P](f: O => P): Fold[I, P]

  // Produces a new Fold that tees inputs to this and another Fold, returning both results
  def join[P](other: Fold[I, P]): Fold[I, (O, P)]

  // Runs this fold over the elements of a Traversable
  def overTraversable(is: Traversable[I]): O

  // Runs this fold over the elements of a Spool, flatMapping along the way
  def overSpool(spool: Spool[I]): Future[O]

  // "Build" this so we can run it with overTraversable/overSpool.
  type X
  def build: FoldState[X, I, O]
}

case class FoldState[X, I, O](
  add: (X, I) => X,  // Adds I to our state
  start: X,          // State
  end: X => O        // Transform state to final result
)
```

Folds do not have internal state themselves; they instead "build()" a FoldState we can use to fold.
Because of this, Folds can be run many times, and they can be run over datatypes not defined
in algebird.

Fold is so simple and fundamental that algebird-core seems like an appropriate place.  It makes
consuming Seqs, Spools, and Readers easy and consistent.  A number of teams have expressed interest
in using and sharing this common type.

This type also admits an effectful variant that can sequence Futures before, during, and after
folding.

Result

We will have a basic vocabulary to express Folds simply, succinctly, and reusably.
