### PR TITLE
BloomFilter should warn or raise on unrealistic input.

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -54,7 +54,16 @@ object BloomFilter {
   def optimalNumHashes(numEntries: Int, width: Int): Int = math.ceil(width / numEntries * math.log(2)).toInt
 
   // Compute optimal width: m = - n ln(p) / (ln(2))^2
-  def optimalWidth(numEntries: Int, fpProb: Double): Int = math.ceil(-1 * numEntries * math.log(fpProb) / math.log(2) / math.log(2)).toInt
+  def optimalWidth(numEntries: Int, fpProb: Double): Int = {
+    val widthEstimate = math.ceil(-1 * numEntries * math.log(fpProb) / math.log(2) / math.log(2)).toInt
+
+    if (widthEstimate == Int.MaxValue) {
+      throw new java.lang.IllegalArgumentException(
+        "BloomFilter cannot guarantee the specified false positive probability for the number of entries!")
+    }
+
+    return widthEstimate
+  }
 }
 
 /**


### PR DESCRIPTION
Given an unrealistic combination of number of elements and false positive
probabilitiy, the optimalWidth method should not fail silently. It should
warn the user or throw an exception to ensure that the BloomFilter delivers
the expected performance.
