### PR TITLE
Fixes the base properties like MonoidLaws that weren't running.

### DIFF
--- a/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
@@ -17,7 +17,7 @@ limitations under the License.
 package com.twitter.algebird
 
 import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalatest.prop.Checkers
 import org.scalacheck.Prop.forAll
 import scala.math.Equiv
 
@@ -41,11 +41,12 @@ object BaseProperties {
     case _ => true
   }
 
-  def isAssociativeEq[T: Semigroup, U <: T: Arbitrary](eqfn: (T, T) => Boolean) = {
-    forAll { (a: U, b: U, c: U) =>
+  def isAssociativeEq[T: Semigroup, U <: T: Arbitrary](eqfn: (T, T) => Boolean) {
+    Checkers.check(forAll { (a: U, b: U, c: U) =>
       val semi = implicitly[Semigroup[T]]
-      eqfn(semi.plus(a, semi.plus(b, c)), semi.plus(semi.plus(a, b), c))
-    }
+      val r = eqfn(semi.plus(a, semi.plus(b, c)), semi.plus(semi.plus(a, b), c))
+      r
+    })
   }
 
   def isAssociativeDifferentTypes[T: Semigroup, U <: T: Arbitrary] =
@@ -53,16 +54,17 @@ object BaseProperties {
 
   def isAssociative[T: Semigroup: Arbitrary] = isAssociativeDifferentTypes[T, T]
 
-  def semigroupSumWorks[T: Semigroup: Arbitrary: Equiv] = forAll { (in: List[T]) =>
+  def semigroupSumWorks[T: Semigroup: Arbitrary: Equiv] = Checkers.check(forAll { (in: List[T]) =>
     in.isEmpty || {
       Equiv[T].equiv(Semigroup.sumOption(in).get, in.reduceLeft(Semigroup.plus(_, _)))
     }
-  }
+  })
 
-  def isCommutativeEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = forAll { (a: T, b: T) =>
+  def isCommutativeEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = Checkers.check(forAll { (a: T, b: T) =>
     val semi = implicitly[Semigroup[T]]
     eqfn(semi.plus(a, b), semi.plus(b, a))
-  }
+  })
+
   def isCommutative[T: Semigroup: Arbitrary] = isCommutativeEq[T](defaultEq _)
 
   def semigroupLaws[T: Semigroup: Arbitrary] = {
@@ -76,100 +78,140 @@ object BaseProperties {
   }
 
   def semigroupLawsEquiv[T: Semigroup: Arbitrary: Equiv] =
-    isAssociativeEq[T, T](Equiv[T].equiv _) && semigroupSumWorks[T]
+    {
+      isAssociativeEq[T, T](Equiv[T].equiv _)
+      semigroupSumWorks[T]
+    }
 
-  def commutativeSemigroupLawsEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) =
-    isAssociativeEq[T, T](eqfn) && isCommutativeEq[T](eqfn)
-  def commutativeSemigroupLaws[T: Semigroup: Arbitrary] = commutativeSemigroupLawsEq[T](defaultEq _)
-
-  def isNonZeroWorksMonoid[T: Monoid: Arbitrary: Equiv] = forAll { (a: T, b: T) =>
-    val aIsLikeZero = Monoid.zeroEquiv[T].equiv(Monoid.plus(a, b), b)
-    Monoid.isNonZero(a) || aIsLikeZero
+  def commutativeSemigroupLawsEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = {
+    isAssociativeEq[T, T](eqfn)
+    isCommutativeEq[T](eqfn)
   }
 
-  def isNonZeroWorksRing[T: Ring: Arbitrary] = forAll { (a: T, b: T) =>
+  def commutativeSemigroupLaws[T: Semigroup: Arbitrary] = commutativeSemigroupLawsEq[T](defaultEq _)
+
+  def isNonZeroWorksMonoid[T: Monoid: Arbitrary: Equiv] = Checkers.check(forAll { (a: T, b: T) =>
+    val aIsLikeZero = Monoid.zeroEquiv[T].equiv(Monoid.plus(a, b), b)
+    Monoid.isNonZero(a) || aIsLikeZero
+  })
+
+  def isNonZeroWorksRing[T: Ring: Arbitrary] = Checkers.check(forAll { (a: T, b: T) =>
     implicit val monT: Monoid[T] = implicitly[Ring[T]]
     val prodZero = !monT.isNonZero(Ring.times(a, b))
     (Monoid.isNonZero(a) && Monoid.isNonZero(b)) || prodZero
-  }
+  })
 
-  def weakZeroDifferentTypes[T: Monoid, U <: T: Arbitrary] = forAll { (a: U) =>
+  def weakZeroDifferentTypes[T: Monoid, U <: T: Arbitrary] = Checkers.check(forAll { (a: U) =>
     val mon = implicitly[Monoid[T]]
     val zero = mon.zero
     // Some types, e.g. Maps, are not totally equal for all inputs (i.e. zero values removed)
     (mon.plus(a, zero) == mon.plus(zero, a))
-  }
+  })
 
   def weakZero[T: Monoid: Arbitrary] = weakZeroDifferentTypes[T, T]
 
-  def validZeroEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = forAll { (a: T) =>
+  def validZeroEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = Checkers.check(forAll { (a: T) =>
     val mon = implicitly[Monoid[T]]
     val zero = mon.zero
     eqfn(a, mon.plus(a, zero)) && eqfn(mon.plus(zero, a), a) && eqfn(mon.plus(a, zero), mon.plus(zero, a))
-  }
+  })
+
   def validZero[T: Monoid: Arbitrary] = validZeroEq[T](defaultEq _)
 
-  def monoidLaws[T: Monoid: Arbitrary] = validZero[T] && semigroupLaws[T] && isNonZeroWorksMonoid[T]
+  def monoidLaws[T: Monoid: Arbitrary] = {
+    validZero[T]
+    semigroupLaws[T]
+    isNonZeroWorksMonoid[T]
+  }
 
-  def monoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean): Prop =
-    validZeroEq[T](eqfn) && semigroupLawsEq[T](eqfn)
+  def monoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = {
+    validZeroEq[T](eqfn)
+    semigroupLawsEq[T](eqfn)
+  }
 
-  def commutativeMonoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) =
-    monoidLawsEq[T](eqfn) && isCommutativeEq[T](eqfn)
+  def commutativeMonoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = {
+    monoidLawsEq[T](eqfn)
+    isCommutativeEq[T](eqfn)
+  }
 
   def commutativeMonoidLaws[T: Monoid: Arbitrary] = commutativeMonoidLawsEq[T](defaultEq _)
 
-  def hasAdditiveInversesDifferentTypes[T: Group, U <: T: Arbitrary] = forAll { (a: U) =>
+  def hasAdditiveInversesDifferentTypes[T: Group, U <: T: Arbitrary] = Checkers.check(forAll { (a: U) =>
     val grp = implicitly[Group[T]]
     (!grp.isNonZero(grp.plus(grp.negate(a), a))) &&
       (!grp.isNonZero(grp.minus(a, a))) &&
       (!grp.isNonZero(grp.plus(a, grp.negate(a))))
-  }
+  })
 
   def hasAdditiveInverses[T: Group: Arbitrary] = hasAdditiveInversesDifferentTypes[T, T]
 
-  def groupLawsEq[T: Group: Arbitrary](eqfn: (T, T) => Boolean) = monoidLawsEq[T](eqfn) && hasAdditiveInverses[T]
+  def groupLawsEq[T: Group: Arbitrary](eqfn: (T, T) => Boolean) = {
+    monoidLawsEq[T](eqfn)
+    hasAdditiveInverses[T]
+  }
 
-  def groupLaws[T: Group: Arbitrary] = monoidLaws[T] && hasAdditiveInverses[T]
+  def groupLaws[T: Group: Arbitrary] = {
+    monoidLaws[T]
+    hasAdditiveInverses[T]
+  }
+
   // Here are multiplicative properties:
-  def validOne[T: Ring: Arbitrary] = forAll { (a: T) =>
+  def validOne[T: Ring: Arbitrary] = Checkers.check(forAll { (a: T) =>
     val rng = implicitly[Ring[T]]
     (rng.times(rng.one, a) == rng.times(a, rng.one)) && (a == rng.times(a, rng.one))
-  }
-  def zeroAnnihilates[T: Ring: Arbitrary] = forAll { (a: T) =>
+  })
+
+  def zeroAnnihilates[T: Ring: Arbitrary] = Checkers.check(forAll { (a: T) =>
     val ring = implicitly[Ring[T]]
     (!ring.isNonZero(ring.times(a, ring.zero))) &&
       (!ring.isNonZero(ring.times(ring.zero, a)))
-  }
-  def isDistributiveDifferentTypes[T: Ring, U <: T: Arbitrary] = forAll { (a: U, b: U, c: U) =>
+  })
+
+  def isDistributiveDifferentTypes[T: Ring, U <: T: Arbitrary] = Checkers.check(forAll { (a: U, b: U, c: U) =>
     val rng = implicitly[Ring[T]]
     (rng.times(a, rng.plus(b, c)) == rng.plus(rng.times(a, b), rng.times(a, c))) &&
       (rng.times(rng.plus(b, c), a) == rng.plus(rng.times(b, a), rng.times(c, a)))
-  }
+  })
+
   def isDistributive[T: Ring: Arbitrary] = isDistributiveDifferentTypes[T, T]
 
-  def timesIsAssociative[T: Ring: Arbitrary] = forAll { (a: T, b: T, c: T) =>
+  def timesIsAssociative[T: Ring: Arbitrary] = Checkers.check(forAll { (a: T, b: T, c: T) =>
     val rng = implicitly[Ring[T]]
     rng.times(a, rng.times(b, c)) == rng.times(rng.times(a, b), c)
+  })
+
+  def pseudoRingLaws[T: Ring: Arbitrary] = {
+    isDistributive[T]
+    timesIsAssociative[T]
+    groupLaws[T]
+    isCommutative[T]
+    isNonZeroWorksRing[T]
   }
-  def pseudoRingLaws[T: Ring: Arbitrary] =
-    isDistributive[T] && timesIsAssociative[T] && groupLaws[T] && isCommutative[T] &&
-      isNonZeroWorksRing[T]
 
-  def semiringLaws[T: Ring: Arbitrary] =
-    isDistributive[T] && timesIsAssociative[T] &&
-      validOne[T] && commutativeMonoidLaws[T] &&
-      zeroAnnihilates[T] &&
-      isNonZeroWorksRing[T]
+  def semiringLaws[T: Ring: Arbitrary] = {
+    isDistributive[T]
+    timesIsAssociative[T]
+    validOne[T]
+    commutativeMonoidLaws[T]
+    zeroAnnihilates[T]
+    isNonZeroWorksRing[T]
+  }
 
-  def ringLaws[T: Ring: Arbitrary] = validOne[T] && pseudoRingLaws[T]
+  def ringLaws[T: Ring: Arbitrary] = {
+    validOne[T]
+    pseudoRingLaws[T]
+  }
 
-  def hasMultiplicativeInverse[T: Field: Arbitrary] = forAll { (a: T) =>
+  def hasMultiplicativeInverse[T: Field: Arbitrary] = Checkers.check(forAll { (a: T) =>
     val fld = implicitly[Field[T]]
     (!fld.isNonZero(a)) || {
       val inva = fld.inverse(a)
       (fld.times(inva, a) == fld.one) && (fld.times(a, inva) == fld.one)
     }
+  })
+
+  def fieldLaws[T: Field: Arbitrary] = {
+    ringLaws[T]
+    hasMultiplicativeInverse[T]
   }
-  def fieldLaws[T: Field: Arbitrary] = ringLaws[T] && hasMultiplicativeInverse[T]
 }

--- a/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
@@ -17,8 +17,10 @@ limitations under the License.
 package com.twitter.algebird
 
 import org.scalacheck.Arbitrary
-import org.scalatest.prop.Checkers
-import org.scalacheck.Prop.forAll
+import org.scalatest.prop.{ PropertyChecks, Checkers }
+import org.scalatest.Matchers
+import org.scalacheck.Prop
+import org.scalactic.Equality
 import scala.math.Equiv
 
 /**
@@ -26,7 +28,20 @@ import scala.math.Equiv
  */
 
 object BaseProperties {
+  import Checkers._
+  import Matchers._
+  import PropertyChecks._
   def defaultEq[T](t0: T, t1: T) = t0 == t1
+
+  private def eqFnToEquality[T](eqfn: (T, T) => Boolean): Equality[T] =
+    new Equality[T] {
+      def areEqual(a: T, b: Any): Boolean = eqfn(b.asInstanceOf[T], a)
+    }
+
+  private def equivToEquality[T: Equiv]: Equality[T] =
+    new Equality[T] {
+      def areEqual(a: T, b: Any): Boolean = implicitly[Equiv[T]].equiv(b.asInstanceOf[T], a)
+    }
 
   trait HigherEq[M[_]] {
     def apply[T](m: M[T], n: M[T]): Boolean
@@ -41,81 +56,87 @@ object BaseProperties {
     case _ => true
   }
 
-  def isAssociativeEq[T: Semigroup, U <: T: Arbitrary](eqfn: (T, T) => Boolean) {
-    Checkers.check(forAll { (a: U, b: U, c: U) =>
+  def isAssociativeEquality[T: Semigroup: Equality, U <: T: Arbitrary] =
+    forAll { (a: U, b: U, c: U) =>
       val semi = implicitly[Semigroup[T]]
-      eqfn(semi.plus(a, semi.plus(b, c)), semi.plus(semi.plus(a, b), c))
-    })
-  }
+      semi.plus(a, semi.plus(b, c)) shouldEqual semi.plus(semi.plus(a, b), c)
+    }
 
   def isAssociativeDifferentTypes[T: Semigroup, U <: T: Arbitrary] =
-    isAssociativeEq[T, U](defaultEq _)
+    isAssociativeEquality[T, U]
 
-  def isAssociative[T: Semigroup: Arbitrary] = isAssociativeDifferentTypes[T, T]
+  def isAssociative[T: Semigroup: Arbitrary] =
+    isAssociativeDifferentTypes[T, T]
 
-  def semigroupSumWorks[T: Semigroup: Arbitrary: Equiv] = Checkers.check(forAll { (in: List[T]) =>
-    in.isEmpty || {
-      Equiv[T].equiv(Semigroup.sumOption(in).get, in.reduceLeft(Semigroup.plus(_, _)))
+  def semigroupSumWorksEquality[T: Semigroup: Arbitrary: Equality] = {
+    forAll { (in: List[T]) =>
+      whenever(!in.isEmpty) {
+        Semigroup.sumOption(in).get shouldEqual in.reduceLeft(Semigroup.plus(_, _))
+      }
     }
-  })
+  }
 
-  def isCommutativeEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = Checkers.check(forAll { (a: T, b: T) =>
+  def semigroupSumWorks[T: Semigroup: Arbitrary: Equiv] = {
+    implicit val eq = equivToEquality[T]
+    semigroupSumWorksEquality
+  }
+
+  def isCommutativeEquality[T: Semigroup: Arbitrary: Equality] = forAll { (a: T, b: T) =>
     val semi = implicitly[Semigroup[T]]
-    eqfn(semi.plus(a, b), semi.plus(b, a))
-  })
-
-  def isCommutative[T: Semigroup: Arbitrary] = isCommutativeEq[T](defaultEq _)
-
-  def semigroupLaws[T: Semigroup: Arbitrary] = {
-    implicit val eq: Equiv[T] = Equiv.fromFunction(defaultEq)
-    semigroupLawsEquiv[T]
+    semi.plus(a, b) shouldEqual semi.plus(b, a)
   }
 
-  def semigroupLawsEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = {
-    implicit val eq: Equiv[T] = Equiv.fromFunction(eqfn)
-    semigroupLawsEquiv[T]
+  def isCommutative[T: Semigroup: Arbitrary] = isCommutativeEquality[T]
+
+  def semigroupLaws[T: Semigroup: Arbitrary] =
+    semigroupLawsEquality[T]
+
+  def semigroupLawsEquiv[T: Semigroup: Arbitrary: Equiv] = {
+    implicit val eq = equivToEquality[T]
+    semigroupLawsEquality
   }
 
-  def semigroupLawsEquiv[T: Semigroup: Arbitrary: Equiv] =
-    {
-      isAssociativeEq[T, T](Equiv[T].equiv _)
-      semigroupSumWorks[T]
-    }
-
-  def commutativeSemigroupLawsEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = {
-    isAssociativeEq[T, T](eqfn)
-    isCommutativeEq[T](eqfn)
+  def semigroupLawsEquality[T: Semigroup: Arbitrary: Equality] = {
+    isAssociativeEquality[T, T]
+    semigroupSumWorksEquality[T]
   }
 
-  def commutativeSemigroupLaws[T: Semigroup: Arbitrary] = commutativeSemigroupLawsEq[T](defaultEq _)
+  def commutativeSemigroupLawsEquality[T: Semigroup: Arbitrary: Equality] = {
+    isAssociativeEquality[T, T]
+    isCommutativeEquality[T]
+  }
 
-  def isNonZeroWorksMonoid[T: Monoid: Arbitrary: Equiv] = Checkers.check(forAll { (a: T, b: T) =>
+  def commutativeSemigroupLaws[T: Semigroup: Arbitrary] = commutativeSemigroupLawsEquality[T]
+
+  def isNonZeroWorksMonoid[T: Monoid: Arbitrary: Equiv] = Checkers.check(Prop.forAll { (a: T, b: T) =>
     val aIsLikeZero = Monoid.zeroEquiv[T].equiv(Monoid.plus(a, b), b)
     Monoid.isNonZero(a) || aIsLikeZero
   })
 
-  def isNonZeroWorksRing[T: Ring: Arbitrary] = Checkers.check(forAll { (a: T, b: T) =>
+  def isNonZeroWorksRing[T: Ring: Arbitrary] = Checkers.check(Prop.forAll { (a: T, b: T) =>
     implicit val monT: Monoid[T] = implicitly[Ring[T]]
     val prodZero = !monT.isNonZero(Ring.times(a, b))
     (Monoid.isNonZero(a) && Monoid.isNonZero(b)) || prodZero
   })
 
-  def weakZeroDifferentTypes[T: Monoid, U <: T: Arbitrary] = Checkers.check(forAll { (a: U) =>
+  def weakZeroDifferentTypes[T: Monoid, U <: T: Arbitrary] = forAll { (a: U) =>
     val mon = implicitly[Monoid[T]]
     val zero = mon.zero
     // Some types, e.g. Maps, are not totally equal for all inputs (i.e. zero values removed)
-    (mon.plus(a, zero) == mon.plus(zero, a))
-  })
+    mon.plus(a, zero) shouldEqual mon.plus(zero, a)
+  }
 
   def weakZero[T: Monoid: Arbitrary] = weakZeroDifferentTypes[T, T]
 
-  def validZeroEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = Checkers.check(forAll { (a: T) =>
+  def validZeroEquality[T: Monoid: Arbitrary: Equality] = forAll { (a: T) =>
     val mon = implicitly[Monoid[T]]
     val zero = mon.zero
-    eqfn(a, mon.plus(a, zero)) && eqfn(mon.plus(zero, a), a) && eqfn(mon.plus(a, zero), mon.plus(zero, a))
-  })
+    a shouldEqual mon.plus(a, zero)
+    mon.plus(zero, a) shouldEqual a
+    mon.plus(a, zero) shouldEqual mon.plus(zero, a)
+  }
 
-  def validZero[T: Monoid: Arbitrary] = validZeroEq[T](defaultEq _)
+  def validZero[T: Monoid: Arbitrary] = validZeroEquality[T]
 
   def monoidLaws[T: Monoid: Arbitrary] = {
     validZero[T]
@@ -123,29 +144,30 @@ object BaseProperties {
     isNonZeroWorksMonoid[T]
   }
 
-  def monoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = {
-    validZeroEq[T](eqfn)
-    semigroupLawsEq[T](eqfn)
+  def monoidLawsEquality[T: Monoid: Arbitrary: Equality] = {
+    validZeroEquality[T]
+    semigroupLawsEquality[T]
   }
 
-  def commutativeMonoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = {
-    monoidLawsEq[T](eqfn)
-    isCommutativeEq[T](eqfn)
+  def commutativeMonoidLawsEquality[T: Monoid: Arbitrary: Equality] = {
+    monoidLawsEquality[T]
+    isCommutativeEquality[T]
   }
 
-  def commutativeMonoidLaws[T: Monoid: Arbitrary] = commutativeMonoidLawsEq[T](defaultEq _)
+  def commutativeMonoidLaws[T: Monoid: Arbitrary] = commutativeMonoidLawsEquality[T]
 
-  def hasAdditiveInversesDifferentTypes[T: Group, U <: T: Arbitrary] = Checkers.check(forAll { (a: U) =>
+  def hasAdditiveInversesDifferentTypes[T: Group, U <: T: Arbitrary] = forAll { (a: U) =>
     val grp = implicitly[Group[T]]
-    (!grp.isNonZero(grp.plus(grp.negate(a), a))) &&
-      (!grp.isNonZero(grp.minus(a, a))) &&
-      (!grp.isNonZero(grp.plus(a, grp.negate(a))))
-  })
+    assert(grp.isNonZero(grp.plus(grp.negate(a), a)) == false)
+    assert(grp.isNonZero(grp.minus(a, a)) == false)
+    assert(grp.isNonZero(grp.plus(a, grp.negate(a))) == false)
+  }
 
-  def hasAdditiveInverses[T: Group: Arbitrary] = hasAdditiveInversesDifferentTypes[T, T]
+  def hasAdditiveInverses[T: Group: Arbitrary] =
+    hasAdditiveInversesDifferentTypes[T, T]
 
-  def groupLawsEq[T: Group: Arbitrary](eqfn: (T, T) => Boolean) = {
-    monoidLawsEq[T](eqfn)
+  def groupLawsEquality[T: Group: Arbitrary: Equality] = {
+    monoidLawsEquality[T]
     hasAdditiveInverses[T]
   }
 
@@ -155,18 +177,18 @@ object BaseProperties {
   }
 
   // Here are multiplicative properties:
-  def validOne[T: Ring: Arbitrary] = Checkers.check(forAll { (a: T) =>
+  def validOne[T: Ring: Arbitrary] = Checkers.check(Prop.forAll { (a: T) =>
     val rng = implicitly[Ring[T]]
     (rng.times(rng.one, a) == rng.times(a, rng.one)) && (a == rng.times(a, rng.one))
   })
 
-  def zeroAnnihilates[T: Ring: Arbitrary] = Checkers.check(forAll { (a: T) =>
+  def zeroAnnihilates[T: Ring: Arbitrary] = Checkers.check(Prop.forAll { (a: T) =>
     val ring = implicitly[Ring[T]]
     (!ring.isNonZero(ring.times(a, ring.zero))) &&
       (!ring.isNonZero(ring.times(ring.zero, a)))
   })
 
-  def isDistributiveDifferentTypes[T: Ring, U <: T: Arbitrary] = Checkers.check(forAll { (a: U, b: U, c: U) =>
+  def isDistributiveDifferentTypes[T: Ring, U <: T: Arbitrary] = Checkers.check(Prop.forAll { (a: U, b: U, c: U) =>
     val rng = implicitly[Ring[T]]
     (rng.times(a, rng.plus(b, c)) == rng.plus(rng.times(a, b), rng.times(a, c))) &&
       (rng.times(rng.plus(b, c), a) == rng.plus(rng.times(b, a), rng.times(c, a)))
@@ -174,7 +196,7 @@ object BaseProperties {
 
   def isDistributive[T: Ring: Arbitrary] = isDistributiveDifferentTypes[T, T]
 
-  def timesIsAssociative[T: Ring: Arbitrary] = Checkers.check(forAll { (a: T, b: T, c: T) =>
+  def timesIsAssociative[T: Ring: Arbitrary] = Checkers.check(Prop.forAll { (a: T, b: T, c: T) =>
     val rng = implicitly[Ring[T]]
     rng.times(a, rng.times(b, c)) == rng.times(rng.times(a, b), c)
   })
@@ -201,7 +223,7 @@ object BaseProperties {
     pseudoRingLaws[T]
   }
 
-  def hasMultiplicativeInverse[T: Field: Arbitrary] = Checkers.check(forAll { (a: T) =>
+  def hasMultiplicativeInverse[T: Field: Arbitrary] = Checkers.check(Prop.forAll { (a: T) =>
     val fld = implicitly[Field[T]]
     (!fld.isNonZero(a)) || {
       val inva = fld.inverse(a)
@@ -212,5 +234,54 @@ object BaseProperties {
   def fieldLaws[T: Field: Arbitrary] = {
     ringLaws[T]
     hasMultiplicativeInverse[T]
+  }
+
+  // Deprecated methods supplying equality as an a == b method
+  @deprecated("Use isAssociativeEquality instead.", "2014-11-30")
+  def isAssociativeEq[T: Semigroup, U <: T: Arbitrary](eqfn: (T, T) => Boolean) {
+    implicit val eq = eqFnToEquality(eqfn)
+    isAssociativeEquality[T, U]
+  }
+
+  @deprecated("Use isCommutativeEquality instead.", "2014-11-30")
+  def isCommutativeEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = {
+    implicit val eq = eqFnToEquality(eqfn)
+    isCommutativeEquality[T]
+  }
+
+  @deprecated("Use validZeroEquality instead.", "2014-11-30")
+  def validZeroEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = {
+    implicit val eq = eqFnToEquality(eqfn)
+    validZeroEquality[T]
+  }
+
+  @deprecated("Use semigroupLawsEquality instead.", "2014-11-30")
+  def semigroupLawsEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = {
+    implicit val eq = eqFnToEquality(eqfn)
+    semigroupLawsEquality[T]
+  }
+
+  @deprecated("Use commutativeSemigroupLawsEquality instead.", "2014-11-30")
+  def commutativeSemigroupLawsEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = {
+    implicit val eq = eqFnToEquality(eqfn)
+    commutativeSemigroupLawsEquality[T]
+  }
+
+  @deprecated("Use commutativeMonoidLawsEquality instead.", "2014-11-30")
+  def commutativeMonoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = {
+    implicit val eq = eqFnToEquality(eqfn)
+    commutativeMonoidLawsEquality[T]
+  }
+
+  @deprecated("Use groupLawsEquality instead.", "2014-11-30")
+  def groupLawsEq[T: Group: Arbitrary](eqfn: (T, T) => Boolean) = {
+    implicit val eq = eqFnToEquality(eqfn)
+    groupLawsEquality[T]
+  }
+
+  @deprecated("Use monoidLawsEquality instead.", "2014-11-30")
+  def monoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = {
+    implicit val eq = eqFnToEquality(eqfn)
+    monoidLawsEquality[T]
   }
 }

--- a/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
@@ -44,8 +44,7 @@ object BaseProperties {
   def isAssociativeEq[T: Semigroup, U <: T: Arbitrary](eqfn: (T, T) => Boolean) {
     Checkers.check(forAll { (a: U, b: U, c: U) =>
       val semi = implicitly[Semigroup[T]]
-      val r = eqfn(semi.plus(a, semi.plus(b, c)), semi.plus(semi.plus(a, b), c))
-      r
+      eqfn(semi.plus(a, semi.plus(b, c)), semi.plus(semi.plus(a, b), c))
     })
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
@@ -59,11 +59,14 @@ class CollectionSpecification extends PropSpec with PropertyChecks with Matchers
   }
 
   property("Option Monoid laws") {
-    monoidLaws[Option[Int]] && monoidLaws[Option[String]]
+    monoidLaws[Option[Int]]
+    monoidLaws[Option[String]]
   }
 
   property("Option Group laws") {
-    groupLaws[Option[Int]] && groupLawsEq[Map[String, Option[Int]]]{
+    groupLaws[Option[Int]]
+
+    groupLawsEq[Map[String, Option[Int]]]{
       (a: Map[String, Option[Int]], b: Map[String, Option[Int]]) =>
         val keys: Set[String] = a.keySet | b.keySet
         keys.forall { key: String =>
@@ -151,15 +154,18 @@ class CollectionSpecification extends PropSpec with PropertyChecks with Matchers
   }
 
   property("Map[Int,Int] Monoid laws") {
-    isAssociative[Map[Int, Int]] && weakZero[Map[Int, Int]]
+    isAssociative[Map[Int, Int]]
+    weakZero[Map[Int, Int]]
   }
 
   property("ScMap[Int,Int] Monoid laws") {
-    isAssociative[ScMap[Int, Int]] && weakZero[ScMap[Int, Int]]
+    isAssociative[ScMap[Int, Int]]
+    weakZero[ScMap[Int, Int]]
   }
 
   property("MMap[Int,Int] Monoid laws") {
-    isAssociativeDifferentTypes[ScMap[Int, Int], MMap[Int, Int]] && weakZeroDifferentTypes[ScMap[Int, Int], MMap[Int, Int]]
+    isAssociativeDifferentTypes[ScMap[Int, Int], MMap[Int, Int]]
+    weakZeroDifferentTypes[ScMap[Int, Int], MMap[Int, Int]]
   }
 
   property("Map[Int,Int] has -") {
@@ -175,15 +181,18 @@ class CollectionSpecification extends PropSpec with PropertyChecks with Matchers
   }
 
   property("Map[Int,String] Monoid laws") {
-    isAssociative[Map[Int, String]] && weakZero[Map[Int, String]]
+    isAssociative[Map[Int, String]]
+    weakZero[Map[Int, String]]
   }
 
   property("ScMap[Int,String] Monoid laws") {
-    isAssociative[ScMap[Int, String]] && weakZero[ScMap[Int, String]]
+    isAssociative[ScMap[Int, String]]
+    weakZero[ScMap[Int, String]]
   }
 
   property("MMap[Int,String] Monoid laws") {
-    isAssociativeDifferentTypes[ScMap[Int, Int], MMap[Int, Int]] && weakZeroDifferentTypes[ScMap[Int, Int], MMap[Int, Int]]
+    isAssociativeDifferentTypes[ScMap[Int, Int], MMap[Int, Int]]
+    weakZeroDifferentTypes[ScMap[Int, Int], MMap[Int, Int]]
   }
 
   // We haven't implemented ring.one yet for the Map, so skip the one property

--- a/algebird-test/src/test/scala/com/twitter/algebird/FunctionMonoidTests.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/FunctionMonoidTests.scala
@@ -1,10 +1,11 @@
 package com.twitter.algebird
 
 import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.{ PropertyChecks, Checkers }
 import org.scalacheck.{ Prop, Arbitrary }
+import scala.reflect.ClassTag
 
-class FunctionMonoidTests extends PropSpec with PropertyChecks with Matchers {
+class FunctionMonoidTests extends PropSpec with PropertyChecks with Matchers with Checkers {
   import BaseProperties._
 
   // Generates an arbitrary linear function of the form f(x) = a * x + b,
@@ -19,7 +20,7 @@ class FunctionMonoidTests extends PropSpec with PropertyChecks with Matchers {
 
   property("Linear functions over the integers form a monoid under function composition") {
     // TODO: switch the scope of the quantification?
-    Prop.forAll { (n: Int) =>
+    forAll { (n: Int) =>
       monoidLawsEq[Function1[Int, Int]] { (f1, f2) => f1(n) == f2(n) }
     }
   }

--- a/algebird-test/src/test/scala/com/twitter/algebird/JavaBoxedTests.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/JavaBoxedTests.scala
@@ -74,11 +74,13 @@ class JavaBoxedTests extends PropSpec with PropertyChecks with Matchers {
   }
 
   property("JMap[String,Int] is a Monoid") {
-    isAssociative[JMap[String, Int]] && weakZero[JMap[String, Int]]
+    isAssociative[JMap[String, Int]]
+    weakZero[JMap[String, Int]]
   }
 
   property("JMap[String,String] is a Monoid") {
-    isAssociative[JMap[String, String]] && weakZero[JMap[String, String]]
+    isAssociative[JMap[String, String]]
+    weakZero[JMap[String, String]]
   }
 
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/MonadProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MonadProperties.scala
@@ -55,14 +55,16 @@ class MonadProperties extends PropSpec with PropertyChecks with Matchers {
     implicit val optSg = new MonadSemigroup[Int, Option]
     implicit val listSg = new MonadSemigroup[String, List]
     // the + here is actually a cross-product, and testing sumOption blows up
-    semigroupLaws[Option[Int]] && isAssociative[List[String]]
+    semigroupLaws[Option[Int]]
+    isAssociative[List[String]]
   }
 
   property("Monad Monoid") {
     implicit val optSg = new MonadMonoid[Int, Option]
     implicit val listSg = new MonadMonoid[String, List]
     // the + here is actually a cross-product, and testing sumOption blows up
-    monoidLaws[Option[Int]] && validZero[List[String]]
+    monoidLaws[Option[Int]]
+    validZero[List[String]]
   }
 
   // These laws work for only "non-empty" monads


### PR DESCRIPTION
Got broken in the scalatest conversion. This brings them back. Fixes #357 
