### PR TITLE
add no-arg count method to aggregator

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -45,7 +45,7 @@ object Aggregator extends java.io.Serializable {
     def present(reduction: T) = reduction
   }
 
-  def count[T]: MonoidAggregator[T, Long, Long] = count[T](t => true)
+  def count[T]: MonoidAggregator[T, Long, Long] = count[T] { (t: T) => true}
 
   /**
    * How many items satisfy a predicate


### PR DESCRIPTION
Trying to write some scalding example that shows scalding equivalent of SQL code using Aggregator. 

so for this SQL statement

```
 SELECT customerName, Count(*)
 FROM order
 GroupBy customerName
```

I have to write something like this

```
 val orders = List(
    Order(1, "12/22/2005", 160, 2, "Smith"),
    Order(2, "08/10/2005", 190, 2, "Johnson"),
    Order(3, "07/13/2005", 500, 5, "Baldwin"),
    Order(4, "07/15/2005", 420, 2, "Smith"),
    Order(5, "12/22/2005", 1000, 4, "Wood"),
    Order(6, "10/2/2005", 820, 4, "Smith"),
    Order(7, "11/03/2005", 2000, 2, "Baldwin"))

TypedPipe.from(orders)
      .groupBy(_.customerName)
      .aggregate(count( x => true))
```

it would be nice if we could just write

```
TypedPipe.from(orders)
      .groupBy(_.customerName)
      .aggregate(count)
```
