### PR TITLE
removed duplicate semigroup

### DIFF
--- a/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/AsyncSummerBenchmark.scala
+++ b/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/AsyncSummerBenchmark.scala
@@ -62,7 +62,7 @@ class AsyncSummerBenchmark extends SimpleBenchmark {
       Counter("memory"),
       Counter("timeOut"),
       Counter("size"),
-      putCounter,
+      Counter("puts"),
       Counter("tuplesIn"),
       Counter("tuplesOut")),
     "NullSummer" -> new NullSummer[K, V](Counter("tuplesIn"), Counter("tuplesOut")))

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
@@ -17,7 +17,7 @@
 package com.twitter.algebird.util.summer
 
 import org.scalatest.prop.PropertyChecks
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.{ Matchers, PropSpec }
 
 class AsyncListSumProperties extends PropSpec with PropertyChecks with Matchers {
 


### PR DESCRIPTION
Based on @johnynek comments [here](https://github.com/twitter/algebird/pull/373#discussion_r21699242)
1. removed duplicate semigroup
2.  Re: join vs SumOption. I am not sure I can switch to `join` as I have a `Future[T]` and a `List[Future[T]`, I can potentially do a foldLeft but not sure if its any better than sumOption. Let me know what you think
