### PR TITLE
GH-381: Fix serialization errors when using new CMS implementation in Storm

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -1031,7 +1031,7 @@ trait CMSHasher[K] extends java.io.Serializable {
 
 }
 
-case class CMSHash[K: CMSHasher](a: Int, b: Int, width: Int) {
+case class CMSHash[K: CMSHasher](a: Int, b: Int, width: Int) extends java.io.Serializable {
 
   /**
    * Returns `a * x + b (mod p) (mod width)`.


### PR DESCRIPTION
See GH-381.

This PR makes a few CMS helper classes extend `java.io.Serializable`, thus fixing the serialization errors reported by Storm.
