### PR TITLE
update qtree to compress more aggressively

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/QTree.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/QTree.scala
@@ -210,7 +210,7 @@ case class QTree[A](
     val (lowerResult, upperResult) =
       mapChildrenWithDefault[(Option[QTree[A]], Boolean)]((None, false)){ _.prune(minCount) }
     val parent =
-      if (lowerResult._2 || lowerResult._2)
+      if (lowerResult._2 || upperResult._2)
         copy(lowerChild = lowerResult._1, upperChild = upperResult._1)
       else
         this


### PR DESCRIPTION
The current qtree compress implementation is too conservative. In the current implementation new nodes with small counts can exist as long as the neighboring subtree has a big enough count.

I've updated the implementation to be more aligned with the algorithm outlined here: http://www.cs.virginia.edu/~son/cs851/papers/ucsb.sensys04.pdf

I've checked my solution by playing around in `./sbt algebird-core/console` and via `./sbt algebird-test/test`

This is also my first pull request for algebird, please let me know if I should have taken some extra steps.