### PR TITLE
Freshen up Applicative instances a bit

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Monad.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Monad.scala
@@ -19,6 +19,8 @@ import java.lang.{ Integer => JInt, Short => JShort, Long => JLong, Float => JFl
 import java.util.{ List => JList, Map => JMap }
 
 import scala.annotation.implicitNotFound
+import scala.util.{Failure, Success, Try}
+import scala.concurrent.{Future, ExecutionContext}
 import collection.GenTraversable
 
 /**
@@ -91,6 +93,28 @@ object Monad {
     def apply[T](v: T) = IndexedSeq(v);
     def flatMap[T, U](m: IndexedSeq[T])(fn: (T) => IndexedSeq[U]) = m.flatMap(fn)
   }
+  implicit val scalaTry: Monad[Try] = new Monad[Try] {
+    def apply[T](t: T): Try[T] = Success(t)
+    def flatMap[T, U](t: Try[T])(fn: T => Try[U]): Try[U] = t.flatMap(fn)
+    override def map[T, U](t: Try[T])(fn: T => U): Try[U] = t.map(fn)
+    override def join[T, U](t: Try[T], u: Try[U]): Try[(T, U)] =
+      // make the common case fast:
+      if(t.isSuccess && u.isSuccess) Success((t.get, u.get))
+      else (t, u) match {
+        case (Failure(e), _) => Failure(e)
+        case (_, Failure(e)) => Failure(e)
+        // One must be a failure due to being in the else branch
+        case (_, _) => sys.error("unreachable, but the compiler can't see that")
+      }
+  }
+  implicit def scalaFuture(implicit ec: ExecutionContext): Monad[Future] = new Monad[Future] {
+    def apply[T](t: T): Future[T] = Future.successful(t)
+    def flatMap[T, U](t: Future[T])(fn: T => Future[U]): Future[U] = t.flatMap(fn)
+    override def map[T, U](t: Future[T])(fn: T => U): Future[U] = t.map(fn)
+    override def join[T, U](t: Future[T], u: Future[U]): Future[(T, U)] = t.zip(u)
+    override def sequence[T](fs: Seq[Future[T]]): Future[Seq[T]] =
+      Future.sequence(fs)
+  }
 
   // Set up the syntax magic (allow .pure[Int] syntax and flatMap in for):
   // import Monad.{pureOp, operators} to get
@@ -105,41 +129,5 @@ object Monad {
  */
 class MonadOperators[A, M[_]](m: M[A])(implicit monad: Monad[M]) extends ApplicativeOperators[A, M](m) {
   def flatMap[U](fn: (A) => M[U]): M[U] = monad.flatMap(m)(fn)
-}
-
-// This is a Semigroup, for all Monads.
-class MonadSemigroup[T, M[_]](implicit monad: Monad[M], sg: Semigroup[T])
-  extends Semigroup[M[T]] {
-  import Monad.operators
-  def plus(l: M[T], r: M[T]) = for (lv <- l; rv <- r) yield sg.plus(lv, rv)
-}
-
-// This is a Monoid, for all Monads.
-class MonadMonoid[T, M[_]](implicit monad: Monad[M], mon: Monoid[T])
-  extends MonadSemigroup[T, M] with Monoid[M[T]] {
-  lazy val zero = monad(mon.zero)
-}
-
-// Group, Ring, and Field ARE NOT AUTOMATIC. You have to check that the laws hold for your Monad.
-
-class MonadGroup[T, M[_]](implicit monad: Monad[M], grp: Group[T])
-  extends MonadMonoid[T, M] with Group[M[T]] {
-  import Monad.operators
-  override def negate(v: M[T]) = v.map { grp.negate(_) }
-  override def minus(l: M[T], r: M[T]) = for (lv <- l; rv <- r) yield grp.minus(lv, rv)
-}
-
-class MonadRing[T, M[_]](implicit monad: Monad[M], ring: Ring[T])
-  extends MonadGroup[T, M] with Ring[M[T]] {
-  import Monad.operators
-  lazy val one = monad(ring.one)
-  def times(l: M[T], r: M[T]) = for (lv <- l; rv <- r) yield ring.times(lv, rv)
-}
-
-class MonadField[T, M[_]](implicit monad: Monad[M], fld: Field[T])
-  extends MonadRing[T, M] with Field[M[T]] {
-  import Monad.operators
-  override def inverse(v: M[T]) = v.map { fld.inverse(_) }
-  override def div(l: M[T], r: M[T]) = for (lv <- l; rv <- r) yield fld.div(lv, rv)
 }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/ApplicativeProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/ApplicativeProperties.scala
@@ -46,4 +46,35 @@ class ApplicativeProperties extends PropSpec with PropertyChecks with Matchers {
   property("seq") {
     applicativeLaws[Seq, Int, String, Long]()
   }
+  // Applicative algebras:
+  import BaseProperties._
+  property("Applicative Semigroup") {
+    implicit val optSg = new ApplicativeSemigroup[Int, Option]
+    implicit val listSg = new ApplicativeSemigroup[String, List]
+    // the + here is actually a cross-product, and testing sumOption blows up
+    semigroupLaws[Option[Int]] && isAssociative[List[String]]
+  }
+
+  property("Applicative Monoid") {
+    implicit val optSg = new ApplicativeMonoid[Int, Option]
+    implicit val listSg = new ApplicativeMonoid[String, List]
+    // the + here is actually a cross-product, and testing sumOption blows up
+    monoidLaws[Option[Int]] && validZero[List[String]]
+  }
+
+  // These laws work for only "non-empty" monads
+  property("Applicative Group") {
+    implicit val optSg = new ApplicativeGroup[Int, Some]
+    groupLaws[Some[Int]]
+  }
+
+  property("Applicative Ring") {
+    implicit val optSg = new ApplicativeRing[Int, Some]
+    ringLaws[Some[Int]]
+  }
+
+  property("Applicative Field") {
+    implicit val optSg = new ApplicativeField[Boolean, Some]
+    fieldLaws[Some[Boolean]]
+  }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/MonadProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MonadProperties.scala
@@ -23,7 +23,6 @@ import org.scalacheck.{ Gen, Arbitrary }
 import Monad.{ pureOp, operators }
 
 class MonadProperties extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
   import MonadLaws._
 
   property("list") {
@@ -48,36 +47,5 @@ class MonadProperties extends PropSpec with PropertyChecks with Matchers {
 
   property("seq") {
     monadLaws[Seq, Int, String, Long]()
-  }
-
-  // Monad algebras:
-  property("Monad Semigroup") {
-    implicit val optSg = new MonadSemigroup[Int, Option]
-    implicit val listSg = new MonadSemigroup[String, List]
-    // the + here is actually a cross-product, and testing sumOption blows up
-    semigroupLaws[Option[Int]] && isAssociative[List[String]]
-  }
-
-  property("Monad Monoid") {
-    implicit val optSg = new MonadMonoid[Int, Option]
-    implicit val listSg = new MonadMonoid[String, List]
-    // the + here is actually a cross-product, and testing sumOption blows up
-    monoidLaws[Option[Int]] && validZero[List[String]]
-  }
-
-  // These laws work for only "non-empty" monads
-  property("Monad Group") {
-    implicit val optSg = new MonadGroup[Int, Some]
-    groupLaws[Some[Int]]
-  }
-
-  property("Monad Ring") {
-    implicit val optSg = new MonadRing[Int, Some]
-    ringLaws[Some[Int]]
-  }
-
-  property("Monad Field") {
-    implicit val optSg = new MonadField[Boolean, Some]
-    fieldLaws[Some[Boolean]]
   }
 }

--- a/algebird-util/src/main/scala/com/twitter/algebird/util/UtilAlgebras.scala
+++ b/algebird-util/src/main/scala/com/twitter/algebird/util/UtilAlgebras.scala
@@ -22,8 +22,25 @@ import com.twitter.util.{ Future, Return, Try }
 object UtilAlgebras {
   implicit val futureMonad: Monad[Future] = new Monad[Future] {
     def apply[T](v: T) = Future.value(v)
-    override def map[T, U](m: Future[T])(fn: T => U) = m.map(fn)
     def flatMap[T, U](m: Future[T])(fn: T => Future[U]) = m.flatMap(fn)
+    /*
+     * We override join with more efficient implementations than
+     * just using flatMap
+     */
+    override def join[T, U](a: Future[T], b: Future[U]): Future[(T, U)] =
+      a.join(b)
+    override def join[T, U, V](t: Future[T], u: Future[U], v: Future[V]) =
+      Future.join(t, u, v)
+    override def join[T, U, V, W](t: Future[T], u: Future[U], v: Future[V], w: Future[W]) =
+      Future.join(t, u, v, w)
+    override def join[T, U, V, W, X](t: Future[T], u: Future[U], v: Future[V], w: Future[W], x: Future[X]) =
+      Future.join(t, u, v, w, x)
+    override def map[T, U](m: Future[T])(fn: T => U) = m.map(fn)
+    /*
+     * We override sequence with more efficient implementations than
+     * just using flatMap
+     */
+    override def sequence[T](fs: Seq[Future[T]]): Future[Seq[T]] = Future.collect(fs)
   }
   implicit val tryMonad: Monad[Try] = new Monad[Try] {
     def apply[T](v: T) = Return(v)
@@ -31,15 +48,15 @@ object UtilAlgebras {
     def flatMap[T, U](m: Try[T])(fn: T => Try[U]) = m.flatMap(fn)
   }
 
-  implicit def futureSemigroup[T: Semigroup]: Semigroup[Future[T]] = new MonadSemigroup[T, Future]
-  implicit def futureMonoid[T: Monoid]: Monoid[Future[T]] = new MonadMonoid[T, Future]
-  implicit def futureGroup[T: Group]: Group[Future[T]] = new MonadGroup[T, Future]
-  implicit def futureRing[T: Ring]: Ring[Future[T]] = new MonadRing[T, Future]
-  implicit def futureField[T: Field]: Field[Future[T]] = new MonadField[T, Future]
+  implicit def futureSemigroup[T: Semigroup]: Semigroup[Future[T]] = new ApplicativeSemigroup[T, Future]
+  implicit def futureMonoid[T: Monoid]: Monoid[Future[T]] = new ApplicativeMonoid[T, Future]
+  implicit def futureGroup[T: Group]: Group[Future[T]] = new ApplicativeGroup[T, Future]
+  implicit def futureRing[T: Ring]: Ring[Future[T]] = new ApplicativeRing[T, Future]
+  implicit def futureField[T: Field]: Field[Future[T]] = new ApplicativeField[T, Future]
 
-  implicit def trySemigroup[T: Semigroup]: Semigroup[Try[T]] = new MonadSemigroup[T, Try]
-  implicit def tryMonoid[T: Monoid]: Monoid[Try[T]] = new MonadMonoid[T, Try]
-  implicit def tryGroup[T: Group]: Group[Try[T]] = new MonadGroup[T, Try]
-  implicit def tryRing[T: Ring]: Ring[Try[T]] = new MonadRing[T, Try]
-  implicit def tryField[T: Field]: Field[Try[T]] = new MonadField[T, Try]
+  implicit def trySemigroup[T: Semigroup]: Semigroup[Try[T]] = new ApplicativeSemigroup[T, Try]
+  implicit def tryMonoid[T: Monoid]: Monoid[Try[T]] = new ApplicativeMonoid[T, Try]
+  implicit def tryGroup[T: Group]: Group[Try[T]] = new ApplicativeGroup[T, Try]
+  implicit def tryRing[T: Ring]: Ring[Try[T]] = new ApplicativeRing[T, Try]
+  implicit def tryField[T: Field]: Field[Try[T]] = new ApplicativeField[T, Try]
 }

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
@@ -54,10 +54,10 @@ class AsyncListSumProperties extends PropSpec with PropertyChecks with Matchers 
 
   property("CompactingList Summing with and without the summer should match") {
     forAll { (inputs: List[List[(Int, Long)]],
-              flushFrequency: FlushFrequency,
-              bufferSize: BufferSize,
-              memoryFlushPercent: MemoryFlushPercent,
-              compactionSize: CompactionSize) =>
+      flushFrequency: FlushFrequency,
+      bufferSize: BufferSize,
+      memoryFlushPercent: MemoryFlushPercent,
+      compactionSize: CompactionSize) =>
       val timeOutCounter = Counter("timeOut")
       val sizeCounter = Counter("size")
       val memoryCounter = Counter("memory")


### PR DESCRIPTION
Cleaning up MonadSemigroup and friends, which always just used Applicative, but we didn't have that type class then.