### PR TITLE
CMSItems

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -472,7 +472,17 @@ case class CMSItems[K: Ordering](items: List[K], override val params: CMSParams[
     items.map{ item => other.frequency(item) }.reduce{ _ + _ }
 
   def toCMS: CMS[K] = if (items.size > CMSItems.MaxSize) toCMSInstance else this
-  def toCMSInstance: CMSInstance[K] = ???
+  def toCMSInstance: CMSInstance[K] = {
+    val vectors = params.hashes.map{ hash =>
+      items.foldLeft(Vector.fill[Long](width)(0L)){
+        case (vector, item) =>
+          val pos = hash(item)
+          vector.updated(pos, vector(pos) + 1L)
+      }
+    }
+
+    CMSInstance(CMSInstance.CountsTable[K](vectors.toVector), items.size, params)
+  }
 }
 
 object CMSItems {

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -21,25 +21,25 @@ class CmsLaws extends PropSpec with PropertyChecks with Matchers {
   }
 
   property("CountMinSketch[Short] is a Monoid") {
-    implicit val cmsMonoid = CMS.monoid[Short](EPS, DELTA, SEED)
+    implicit val cmsMonoid = new CMSMonoid[Short](EPS, DELTA, SEED, 0)
     implicit val cmsGen = createArbitrary[Short](cmsMonoid)
     monoidLaws[CMS[Short]]
   }
 
   property("CountMinSketch[Int] is a Monoid") {
-    implicit val cmsMonoid = CMS.monoid[Int](EPS, DELTA, SEED)
+    implicit val cmsMonoid = new CMSMonoid[Int](EPS, DELTA, SEED, 0)
     implicit val cmsGen = createArbitrary[Int](cmsMonoid)
     monoidLaws[CMS[Int]]
   }
 
   property("CountMinSketch[Long] is a Monoid") {
-    implicit val cmsMonoid = CMS.monoid[Long](EPS, DELTA, SEED)
+    implicit val cmsMonoid = new CMSMonoid[Long](EPS, DELTA, SEED, 0)
     implicit val cmsGen = createArbitrary[Long](cmsMonoid)
     monoidLaws[CMS[Long]]
   }
 
   property("CountMinSketch[BigInt] is a Monoid") {
-    implicit val cmsMonoid = CMS.monoid[BigInt](EPS, DELTA, SEED)
+    implicit val cmsMonoid = new CMSMonoid[BigInt](EPS, DELTA, SEED, 0)
     implicit val cmsGen = createArbitrary[BigInt](cmsMonoid)
     monoidLaws[CMS[BigInt]]
   }

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
@@ -54,10 +54,10 @@ class AsyncListSumProperties extends PropSpec with PropertyChecks with Matchers 
 
   property("CompactingList Summing with and without the summer should match") {
     forAll { (inputs: List[List[(Int, Long)]],
-      flushFrequency: FlushFrequency,
-      bufferSize: BufferSize,
-      memoryFlushPercent: MemoryFlushPercent,
-      compactionSize: CompactionSize) =>
+              flushFrequency: FlushFrequency,
+              bufferSize: BufferSize,
+              memoryFlushPercent: MemoryFlushPercent,
+              compactionSize: CompactionSize) =>
       val timeOutCounter = Counter("timeOut")
       val sizeCounter = Counter("size")
       val memoryCounter = Counter("memory")

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
@@ -54,10 +54,10 @@ class AsyncListSumProperties extends PropSpec with PropertyChecks with Matchers 
 
   property("CompactingList Summing with and without the summer should match") {
     forAll { (inputs: List[List[(Int, Long)]],
-              flushFrequency: FlushFrequency,
-              bufferSize: BufferSize,
-              memoryFlushPercent: MemoryFlushPercent,
-              compactionSize: CompactionSize) =>
+      flushFrequency: FlushFrequency,
+      bufferSize: BufferSize,
+      memoryFlushPercent: MemoryFlushPercent,
+      compactionSize: CompactionSize) =>
       val timeOutCounter = Counter("timeOut")
       val sizeCounter = Counter("size")
       val memoryCounter = Counter("memory")


### PR DESCRIPTION
Adds a `CMSItems[K]` implementation of `CMS[K]` which, like `CMSItem[K]`, is exact, but for a small set of keys instead of just one.

You can add `CMSItem` and `CMSItem` or `CMSItems` and `CMSItems` and get a `CMSItems`. At a certain threshold (currently set to 100 items), this will transition to a `CMSInstance[K]`.

I haven't updated the TopN or TopPct variants, just the basic CMS.

I have a specific need for this, but it seems like a generally useful optimization. It could *probably* entirely replace `CMSItem` but I wouldn't want to do that without benchmarking first, which I have not done.

Thoughts @johnynek @miguno?