### PR TITLE
add averageFrom to DecayedValue

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/DecayedValue.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/DecayedValue.scala
@@ -73,4 +73,19 @@ case class DecayedValue(value: Double, scaledTime: Double) extends Ordered[Decay
     val normalization = halfLife / math.log(2)
     value / normalization
   }
+
+  /*
+  * Moving average assuming the signal started at zero a fixed point in the past.
+  * This normalizes by the integral of exp(-t(ln(2))/halflife) from 0 to (endTime - startTime).
+  */
+  def averageFrom(halfLife: Double, startTime: Double, endTime: Double) = {
+    if(endTime > startTime) {
+      val asOfEndTime = DecayedValue.scale(DecayedValue.build(0, endTime, halfLife), this, 0.0)
+      val timeDelta = startTime - endTime
+      val normalization = halfLife * (1 - math.pow(2, timeDelta / halfLife)) / math.log(2)
+      asOfEndTime.value / normalization
+    } else {
+      0.0
+    }
+  }
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/DecayedValue.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/DecayedValue.scala
@@ -79,7 +79,7 @@ case class DecayedValue(value: Double, scaledTime: Double) extends Ordered[Decay
   * This normalizes by the integral of exp(-t(ln(2))/halflife) from 0 to (endTime - startTime).
   */
   def averageFrom(halfLife: Double, startTime: Double, endTime: Double) = {
-    if(endTime > startTime) {
+    if (endTime > startTime) {
       val asOfEndTime = DecayedValue.scale(DecayedValue.build(0, endTime, halfLife), this, 0.0)
       val timeDelta = startTime - endTime
       val normalization = halfLife * (1 - math.pow(2, timeDelta / halfLife)) / math.log(2)
@@ -87,5 +87,16 @@ case class DecayedValue(value: Double, scaledTime: Double) extends Ordered[Decay
     } else {
       0.0
     }
+  }
+
+  /*
+  * Moving average assuming a discrete view of time - in other words,
+  * where the halfLife is a small multiple of the resolution of the timestamps.
+  * Works best when the timestamp resolution is 1.0
+  */
+
+  def discreteAverage(halfLife: Double) = {
+    val normalization = 1.0 - math.pow(2, -1.0 / halfLife)
+    value * normalization
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/DecayedValueTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/DecayedValueTest.scala
@@ -14,22 +14,27 @@ class DecayedValueLaws extends PropSpec with PropertyChecks with Matchers {
 
   def averageApproxEq(fn: (DecayedValue, Params) => Double)(implicit p: Arbitrary[Params]) = {
     forAll{ (params: Params) =>
-      val data = (0 to params.count).map{ t => DecayedValue.build(params.mean, t, params.halfLife) }
+      val rand = new scala.util.Random
+      val data = (0 to params.count).map{ t =>
+        val noise = rand.nextDouble * params.maxNoise * rand.nextInt.signum
+        DecayedValue.build(params.mean + (params.mean * noise), t, params.halfLife)
+      }
       val result = decayedMonoid.sum(data)
       assert(approxEq(fn(result, params), params.mean))
     }
   }
 
   implicit val decayedMonoid = DecayedValue.monoidWithEpsilon(0.001)
-  case class Params(mean: Double, halfLife: Double, count: Int)
+  case class Params(mean: Double, halfLife: Double, count: Int, maxNoise: Double)
 
   property("for large HL and count, average(f(t)=x)=x") {
     implicit val params: Arbitrary[Params] = Arbitrary{
       for (
         x <- choose(-1e100, 1e100);
         hl <- choose(100.0, 1000.0);
-        c <- choose(10000, 100000)
-      ) yield Params(x, hl, c)
+        c <- choose(10000, 100000);
+        n <- choose(0.0, 0.2)
+      ) yield Params(x, hl, c, n)
     }
 
     averageApproxEq{ (dv, params) => dv.average(params.halfLife) }
@@ -40,8 +45,9 @@ class DecayedValueLaws extends PropSpec with PropertyChecks with Matchers {
       for (
         x <- choose(-1e100, 1e100);
         hl <- choose(100.0, 1000.0);
-        c <- choose(20, 1000)
-      ) yield Params(x, hl, c)
+        c <- choose(20, 1000);
+        n <- choose(0.0, 0.2)
+      ) yield Params(x, hl, c, n)
     }
 
     averageApproxEq{ (dv, params) => dv.averageFrom(params.halfLife, 0, params.count) }
@@ -52,8 +58,9 @@ class DecayedValueLaws extends PropSpec with PropertyChecks with Matchers {
       for (
         x <- choose(-1e100, 1e100);
         hl <- choose(1.0, 10.0);
-        c <- choose(10000, 100000)
-      ) yield Params(x, hl, c)
+        c <- choose(10000, 100000);
+        n <- choose(0.0, 0.2)
+      ) yield Params(x, hl, c, n)
     }
 
     averageApproxEq{ (dv, params) => dv.discreteAverage(params.halfLife) }

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
@@ -54,10 +54,10 @@ class AsyncListSumProperties extends PropSpec with PropertyChecks with Matchers 
 
   property("CompactingList Summing with and without the summer should match") {
     forAll { (inputs: List[List[(Int, Long)]],
-              flushFrequency: FlushFrequency,
-              bufferSize: BufferSize,
-              memoryFlushPercent: MemoryFlushPercent,
-              compactionSize: CompactionSize) =>
+      flushFrequency: FlushFrequency,
+      bufferSize: BufferSize,
+      memoryFlushPercent: MemoryFlushPercent,
+      compactionSize: CompactionSize) =>
       val timeOutCounter = Counter("timeOut")
       val sizeCounter = Counter("size")
       val memoryCounter = Counter("memory")


### PR DESCRIPTION
DecayedValue's `average` method is useful but it gives artificially low results if the counter is only a small number of half lives old. `averageFrom` accounts for the fact that you might have a fixed bound in the past for your oldest value.

It currently requires passing an explicit endTime. I'm not sure if it's worth having a version which derives the endTime from the scaledTime (or possibly *only* having that version, and maybe adding a separate `asOf` method which can be used in conjunction... this seems better than having `valueAsOf` on the monoid, anyway).