### PR TITLE
GH-392: Improve hashing of BigInt

### DIFF
--- a/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/CMSHashingBenchmark.scala
+++ b/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/CMSHashingBenchmark.scala
@@ -60,9 +60,9 @@ class CMSHashingBenchmark extends SimpleBenchmark {
   private def murmurHashScala(a: Int, b: Int, width: Int)(x: BigInt) = {
     val hash: Int = scala.util.hashing.MurmurHash3.arrayHash(x.toByteArray, a)
     val h = {
-      // We only want positive integers for the subsequent modulo.  This method mimics Java's Hashtable implementation,
-      // and it requires `hash` to be an `Int` = have 32 bits (to match with `0x7FFFFFFF`).
-      val positiveHash = hash & 0x7FFFFFFF
+      // We only want positive integers for the subsequent modulo.  This method mimics Java's Hashtable
+      // implementation.  The Java code uses `0x7FFFFFFF` for the bit-wise AND, which is equal to Int.MaxValue.
+      val positiveHash = hash & Int.MaxValue
       positiveHash % width
     }
     assert(h >= 0, "hash must not be negative")

--- a/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/CMSHashingBenchmark.scala
+++ b/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/CMSHashingBenchmark.scala
@@ -1,0 +1,98 @@
+package com.twitter.algebird.caliper
+
+import com.google.caliper.{Param, SimpleBenchmark}
+
+/**
+ * Benchmarks the hashing algorithms used by Count-Min sketch for CMS[BigInt].
+ *
+ * The input values are generated ahead of time to ensure that each trial uses the same input (and that the RNG is not
+ * influencing the runtime of the trials).
+ */
+// Once we can convince cappi (https://github.com/softprops/capp) -- the sbt plugin we use to run
+// caliper benchmarks -- to work with the latest caliper 1.0-beta-1, we would:
+//     - Let `CMSHashingBenchmark` extend `Benchmark` (instead of `SimpleBenchmark`)
+//     - Annotate `timePlus` with `@MacroBenchmark`.
+class CMSHashingBenchmark extends SimpleBenchmark {
+
+  /**
+   * The `a` parameter for CMS' default ("legacy") hashing algorithm: `h_i(x) = a_i * x + b_i (mod p)`.
+   */
+  @Param(Array("5123456"))
+  val a: Int = 0
+
+  /**
+   * The `b` parameter for CMS' default ("legacy") hashing algorithm: `h_i(x) = a_i * x + b_i (mod p)`.
+   *
+   * Algebird's CMS implementation hard-codes `b` to `0`.
+   */
+  @Param(Array("0"))
+  val b: Int = 0
+
+  /**
+   * Width of the counting table.
+   */
+  @Param(Array("11" /* eps = 0.271 */ , "544" /* eps = 0.005 */ , "2719" /* eps = 1E-3 */ , "271829" /* eps = 1E-5 */))
+  val width: Int = 0
+
+  /**
+   * Number of operations per benchmark repetition.
+   */
+  @Param(Array("100000"))
+  val operations: Int = 0
+
+  /**
+   * Maximum number of bits for randomly generated BigInt instances.
+   */
+  @Param(Array("128", "1024", "2048"))
+  val maxBits: Int = 0
+
+  var random: scala.util.Random = _
+  var inputs: Seq[BigInt] = _
+
+  override def setUp() {
+    random = new scala.util.Random
+    // We draw numbers randomly from a 2^maxBits address space.
+    inputs = (1 to operations).view.map { _ => scala.math.BigInt(maxBits, random)}
+  }
+
+  private def murmurHashScala(a: Int, b: Int, width: Int)(x: BigInt) = {
+    val hash: Int = scala.util.hashing.MurmurHash3.arrayHash(x.toByteArray, a)
+    val h = {
+      // We only want positive integers for the subsequent modulo.  This method mimics Java's Hashtable implementation,
+      // and it requires `hash` to be an `Int` = have 32 bits (to match with `0x7FFFFFFF`).
+      val positiveHash = hash & 0x7FFFFFFF
+      positiveHash % width
+    }
+    assert(h >= 0, "hash must not be negative")
+    h
+  }
+
+  private val PRIME_MODULUS = (1L << 31) - 1
+
+  private def brokenCurrentHash(a: Int, b: Int, width: Int)(x: BigInt) = {
+    val unModded: BigInt = (x * a) + b
+    val modded: BigInt = (unModded + (unModded >> 32)) & PRIME_MODULUS
+    val h = modded.toInt % width
+    assert(h >= 0, "hash must not be negative")
+    h
+  }
+
+  def timeBrokenCurrentHashWithRandomMaxBitsNumbers(operations: Int): Int = {
+    var dummy = 0
+    while (dummy < operations) {
+      inputs.foreach { input => brokenCurrentHash(a, b, width)(input)}
+      dummy += 1
+    }
+    dummy
+  }
+
+  def timeMurmurHashScalaWithRandomMaxBitsNumbers(operations: Int): Int = {
+    var dummy = 0
+    while (dummy < operations) {
+      inputs.foreach { input => murmurHashScala(a, b, width)(input)}
+      dummy += 1
+    }
+    dummy
+  }
+
+}

--- a/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/CMSHashingBenchmark.scala
+++ b/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/CMSHashingBenchmark.scala
@@ -7,6 +7,8 @@ import com.google.caliper.{Param, SimpleBenchmark}
  *
  * The input values are generated ahead of time to ensure that each trial uses the same input (and that the RNG is not
  * influencing the runtime of the trials).
+ *
+ * More details available at https://github.com/twitter/algebird/issues/392.
  */
 // Once we can convince cappi (https://github.com/softprops/capp) -- the sbt plugin we use to run
 // caliper benchmarks -- to work with the latest caliper 1.0-beta-1, we would:

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -479,7 +479,7 @@ case class CMSInstance[K: Ordering](countsTable: CMSInstance.CountsTable[K],
    * Let X be a CMS, and let count_X[j, k] denote the value in X's 2-dimensional count table at row j and column k.
    * Then the Count-Min sketch estimate of the inner product between A and B is the minimum inner product between their
    * rows:
-   * estimatedInnerProduct = min_j (\sum_k count_A[j, k] * count_B[j, k])
+   * estimatedInnerProduct = min_j (\sum_k count_A[j, k] * count_B[j, k]|)
    */
   def innerProduct(other: CMS[K]): Approximate[Long] = {
     other match {

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -1055,7 +1055,7 @@ object CMSHasherImplicits {
 
   implicit object CMSHasherLong extends CMSHasher[Long] {
 
-    override def hash(a: Int, b: Int, width: Int)(x: Long) = {
+    override def hash(a: Int, b: Int, width: Int)(x: Long): Int = {
       val unModded: Long = (x * a) + b
       // Apparently a super fast way of computing x mod 2^p-1
       // See page 149 of http://www.cs.princeton.edu/courses/archive/fall09/cos521/Handouts/universalclasses.pdf
@@ -1069,13 +1069,13 @@ object CMSHasherImplicits {
 
   implicit object CMSHasherShort extends CMSHasher[Short] {
 
-    override def hash(a: Int, b: Int, width: Int)(x: Short) = CMSHasherInt.hash(a, b, width)(x)
+    override def hash(a: Int, b: Int, width: Int)(x: Short): Int = CMSHasherInt.hash(a, b, width)(x)
 
   }
 
   implicit object CMSHasherInt extends CMSHasher[Int] {
 
-    override def hash(a: Int, b: Int, width: Int)(x: Int) = {
+    override def hash(a: Int, b: Int, width: Int)(x: Int): Int = {
       val unModded: Int = (x * a) + b
       val modded: Long = (unModded + (unModded >> 32)) & PRIME_MODULUS
       val h = modded.toInt % width
@@ -1112,7 +1112,7 @@ object CMSHasherImplicits {
      * @param x Item to be hashed.
      * @return Slot assigned to item `x` in the vector of size `width`, where `x in [0, width)`.
      */
-    override def hash(a: Int, b: Int, width: Int)(x: BigInt) = {
+    override def hash(a: Int, b: Int, width: Int)(x: BigInt): Int = {
       val hash: Int = scala.util.hashing.MurmurHash3.arrayHash(x.toByteArray, a)
       val h = {
         // We only want positive integers for the subsequent modulo.  This method mimics Java's Hashtable

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -1078,9 +1078,7 @@ object CMSHasherImplicits {
     override def hash(a: Int, b: Int, width: Int)(x: Int): Int = {
       val unModded: Int = (x * a) + b
       val modded: Long = (unModded + (unModded >> 32)) & PRIME_MODULUS
-      val h = modded.toInt % width
-      assert(h >= 0, "hash must not be negative")
-      h
+      modded.toInt % width
     }
 
   }
@@ -1114,14 +1112,10 @@ object CMSHasherImplicits {
      */
     override def hash(a: Int, b: Int, width: Int)(x: BigInt): Int = {
       val hash: Int = scala.util.hashing.MurmurHash3.arrayHash(x.toByteArray, a)
-      val h = {
-        // We only want positive integers for the subsequent modulo.  This method mimics Java's Hashtable
-        // implementation.  The Java code uses `0x7FFFFFFF` for the bit-wise AND, which is equal to Int.MaxValue.
-        val positiveHash = hash & Int.MaxValue
-        positiveHash % width
-      }
-      assert(h >= 0, "hash must not be negative")
-      h
+      // We only want positive integers for the subsequent modulo.  This method mimics Java's Hashtable
+      // implementation.  The Java code uses `0x7FFFFFFF` for the bit-wise AND, which is equal to Int.MaxValue.
+      val positiveHash = hash & Int.MaxValue
+      positiveHash % width
     }
 
   }

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -491,7 +491,8 @@ case class CMSInstance[K: Ordering](countsTable: CMSInstance.CountsTable[K],
         }.sum
 
         val est = (0 to (depth - 1)).iterator.map { innerProductAtDepth }.min
-        Approximate(est - (eps * totalCount * other.totalCount).toLong, est, est, 1 - delta)
+        val minimum = math.max(est - (eps * totalCount * other.totalCount).toLong, 0)
+        Approximate(minimum, est, est, 1 - delta)
       case _ => other.innerProduct(this)
     }
   }

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -1030,7 +1030,7 @@ case class TopNCMSAggregator[K](cmsMonoid: TopNCMSMonoid[K])
  */
 trait CMSHasher[K] extends java.io.Serializable {
 
-  val PRIME_MODULUS = (1L << 31) - 1
+  val PRIME_MODULUS = Int.MaxValue
 
   /**
    * Returns `a * x + b (mod p) (mod width)`.

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -201,7 +201,7 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
       val data1 = (0 to (totalCount - 1)).map { _ => RAND.nextInt(range) }.toK[K]
       val data2 = (0 to (totalCount - 1)).map { _ => RAND.nextInt(range) }.toK[K]
       val cms1 = COUNTING_CMS_MONOID.create(data1)
-      val cms2 = COUNTING_CMS_MONOID.create(data1)
+      val cms2 = COUNTING_CMS_MONOID.create(data2)
 
       val approxA = cms1.innerProduct(cms2)
       val approx = approxA.estimate

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -213,7 +213,7 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
       val totalCounts = Gen.choose(1, 10000)
       val ranges = Gen.choose(100, 2000)
 
-      forAll(totalCounts, ranges) { (totalCount: Int, range: Int) =>
+      forAll((totalCounts, "totalCount"), (ranges, "range"), minSuccessful(50)) { (totalCount: Int, range: Int) =>
         val data1 = createRandomStream(totalCount, range)
         val data2 = createRandomStream(totalCount, range)
         val cms1 = COUNTING_CMS_MONOID.create(data1)

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.algebird
 
 import org.scalatest.{ PropSpec, Matchers, WordSpec }
-import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
+import org.scalatest.prop.{ GeneratorDrivenPropertyChecks, PropertyChecks }
 import org.scalacheck.{ Gen, Arbitrary }
 
 import CMSHasherImplicits._
@@ -284,27 +284,27 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
   "A Top-% Count-Min sketch implementing CMSHeavyHitters" should {
 
     "create correct sketches out of a single item" in {
-      forAll{ (x: Int, y: Int) =>
-        whenever (x != y) {
-          val data = x.toK[K]
-          val cmsMonoid = {
-            val anyHeavyHittersPct = 0.1 // exact setting not relevant for this test
-            TopPctCMS.monoid[K](EPS, DELTA, SEED, anyHeavyHittersPct)
-          }
-          val topCms = cmsMonoid.create(data)
-          topCms.totalCount should be(1)
-          topCms.cms.totalCount should be(1)
-          topCms.frequency(x.toK[K]).estimate should be(1)
-          topCms.frequency(y.toK[K]).estimate should be(0)
-          // The following assert indirectly verifies whether the counting table is not all-zero (cf. GH-393).
-          topCms.innerProduct(topCms).estimate should be(1)
+      forAll{ (x: Int) =>
+        val data = x.toK[K]
+        val cmsMonoid = {
+          val anyHeavyHittersPct = 0.1 // exact setting not relevant for this test
+          TopPctCMS.monoid[K](EPS, DELTA, SEED, anyHeavyHittersPct)
         }
+        val topCms = cmsMonoid.create(data)
+        topCms.totalCount should be(1)
+        topCms.cms.totalCount should be(1)
+        topCms.frequency(x.toK[K]).estimate should be(1)
+        // Poor man's way to come up with an item that is not x and that is very unlikely to hash to the same slot.
+        val otherItem = x + 1
+        topCms.frequency(otherItem.toK[K]).estimate should be(0)
+        // The following assert indirectly verifies whether the counting table is not all-zero (cf. GH-393).
+        topCms.innerProduct(topCms).estimate should be(1)
       }
     }
 
     "create correct sketches out of a single-item stream" in {
       forAll{ (x: Int, y: Int) =>
-        whenever (x != y) {
+        forAll{ (x: Int) =>
           val data = Seq(x).toK[K]
           val cmsMonoid = {
             val anyHeavyHittersPct = 0.1 // exact setting not relevant for this test
@@ -314,7 +314,9 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
           topCms.totalCount should be(1)
           topCms.cms.totalCount should be(1)
           topCms.frequency(x.toK[K]).estimate should be(1)
-          topCms.frequency(y.toK[K]).estimate should be(0)
+          // Poor man's way to come up with an item that is not x and that is very unlikely to hash to the same slot.
+          val otherItem = x + 1
+          topCms.frequency(otherItem.toK[K]).estimate should be(0)
           // The following assert indirectly verifies whether the counting table is not all-zero (cf. GH-393).
           topCms.innerProduct(topCms).estimate should be(1)
         }
@@ -455,27 +457,27 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
     // operation.
 
     "create correct sketches out of a single item" in {
-      forAll{ (x: Int, y: Int) =>
-        whenever (x != y) {
-          val data = x.toK[K]
-          val cmsMonoid = {
-            val anyHeavyHittersN = 2 // exact setting not relevant for this test
-            TopNCMS.monoid[K](EPS, DELTA, SEED, anyHeavyHittersN)
-          }
-          val topCms = cmsMonoid.create(data)
-          topCms.totalCount should be(1)
-          topCms.cms.totalCount should be(1)
-          topCms.frequency(x.toK[K]).estimate should be(1)
-          topCms.frequency(y.toK[K]).estimate should be(0)
-          // The following assert indirectly verifies whether the counting table is not all-zero (cf. GH-393).
-          topCms.innerProduct(topCms).estimate should be(1)
+      forAll{ (x: Int) =>
+        val data = x.toK[K]
+        val cmsMonoid = {
+          val anyHeavyHittersN = 2 // exact setting not relevant for this test
+          TopNCMS.monoid[K](EPS, DELTA, SEED, anyHeavyHittersN)
         }
+        val topCms = cmsMonoid.create(data)
+        topCms.totalCount should be(1)
+        topCms.cms.totalCount should be(1)
+        topCms.frequency(x.toK[K]).estimate should be(1)
+        // Poor man's way to come up with an item that is not x and that is very unlikely to hash to the same slot.
+        val otherItem = x + 1
+        topCms.frequency(otherItem.toK[K]).estimate should be(0)
+        // The following assert indirectly verifies whether the counting table is not all-zero (cf. GH-393).
+        topCms.innerProduct(topCms).estimate should be(1)
       }
     }
 
     "create correct sketches out of a single-item stream" in {
       forAll{ (x: Int, y: Int) =>
-        whenever (x != y) {
+        forAll{ (x: Int) =>
           val data = Seq(x).toK[K]
           val cmsMonoid = {
             val anyHeavyHittersN = 2 // exact setting not relevant for this test
@@ -485,7 +487,9 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
           topCms.totalCount should be(1)
           topCms.cms.totalCount should be(1)
           topCms.frequency(x.toK[K]).estimate should be(1)
-          topCms.frequency(y.toK[K]).estimate should be(0)
+          // Poor man's way to come up with an item that is not x and that is very unlikely to hash to the same slot.
+          val otherItem = x + 1
+          topCms.frequency(otherItem.toK[K]).estimate should be(0)
           // The following assert indirectly verifies whether the counting table is not all-zero (cf. GH-393).
           topCms.innerProduct(topCms).estimate should be(1)
         }
@@ -729,11 +733,10 @@ class CMSParamsSpec extends PropSpec with PropertyChecks with Matchers {
 
 }
 
-
 class CMSHasherShortSpec extends CMSHasherSpec[Short]
 class CMSHasherIntSpec extends CMSHasherSpec[Int]
-class CMSHasherLongSpec  extends CMSHasherSpec[Long]
-class CMSHasherBigIntSpec  extends CMSHasherSpec[BigInt]
+class CMSHasherLongSpec extends CMSHasherSpec[Long]
+class CMSHasherBigIntSpec extends CMSHasherSpec[BigInt]
 
 abstract class CMSHasherSpec[K: CMSHasher: Numeric] extends PropSpec with PropertyChecks with Matchers {
 
@@ -741,15 +744,14 @@ abstract class CMSHasherSpec[K: CMSHasher: Numeric] extends PropSpec with Proper
 
   property("returns positive hashes (i.e. slots) only") {
     forAll { (a: Int, b: Int, width: Int, x: Int) =>
-        whenever (width > 0) {
-          val hash = CMSHash[K](a, b, width)
-          hash(x.toK[K]) should be >= 0
-        }
+      whenever (width > 0) {
+        val hash = CMSHash[K](a, b, width)
+        hash(x.toK[K]) should be >= 0
+      }
     }
   }
 
 }
-
 
 /**
  * This spec verifies that we provide legacy types for the CMS and CountMinSketchMonoid classes we had in Algebird

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -138,7 +138,7 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
     val counts1 = data1.groupBy(x => x).mapValues(_.size)
     val counts2 = data2.groupBy(x => x).mapValues(_.size)
 
-    (counts1.keys.toSet & counts2.keys.toSet).map { k => counts1(k) * counts2(k) }.sum
+    (counts1.keys.toSet & counts2.keys.toSet).toSeq.map { k => counts1(k) * counts2(k) }.sum
   }
 
   /**

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -303,24 +303,22 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
     }
 
     "create correct sketches out of a single-item stream" in {
-      forAll{ (x: Int, y: Int) =>
-        forAll{ (x: Int) =>
-          val data = Seq(x).toK[K]
-          val cmsMonoid = {
-            val anyHeavyHittersPct = 0.1 // exact setting not relevant for this test
-            TopPctCMS.monoid[K](EPS, DELTA, SEED, anyHeavyHittersPct)
-          }
-          val topCms = cmsMonoid.create(data)
-          topCms.totalCount should be(1)
-          topCms.cms.totalCount should be(1)
-          topCms.frequency(x.toK[K]).estimate should be(1)
-          // Poor man's way to come up with an item that is not x and that is very unlikely to hash to the same slot.
-          val otherItem = x + 1
-          topCms.frequency(otherItem.toK[K]).estimate should be(0)
-          // The following assert indirectly verifies whether the counting table is not all-zero (cf. GH-393).
-          topCms.innerProduct(topCms).estimate should be(1)
+      forAll{ (x: Int) =>
+        val data = Seq(x).toK[K]
+        val cmsMonoid = {
+          val anyHeavyHittersPct = 0.1 // exact setting not relevant for this test
+          TopPctCMS.monoid[K](EPS, DELTA, SEED, anyHeavyHittersPct)
         }
-      }
+        val topCms = cmsMonoid.create(data)
+        topCms.totalCount should be(1)
+        topCms.cms.totalCount should be(1)
+        topCms.frequency(x.toK[K]).estimate should be(1)
+        // Poor man's way to come up with an item that is not x and that is very unlikely to hash to the same slot.
+        val otherItem = x + 1
+        topCms.frequency(otherItem.toK[K]).estimate should be(0)
+        // The following assert indirectly verifies whether the counting table is not all-zero (cf. GH-393).
+        topCms.innerProduct(topCms).estimate should be(1)
+    }
     }
 
     "estimate heavy hitters" in {
@@ -476,23 +474,21 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
     }
 
     "create correct sketches out of a single-item stream" in {
-      forAll{ (x: Int, y: Int) =>
-        forAll{ (x: Int) =>
-          val data = Seq(x).toK[K]
-          val cmsMonoid = {
-            val anyHeavyHittersN = 2 // exact setting not relevant for this test
-            TopNCMS.monoid[K](EPS, DELTA, SEED, anyHeavyHittersN)
-          }
-          val topCms = cmsMonoid.create(data)
-          topCms.totalCount should be(1)
-          topCms.cms.totalCount should be(1)
-          topCms.frequency(x.toK[K]).estimate should be(1)
-          // Poor man's way to come up with an item that is not x and that is very unlikely to hash to the same slot.
-          val otherItem = x + 1
-          topCms.frequency(otherItem.toK[K]).estimate should be(0)
-          // The following assert indirectly verifies whether the counting table is not all-zero (cf. GH-393).
-          topCms.innerProduct(topCms).estimate should be(1)
+      forAll{ (x: Int) =>
+        val data = Seq(x).toK[K]
+        val cmsMonoid = {
+          val anyHeavyHittersN = 2 // exact setting not relevant for this test
+          TopNCMS.monoid[K](EPS, DELTA, SEED, anyHeavyHittersN)
         }
+        val topCms = cmsMonoid.create(data)
+        topCms.totalCount should be(1)
+        topCms.cms.totalCount should be(1)
+        topCms.frequency(x.toK[K]).estimate should be(1)
+        // Poor man's way to come up with an item that is not x and that is very unlikely to hash to the same slot.
+        val otherItem = x + 1
+        topCms.frequency(otherItem.toK[K]).estimate should be(0)
+        // The following assert indirectly verifies whether the counting table is not all-zero (cf. GH-393).
+        topCms.innerProduct(topCms).estimate should be(1)
       }
     }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -194,7 +194,11 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
 
     "exactly compute frequencies in a small stream" in {
       val one = COUNTING_CMS_MONOID.create(1.toK[K])
+      one.frequency(1.toK[K]).estimate should be(1)
+      one.frequency(2.toK[K]).estimate should be(0)
       val two = COUNTING_CMS_MONOID.create(2.toK[K])
+      two.frequency(1.toK[K]).estimate should be(0)
+      two.frequency(2.toK[K]).estimate should be(1)
       val cms = COUNTING_CMS_MONOID.plus(COUNTING_CMS_MONOID.plus(one, two), two)
 
       cms.frequency(0.toK[K]).estimate should be(0)

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -230,6 +230,9 @@ abstract class CMSTest[K: Ordering: CMSHasher: Numeric] extends WordSpec with Ma
         val maxError = approx - approxA.min
         val beWithinTolerance = be >= 0L and be <= maxError
 
+        // We do not support negative counts, hence the lower limit of a frequency is 0 but never negative.
+        approxA.min should be >= 0L
+
         approx should be(cms2.innerProduct(cms1).estimate)
         approx should be >= exact
         estimationError should beWithinTolerance


### PR DESCRIPTION
This PR addresses the issue described in #392.

In addition, this PR includes several CMS code fixes as well as CMS test/spec fixes that I described at #393.  The reason these fixes are included in the PR is that the hashing improvements for BigInt exposed these code bugs / test bugs, and excluding those fixes would have meant that we end up with non-working code.

On a high-level, the hashing improvement for `CMS[BigInt]` covers (cf. #392):

- We now use Murmur3-based hashing for `BigInt` instead of the "default" hashing implementation we use for `Long` and friends.  See #392 for the justification of using Murmur3 and for why this change in general is important for `BigInt` use cases.

On a high-level, the additional fixes cover (cf. #393):

- Fixes to how we estimate inner products of CMS.
- Fixes and improvements (we use ScalaCheck now) to how we test the estimation of inner products.
- Fix to ensure `TopCMSItem` instances (which represent a single item with count 1) are created with a correct counting table.  The previous code was buggy and resulted in miscomputation of inner products.