### PR TITLE
GH-388: Fix CMS test issue caused by roundtripping depth->delta->depth

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -572,7 +572,7 @@ class CMSFunctionsSpec extends PropSpec with PropertyChecks with Matchers {
     // For all i > 709 this test break because of precision limits:  For all i > 709 will return 0.0, which is not the
     // mathematically correct value but rather the asymptote of delta.
     val maxI = 709
-    forAll(Gen.choose(0, maxI)) { (i: Int) =>
+    forAll((Gen.choose(1, maxI), "depth")) { (i: Int) =>
       CMSFunctions.depth(CMSFunctions.delta(i)) should be(i)
     }
   }


### PR DESCRIPTION
This 1-character change (essentially) should fix the problem described at #388 . :-)