### PR TITLE
Preparer

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
@@ -1,0 +1,37 @@
+package com.twitter.algebird
+
+case class Preparer[A, T](prepareFn: A => T) {
+  def map[U](fn: T => U) =
+    Preparer[A, U](fn.compose(prepareFn))
+
+  def flatMap[U](fn: T => TraversableOnce[U]) =
+    FlatPreparer[A, U](fn.compose(prepareFn))
+
+  def aggregate[B, C](aggregator: Aggregator[T, B, C]): Aggregator[A, B, C] =
+    aggregator.composePrepare(prepareFn)
+
+  def split[B1, B2, C1, C2](fn: Preparer[A, T] => (Aggregator[A, B1, C1], Aggregator[A, B2, C2])): Aggregator[A, (B1, B2), (C1, C2)] = {
+    val (a1, a2) = fn(this)
+    a1.join(a2)
+  }
+}
+
+object Preparer {
+  def apply[A]: Preparer[A, A] = Preparer[A, A](identity)
+}
+
+case class FlatPreparer[A, T](prepareFn: A => TraversableOnce[T]) {
+  def map[U](fn: T => U): FlatPreparer[A, U] =
+    FlatPreparer { a: A => prepareFn(a).map(fn) }
+
+  def flatMap[U](fn: T => TraversableOnce[U]): FlatPreparer[A, U] =
+    FlatPreparer { a: A => prepareFn(a).flatMap(fn) }
+
+  def aggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C] =
+    aggregator.sumBefore.composePrepare(prepareFn)
+
+  def split[B1, B2, C1, C2](fn: FlatPreparer[A, T] => (Aggregator[A, B1, C1], Aggregator[A, B2, C2])): Aggregator[A, (B1, B2), (C1, C2)] = {
+    val (a1, a2) = fn(this)
+    a1.join(a2)
+  }
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
@@ -1,62 +1,80 @@
 package com.twitter.algebird
 
-trait Preparer[A, T, +This[A, T] <: Preparer[A, T, This]] extends HasMonoidAggregate[A, T] {
+/**
+ * Preparer is a way to build up an Aggregator through composition using a
+ * more natural API: it allows you to start with the input type and describe a series
+ * of transformations and aggregations from there, rather than starting from the aggregation
+ * and composing "outwards" in both directions.
+ *
+ * Uses of Preparer will always start with a call to Preparer[A], and end with a call to
+ * monoidAggregate or a related method, to produce an Aggregator instance.
+ *
+ * This simple trait is just there to make it easier to write enrichments.
+ * Most of the interesting stuff is in BasePreparer (but that has a more complicated type signature).
+ */
+sealed trait Preparer[A, T] {
+  /**
+   * Produce a new MonoidAggregator which includes the Preparer's transformation chain in its prepare stage.
+   */
+  def monoidAggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C]
+}
+
+object Preparer {
+  /**
+   * This is the expected entry point for creating a new Preparer.
+   */
+  def apply[A] = MapPreparer.identity[A]
+}
+
+/**
+ * The two sub-types of Preparer, MapPreparer and FlatMapPreparer, both descend from this.
+ * It uses F-bounded polymorphism to provide precise types for the return value of map
+ * and the input values in split.
+ */
+trait BasePreparer[A, T, +This[A, T] <: BasePreparer[A, T, This]]
+  extends Preparer[A, T] {
+  /**
+   * Produce a new Preparer of the same type that chains this additional transformation.
+   */
   def map[U](fn: T => U): This[A, U]
 
+  /**
+   * Produce a new Preparer that chains this one-to-many transformation.
+   * Because "many" could include "none", this limits future aggregations
+   * to those done using monoids.
+   */
   def flatMap[U](fn: T => TraversableOnce[U]): FlatMapPreparer[A, U]
 
+  /**
+   * Like flatMap using identity.
+   */
   def flatten[U](implicit ev: <:<[T, TraversableOnce[U]]) = flatMap(ev)
 
+  /**
+   * Filter out values that do not meet the predicate.
+   * Like flatMap, this limits future aggregations to MonoidAggregator.
+   */
   def filter(fn: T => Boolean) = flatMap{ t => if (fn(t)) Some(t) else None }
 
-  //really ought to generate N versions of this...
+  /**
+   * Split the processing into two parallel aggregations.
+   * You provide a function which produces two different aggregators from this preparer,
+   * and it will return a single aggregator which does both aggregations in parallel.
+   * (See also Aggregator's join method.)
+   *
+   * Note: this currently produces an Aggregator which executes all of the prepare transformations
+   * twice, which is not ideal.
+   * Also, we really need to generate N versions of this for 3-way, 4-way etc splits.
+   */
   def split[B1, B2, C1, C2](fn: This[A, T] => (Aggregator[A, B1, C1], Aggregator[A, B2, C2])): Aggregator[A, (B1, B2), (C1, C2)] = {
     val (a1, a2) = fn(this.asInstanceOf[This[A, T]])
     a1.join(a2)
   }
-}
 
-object Preparer {
-  def apply[A] = MapPreparer[A, A](identity)
-}
-
-case class MapPreparer[A, T](prepareFn: A => T)
-  extends Preparer[A, T, MapPreparer]
-  with HasAggregate[A, T] {
-
-  def map[U](fn: T => U) =
-    MapPreparer[A, U](fn.compose(prepareFn))
-
-  def flatMap[U](fn: T => TraversableOnce[U]) =
-    FlatMapPreparer[A, U](fn.compose(prepareFn))
-
-  def aggregate[B, C](aggregator: Aggregator[T, B, C]): Aggregator[A, B, C] =
-    aggregator.composePrepare(prepareFn)
-
-  def monoidAggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C] =
-    aggregator.composePrepare(prepareFn)
-}
-
-case class FlatMapPreparer[A, T](prepareFn: A => TraversableOnce[T])
-  extends Preparer[A, T, FlatMapPreparer]
-  with HasLift[A, T] {
-  def map[U](fn: T => U) =
-    FlatMapPreparer { a: A => prepareFn(a).map(fn) }
-
-  def flatMap[U](fn: T => TraversableOnce[U]) =
-    FlatMapPreparer { a: A => prepareFn(a).flatMap(fn) }
-
-  def monoidAggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C] =
-    aggregator.sumBefore.composePrepare(prepareFn)
-
-  //alias for convenience
-  def aggregate[B, C](aggregator: MonoidAggregator[T, B, C]) = monoidAggregate(aggregator)
-
-  def sum(implicit monoid: Monoid[T]) = monoidAggregate(Aggregator.fromMonoid(monoid))
-}
-
-trait HasMonoidAggregate[A, T] {
-  def monoidAggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C]
+  /**
+   * count and following methods all just call monoidAggregate with one of the standard Aggregators.
+   * see the Aggregator object for more docs.
+   */
 
   def count(pred: T => Boolean) = monoidAggregate(Aggregator.count(pred))
   def exists(pred: T => Boolean) = monoidAggregate(Aggregator.exists(pred))
@@ -74,8 +92,34 @@ trait HasMonoidAggregate[A, T] {
   def uniqueCount = monoidAggregate(Aggregator.uniqueCount)
 }
 
-trait HasAggregate[A, T] {
-  def aggregate[B, C](aggregator: Aggregator[T, B, C]): Aggregator[A, B, C]
+/**
+ * A Preparer that has had zero or more map transformations applied, but no flatMaps.
+ * This can produce any type of Aggregator.
+ */
+trait MapPreparer[A, T]
+  extends BasePreparer[A, T, MapPreparer] {
+
+  def prepareFn: A => T
+
+  def map[U](fn: T => U) =
+    MapPreparer[A, U](fn.compose(prepareFn))
+
+  def flatMap[U](fn: T => TraversableOnce[U]) =
+    FlatMapPreparer[A, U](fn.compose(prepareFn))
+
+  def monoidAggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C] =
+    aggregator.composePrepare(prepareFn)
+
+  /**
+   * Produce a new Aggregator which includes the Preparer's transformation chain in its prepare stage.
+   */
+  def aggregate[B, C](aggregator: Aggregator[T, B, C]): Aggregator[A, B, C] =
+    aggregator.composePrepare(prepareFn)
+
+  /**
+   * head and following methods all just call aggregate with one of the standard Aggregators.
+   * see the Aggregator object for more docs.
+   */
 
   def head = aggregate(Aggregator.head)
   def last = aggregate(Aggregator.last)
@@ -95,10 +139,62 @@ trait HasAggregate[A, T] {
   def reduce(fn: (T, T) => T) = aggregate(Aggregator.fromReduce(fn))
 }
 
-trait HasLift[A, T] extends HasMonoidAggregate[A, T] {
+object MapPreparer {
+  /**
+   * Create a concrete MapPreparer.
+   */
+  def apply[A, T](fn: A => T) = new MapPreparer[A, T] { val prepareFn = fn }
+
+  /**
+   * This is purely an optimization for the case of mapping by identity.
+   * It overrides the key methods to not actually use the identity function.
+   */
+  def identity[A] = new MapPreparer[A, A] {
+    val prepareFn = (a: A) => a
+    override def map[U](fn: A => U) = MapPreparer(fn)
+    override def flatMap[U](fn: A => TraversableOnce[U]) = FlatMapPreparer(fn)
+    override def monoidAggregate[B, C](aggregator: MonoidAggregator[A, B, C]) = aggregator
+    override def aggregate[B, C](aggregator: Aggregator[A, B, C]) = aggregator
+  }
+}
+
+/**
+ * A Preparer that has had one or more flatMap operations applied.
+ * It can only accept MonoidAggregators.
+ */
+case class FlatMapPreparer[A, T](prepareFn: A => TraversableOnce[T])
+  extends BasePreparer[A, T, FlatMapPreparer] {
+  def map[U](fn: T => U) =
+    FlatMapPreparer { a: A => prepareFn(a).map(fn) }
+
+  def flatMap[U](fn: T => TraversableOnce[U]) =
+    FlatMapPreparer { a: A => prepareFn(a).flatMap(fn) }
+
+  def monoidAggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C] =
+    aggregator.sumBefore.composePrepare(prepareFn)
+
+  /**
+   * alias of monoidAggregate for convenience
+   * unlike MapPreparer's aggregate, can only take MonoidAggregator
+   */
+  def aggregate[B, C](aggregator: MonoidAggregator[T, B, C]) = monoidAggregate(aggregator)
+
+  /**
+   * Like monoidAggregate, but using an implicit Monoid to construct the Aggregator
+   */
+  def sum(implicit monoid: Monoid[T]) = monoidAggregate(Aggregator.fromMonoid(monoid))
+
+  /**
+   * transform a given Aggregator into a MonoidAggregator by lifting the reduce and present stages
+   * into Option space
+   */
   def lift[B, C](aggregator: Aggregator[T, B, C]): MonoidAggregator[A, Option[B], Option[C]] =
     monoidAggregate(aggregator.lift)
 
+  /**
+   * headOption and following methods are all just calling lift with standard Aggregators
+   * see the Aggregator object for more docs
+   */
   def headOption = lift(Aggregator.head)
   def lastOption = lift(Aggregator.last)
   def maxOption(implicit ord: Ordering[T]) = lift(Aggregator.max)
@@ -117,17 +213,23 @@ trait HasLift[A, T] extends HasMonoidAggregate[A, T] {
   def reduceOption(fn: (T, T) => T) = lift(Aggregator.fromReduce(fn))
 }
 
-//implementing unzip as an enrichment because it seems to help with type inference
-//ideally we'd generate N versions of this, too
-//and figure out how to make it work with FlatMapPreparer
+/**
+ * This should really be a method on MapPreparer but it needs to be implemented as an enrichment to help the type inference.
+ */
 case class Unzipper[A, U, V](preparer: MapPreparer[A, (U, V)]) {
+  /**
+   * given a chain of transformations that ends in a Tuple2, aggregate each element of the tuple separately,
+   * and return a single Aggregator that will ultimately produce a tuple of aggregations.
+   */
   def unzip[B1, B2, C1, C2](fn: (MapPreparer[U, U], MapPreparer[V, V]) => (Aggregator[U, B1, C1], Aggregator[V, B2, C2])) = {
     val (a1, a2) = fn(Preparer[U], Preparer[V])
     preparer.aggregate(a1.zip(a2))
   }
 }
 
-//for some reason this implicit doesn't get picked up automatically?
+/*
+* implicit for Unzipper. For some reason this isn't getting found without an explicit import.
+*/
 object Unzipper {
   implicit def unzipper[A, U, V](preparer: MapPreparer[A, (U, V)]): Unzipper[A, U, V] = Unzipper(preparer)
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
@@ -3,7 +3,7 @@ package com.twitter.algebird
 trait Preparer[A, T, +This[A, T] <: Preparer[A, T, This]] extends HasMonoidAggregate[A, T] {
   def map[U](fn: T => U): This[A, U]
 
-  def flatMap[U](fn: T => TraversableOnce[U]): FlatPreparer[A, U]
+  def flatMap[U](fn: T => TraversableOnce[U]): FlatMapPreparer[A, U]
 
   //really ought to generate N versions of this...
   def split[B1, B2, C1, C2](fn: This[A, T] => (Aggregator[A, B1, C1], Aggregator[A, B2, C2])): Aggregator[A, (B1, B2), (C1, C2)] = {
@@ -13,18 +13,18 @@ trait Preparer[A, T, +This[A, T] <: Preparer[A, T, This]] extends HasMonoidAggre
 }
 
 object Preparer {
-  def apply[A]: SimplePreparer[A, A] = SimplePreparer[A, A](identity)
+  def apply[A] = MapPreparer[A, A](identity)
 }
 
-case class SimplePreparer[A, T](prepareFn: A => T)
-  extends Preparer[A, T, SimplePreparer]
+case class MapPreparer[A, T](prepareFn: A => T)
+  extends Preparer[A, T, MapPreparer]
   with HasAggregate[A, T] {
 
   def map[U](fn: T => U) =
-    SimplePreparer[A, U](fn.compose(prepareFn))
+    MapPreparer[A, U](fn.compose(prepareFn))
 
   def flatMap[U](fn: T => TraversableOnce[U]) =
-    FlatPreparer[A, U](fn.compose(prepareFn))
+    FlatMapPreparer[A, U](fn.compose(prepareFn))
 
   def aggregate[B, C](aggregator: Aggregator[T, B, C]): Aggregator[A, B, C] =
     aggregator.composePrepare(prepareFn)
@@ -33,14 +33,14 @@ case class SimplePreparer[A, T](prepareFn: A => T)
     aggregator.composePrepare(prepareFn)
 }
 
-case class FlatPreparer[A, T](prepareFn: A => TraversableOnce[T])
-  extends Preparer[A, T, FlatPreparer]
+case class FlatMapPreparer[A, T](prepareFn: A => TraversableOnce[T])
+  extends Preparer[A, T, FlatMapPreparer]
   with HasLift[A, T] {
   def map[U](fn: T => U) =
-    FlatPreparer { a: A => prepareFn(a).map(fn) }
+    FlatMapPreparer { a: A => prepareFn(a).map(fn) }
 
   def flatMap[U](fn: T => TraversableOnce[U]) =
-    FlatPreparer { a: A => prepareFn(a).flatMap(fn) }
+    FlatMapPreparer { a: A => prepareFn(a).flatMap(fn) }
 
   def monoidAggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C] =
     aggregator.sumBefore.composePrepare(prepareFn)

--- a/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
@@ -7,6 +7,8 @@ trait Preparer[A, T, +This[A, T] <: Preparer[A, T, This]] extends HasMonoidAggre
 
   def flatten[U](implicit ev: <:<[T, TraversableOnce[U]]) = flatMap(ev)
 
+  def filter(fn: T => Boolean) = flatMap{ t => if (fn(t)) Some(t) else None }
+
   //really ought to generate N versions of this...
   def split[B1, B2, C1, C2](fn: This[A, T] => (Aggregator[A, B1, C1], Aggregator[A, B2, C2])): Aggregator[A, (B1, B2), (C1, C2)] = {
     val (a1, a2) = fn(this.asInstanceOf[This[A, T]])

--- a/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
@@ -1,8 +1,27 @@
 package com.twitter.algebird
 
-case class Preparer[A, T](prepareFn: A => T) {
+trait Preparer[A, T, +This[A, T] <: Preparer[A, T, This]] extends HasMonoidAggregate[A, T] {
+  def map[U](fn: T => U): This[A, U]
+
+  def flatMap[U](fn: T => TraversableOnce[U]): FlatPreparer[A, U]
+
+  //really ought to generate N versions of this...
+  def split[B1, B2, C1, C2](fn: This[A, T] => (Aggregator[A, B1, C1], Aggregator[A, B2, C2])): Aggregator[A, (B1, B2), (C1, C2)] = {
+    val (a1, a2) = fn(this.asInstanceOf[This[A, T]])
+    a1.join(a2)
+  }
+}
+
+object Preparer {
+  def apply[A]: SimplePreparer[A, A] = SimplePreparer[A, A](identity)
+}
+
+case class SimplePreparer[A, T](prepareFn: A => T)
+  extends Preparer[A, T, SimplePreparer]
+  with HasAggregate[A, T] {
+
   def map[U](fn: T => U) =
-    Preparer[A, U](fn.compose(prepareFn))
+    SimplePreparer[A, U](fn.compose(prepareFn))
 
   def flatMap[U](fn: T => TraversableOnce[U]) =
     FlatPreparer[A, U](fn.compose(prepareFn))
@@ -10,28 +29,78 @@ case class Preparer[A, T](prepareFn: A => T) {
   def aggregate[B, C](aggregator: Aggregator[T, B, C]): Aggregator[A, B, C] =
     aggregator.composePrepare(prepareFn)
 
-  def split[B1, B2, C1, C2](fn: Preparer[A, T] => (Aggregator[A, B1, C1], Aggregator[A, B2, C2])): Aggregator[A, (B1, B2), (C1, C2)] = {
-    val (a1, a2) = fn(this)
-    a1.join(a2)
+  def monoidAggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C] =
+    aggregator.composePrepare(prepareFn)
+}
+
+case class FlatPreparer[A, T](prepareFn: A => TraversableOnce[T])
+  extends Preparer[A, T, FlatPreparer]
+  with HasLift[A, T] {
+  def map[U](fn: T => U) =
+    FlatPreparer { a: A => prepareFn(a).map(fn) }
+
+  def flatMap[U](fn: T => TraversableOnce[U]) =
+    FlatPreparer { a: A => prepareFn(a).flatMap(fn) }
+
+  def monoidAggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C] =
+    aggregator.sumBefore.composePrepare(prepareFn)
+
+  //alias for convenience
+  def aggregate[B, C](aggregator: MonoidAggregator[T, B, C]) = monoidAggregate(aggregator)
+}
+
+trait HasMonoidAggregate[A, T] {
+  def monoidAggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C]
+
+  def count(pred: T => Boolean) = monoidAggregate(Aggregator.count(pred))
+  def exists(pred: T => Boolean) = monoidAggregate(Aggregator.exists(pred))
+  def forall(pred: T => Boolean) = monoidAggregate(Aggregator.forall(pred))
+  def size = monoidAggregate(Aggregator.size)
+
+  def sortedTake(count: Int)(implicit ord: Ordering[T]) =
+    monoidAggregate(Aggregator.sortedTake(count))
+
+  def sortedReverseTake(count: Int)(implicit ord: Ordering[T]) =
+    monoidAggregate(Aggregator.sortedReverseTake(count))
+
+  def toList = monoidAggregate(Aggregator.toList)
+  def toSet = monoidAggregate(Aggregator.toSet)
+  def uniqueCount = monoidAggregate(Aggregator.uniqueCount)
+}
+
+trait HasAggregate[A, T] {
+  def aggregate[B, C](aggregator: Aggregator[T, B, C]): Aggregator[A, B, C]
+
+  def head = aggregate(Aggregator.head)
+  def last = aggregate(Aggregator.last)
+  def max(implicit ord: Ordering[T]) = aggregate(Aggregator.max)
+  def maxBy[U: Ordering](fn: T => U) = {
+    implicit val ordT = Ordering.by(fn)
+    aggregate(Aggregator.max[T])
+  }
+
+  def min(implicit ord: Ordering[T]) = aggregate(Aggregator.min)
+  def minBy[U: Ordering](fn: T => U) = {
+    implicit val ordT = Ordering.by(fn)
+    aggregate(Aggregator.min[T])
   }
 }
 
-object Preparer {
-  def apply[A]: Preparer[A, A] = Preparer[A, A](identity)
-}
+trait HasLift[A, T] extends HasMonoidAggregate[A, T] {
+  def lift[B, C](aggregator: Aggregator[T, B, C]): MonoidAggregator[A, Option[B], Option[C]] =
+    monoidAggregate(aggregator.lift)
 
-case class FlatPreparer[A, T](prepareFn: A => TraversableOnce[T]) {
-  def map[U](fn: T => U): FlatPreparer[A, U] =
-    FlatPreparer { a: A => prepareFn(a).map(fn) }
+  def head = lift(Aggregator.head)
+  def last = lift(Aggregator.last)
+  def max(implicit ord: Ordering[T]) = lift(Aggregator.max)
+  def maxBy[U: Ordering](fn: T => U) = {
+    implicit val ordT = Ordering.by(fn)
+    lift(Aggregator.max[T])
+  }
 
-  def flatMap[U](fn: T => TraversableOnce[U]): FlatPreparer[A, U] =
-    FlatPreparer { a: A => prepareFn(a).flatMap(fn) }
-
-  def aggregate[B, C](aggregator: MonoidAggregator[T, B, C]): MonoidAggregator[A, B, C] =
-    aggregator.sumBefore.composePrepare(prepareFn)
-
-  def split[B1, B2, C1, C2](fn: FlatPreparer[A, T] => (Aggregator[A, B1, C1], Aggregator[A, B2, C2])): Aggregator[A, (B1, B2), (C1, C2)] = {
-    val (a1, a2) = fn(this)
-    a1.join(a2)
+  def min(implicit ord: Ordering[T]) = lift(Aggregator.min)
+  def minBy[U: Ordering](fn: T => U) = {
+    implicit val ordT = Ordering.by(fn)
+    lift(Aggregator.min[T])
   }
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
@@ -5,6 +5,8 @@ trait Preparer[A, T, +This[A, T] <: Preparer[A, T, This]] extends HasMonoidAggre
 
   def flatMap[U](fn: T => TraversableOnce[U]): FlatMapPreparer[A, U]
 
+  def flatten[U](implicit ev: <:<[T, TraversableOnce[U]]) = flatMap(ev)
+
   //really ought to generate N versions of this...
   def split[B1, B2, C1, C2](fn: This[A, T] => (Aggregator[A, B1, C1], Aggregator[A, B2, C2])): Aggregator[A, (B1, B2), (C1, C2)] = {
     val (a1, a2) = fn(this.asInstanceOf[This[A, T]])

--- a/algebird-test/src/test/scala/com/twitter/algebird/PreparerLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/PreparerLaws.scala
@@ -1,0 +1,81 @@
+/*
+Copyright 2015 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird
+
+import org.scalacheck.Arbitrary
+import org.scalatest.{ PropSpec, Matchers }
+import org.scalatest.prop.PropertyChecks
+
+class PreparerLaws extends PropSpec with PropertyChecks with Matchers {
+  import BaseProperties._
+
+  implicit def aggregator[A, B, C](implicit prepare: Arbitrary[A => B], sg: Semigroup[B], present: Arbitrary[B => C]): Arbitrary[Aggregator[A, B, C]] = Arbitrary {
+    for {
+      pp <- prepare.arbitrary
+      ps <- present.arbitrary
+    } yield new Aggregator[A, B, C] {
+      def prepare(a: A) = pp(a)
+      def semigroup = sg
+      def present(b: B) = ps(b)
+    }
+  }
+
+  property("mapping before aggregate is correct") {
+    forAll { (in: List[Int], compose: (Int => Int), ag: Aggregator[Int, Int, Int]) =>
+      val composed = Preparer[Int].map(compose).aggregate(ag)
+      assert(in.isEmpty || composed(in) == ag(in.map(compose)))
+    }
+  }
+
+  property("split with two aggregators is correct") {
+    forAll { (in: List[Int], ag1: Aggregator[Int, Set[Int], Int], ag2: Aggregator[Int, Unit, String]) =>
+      val c = Preparer[Int].split{ p => (p.aggregate(ag1), p.aggregate(ag2)) }
+      assert(in.isEmpty || c(in) == (ag1(in), ag2(in)))
+    }
+  }
+
+  implicit def monoidAggregator[A, B, C](implicit prepare: Arbitrary[A => B], m: Monoid[B], present: Arbitrary[B => C]): Arbitrary[MonoidAggregator[A, B, C]] = Arbitrary {
+    for {
+      pp <- prepare.arbitrary
+      ps <- present.arbitrary
+    } yield new MonoidAggregator[A, B, C] {
+      def prepare(a: A) = pp(a)
+      def monoid = m
+      def present(b: B) = ps(b)
+    }
+  }
+
+  property("flatten before aggregate is correct") {
+    forAll{ (in: List[List[Int]], ag: MonoidAggregator[Int, Int, Int]) =>
+      val flattenedAg = Preparer[List[Int]].flatten.aggregate(ag)
+      assert(flattenedAg(in) == ag(in.flatten))
+    }
+  }
+
+  property("map, flatMap, and split all together are correct") {
+    forAll{ (in: List[Int], mapFn: (Int => Int), flatMapFn: (Int => List[Int]), ag1: MonoidAggregator[Int, Int, Int], ag2: MonoidAggregator[Int, Int, Int]) =>
+      val ag =
+        Preparer[Int]
+          .map(mapFn)
+          .flatMap(flatMapFn)
+          .split{ a => (a.aggregate(ag1), a.aggregate(ag2)) }
+
+      val preSplit = in.map(mapFn).flatMap(flatMapFn)
+      assert(in.isEmpty || ag(in) == (ag1(preSplit), ag2(preSplit)))
+    }
+  }
+}


### PR DESCRIPTION
This is a trait that makes it more convenient to produce complex compositions of Aggregators. For example, if you want to aggregate over a stream of values of type `List[Int]`, and produce both the total (flattened) sum and the largest individual item (if it exists, which it might not if all lists are empty), then with standard aggregators you would need:

````scala
Aggregator
   .fromMonoid[Int]
   .sumBefore
   .join(Aggregator.max.lift.sumBefore)
````

whereas with Preparer you would use:

````scala
 Preparer[List[Int]].flatten.split{p => (p.sum, p.maxOption)}
````
I propose that this is a lot easier to understand.

