### PR TITLE
Return a MonoidAggregator from MultiAggregator when possible

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/TupleAggregatorsTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/TupleAggregatorsTest.scala
@@ -225,5 +225,113 @@ class TupleAggregatorsTest extends WordSpec with Matchers {
       val agg: Aggregator[Int, Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int], Tuple22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]] = MultiAggregator(MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg, MinAgg)
       assert(agg(data) == Tuple22(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
     }
+
+    val longData = data.map{ _.toLong }
+    val MinMonoidAgg = Aggregator.size
+
+    "Create a MonoidAggregator from a tuple of 2 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple2[Long, Long], Tuple2[Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple2(6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 3 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple3[Long, Long, Long], Tuple3[Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple3(6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 4 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple4[Long, Long, Long, Long], Tuple4[Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple4(6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 5 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple5[Long, Long, Long, Long, Long], Tuple5[Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple5(6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 6 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple6[Long, Long, Long, Long, Long, Long], Tuple6[Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple6(6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 7 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple7[Long, Long, Long, Long, Long, Long, Long], Tuple7[Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple7(6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 8 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple8[Long, Long, Long, Long, Long, Long, Long, Long], Tuple8[Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple8(6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 9 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple9[Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple9[Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple9(6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 10 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple10[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple10[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple10(6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 11 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple11[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple11[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple11(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 12 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple12[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple12[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple12(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 13 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple13[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple13[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple13(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 14 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple14[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple14[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple14(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 15 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple15[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple15[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple15(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 16 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple16[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple16[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple16(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 17 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple17[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple17[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple17(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 18 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple18[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple18[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple18(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 19 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple19[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple19[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple19(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 20 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple20[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple20[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple20(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 21 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple21[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple21[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple21(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
+
+    "Create a MonoidAggregator from a tuple of 22 MonoidAggregators" in {
+      val agg: MonoidAggregator[Long, Tuple22[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long], Tuple22[Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long]] = MultiAggregator(MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg, MinMonoidAgg)
+      assert(agg(longData) == Tuple22(6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6))
+    }
   }
 }

--- a/project/GenTupleAggregators.scala
+++ b/project/GenTupleAggregators.scala
@@ -18,36 +18,40 @@ trait GeneratedTupleAggregator {
 """package com.twitter.algebird
 
 object MultiAggregator {
-""" + genMethods(22, "def", Some("apply")) + "\n" + "}")
+""" +
+      genMethods(22, "def", Some("apply")) + "\n" +
+      genMethods(22, "def", Some("apply"), true) + "\n" + "}")
 
     Seq(tupleAggPlace, multiAggPlace)
   }
 
-  def genMethods(max: Int, defStr: String, name: Option[String]): String = {
+  def genMethods(max: Int, defStr: String, name: Option[String], isMonoid: Boolean = false): String = {
     (2 to max).map(i => {
       val methodName = name.getOrElse("from%d".format(i))
+      val aggType = if (isMonoid) "Monoid" else ""
       val nums = (1 to i)
       val bs = nums.map("B" + _).mkString(", ")
       val cs = nums.map("C" + _).mkString(", ")
-      val aggs = nums.map(x => "Aggregator[A, B%s, C%s]".format(x, x)).mkString(", ")
+      val aggs = nums.map(x => "%sAggregator[A, B%s, C%s]".format(aggType, x, x)).mkString(", ")
       val prepares = nums.map(x => "aggs._%s.prepare(a)".format(x)).mkString(", ")
-      val semigroups = nums.map(x => "aggs._%s.semigroup".format(x)).mkString(", ")
-      val semigroup = "new Tuple%dSemigroup()(%s)".format(i, semigroups)
+      val semiType = if (isMonoid) "monoid" else "semigroup"
+      val semigroups = nums.map(x => "aggs._%s.%s".format(x, semiType)).mkString(", ")
+      val semigroup = "new Tuple%d%s()(%s)".format(i, semiType.capitalize, semigroups)
       val present = nums.map(x => "aggs._%s.present(b._%s)".format(x, x)).mkString(", ")
       val tupleBs = "Tuple%d[%s]".format(i, bs)
       val tupleCs = "Tuple%d[%s]".format(i, cs)
 
       """
-%s %s[A, %s, %s](aggs: Tuple%d[%s]): Aggregator[A, %s, %s] = {
-  new Aggregator[A, %s, %s] {
+%s %s[A, %s, %s](aggs: Tuple%d[%s]): %sAggregator[A, %s, %s] = {
+  new %sAggregator[A, %s, %s] {
     def prepare(a: A) = (%s)
-    val semigroup = %s
+    val %s = %s
     def present(b: %s) = (%s)
   }
-}""".format(defStr, methodName, bs, cs, i, aggs, tupleBs, tupleCs,
-            tupleBs, tupleCs,
+}""".format(defStr, methodName, bs, cs, i, aggs, aggType, tupleBs, tupleCs,
+            aggType, tupleBs, tupleCs,
             prepares,
-            semigroup,
+            semiType, semigroup,
             tupleBs, present)
     }).mkString("\n")
   }


### PR DESCRIPTION
Given MonoidAggregators as input, return a MonoidAggregator
instead of just a plain old Aggregator.

cc @avibryant