### PR TITLE
Added function to safely downsize a HyperLogLog sketch

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -227,11 +227,27 @@ class HyperLogLogTest extends WordSpec with Matchers {
     "correctly downsize sparse HLL" in {
       testDownsize(10)(10, 7)
       testDownsize(10)(14, 4)
+      testDownsize(10)(12, 12)
+      
+      intercept[IllegalArgumentException] {
+        testDownsize(10)(9, 13)
+      }
+      intercept[IllegalArgumentException] {
+        testDownsize(10)(15, 3)
+      }
     }
 
     "correctly downsize dense HLL" in {
       testDownsize(10000)(10, 7)
       testDownsize(10000)(14, 4)
+      testDownsize(10000)(12, 12)
+
+      intercept[IllegalArgumentException] {
+        testDownsize(10000)(9, 13)
+      }
+      intercept[IllegalArgumentException] {
+        testDownsize(10000)(15, 3)
+      }
     }
 
     def verifySerialization(h: HLL) {

--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -112,6 +112,14 @@ class HyperLogLogTest extends WordSpec with Matchers {
     assert(scala.math.abs(exact - approxIntersect(bits, data)) / exact < errorMult *
       aveErrorOf(bits))
   }
+  def testDownsize(dataSize: Int)(oldBits: Int, newBits: Int) {
+    val data = (0 until dataSize).map { i => r.nextLong }
+    val exact = exactCount(data).toDouble
+    val hll = new HyperLogLogMonoid(oldBits)
+    val oldHll = hll.sum(data.map { hll(_) })
+    val newHll = oldHll.downsize(newBits)
+    assert(scala.math.abs(exact - newHll.estimatedSize) / exact < 3.5 * aveErrorOf(newBits))
+  }
 
   "HyperLogLog" should {
     "count with 5-bits" in {
@@ -214,6 +222,16 @@ class HyperLogLogTest extends WordSpec with Matchers {
         val estimate = aggregator(data.map(int2Bytes(_)))
         assert(scala.math.abs(exact - estimate) / exact < 3.5 * aveErrorOf(bits))
       })
+    }
+
+    "correctly downsize sparse HLL" in {
+      testDownsize(10)(10, 7)
+      testDownsize(10)(14, 4)
+    }
+
+    "correctly downsize dense HLL" in {
+      testDownsize(10000)(10, 7)
+      testDownsize(10000)(14, 4)
     }
 
     def verifySerialization(h: HLL) {


### PR DESCRIPTION
A new function called "downsize" to safely reduce the size of a HyperLogLog sketch. The error rate goes up correspondingly due to loss of information. Based on the ideas presented in: [Set Operations On HLLs of Different Sizes](http://research.neustar.biz/2012/09/12/set-operations-on-hlls-of-different-sizes/) and its follow-up [HyperLogLog Engineering: Choosing The Right Bits](http://research.neustar.biz/2013/03/25/hyperloglog-engineering-choosing-the-right-bits/).