### PR TITLE
fix property tests

### DIFF
--- a/algebird-bijection/src/test/scala/com/twitter/algebird/bijection/AlgebirdBijectionLaws.scala
+++ b/algebird-bijection/src/test/scala/com/twitter/algebird/bijection/AlgebirdBijectionLaws.scala
@@ -16,11 +16,9 @@
 
 package com.twitter.algebird.bijection
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Arbitrary, Properties }
+import com.twitter.algebird.CheckProperties
 
-class AlgebirdBijectionLaws extends PropSpec with PropertyChecks with Matchers {
+class AlgebirdBijectionLaws extends CheckProperties {
   // TODO: Fill in tests. Ideally we'd publish an algebird-testing
   // module before merging this in.
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/Monoid.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Monoid.scala
@@ -125,6 +125,10 @@ class SeqMonoid[T] extends Monoid[Seq[T]] {
  * zero is an empty array
  */
 class ArrayMonoid[T: ClassTag](implicit semi: Semigroup[T]) extends Monoid[Array[T]] {
+
+  //additive identity
+  override def isNonZero(v: Array[T]): Boolean = v.nonEmpty
+
   override def zero = Array[T]()
   override def plus(left: Array[T], right: Array[T]) = {
     val (longer, shorter) = if (left.length > right.length) (left, right) else (right, left)

--- a/algebird-core/src/main/scala/com/twitter/algebird/SummingCache.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SummingCache.scala
@@ -83,7 +83,7 @@ object SummingWithHitsCache {
 /**
  * A SummingCache that also tracks the number of key hits
  */
-class SummingWithHitsCache[K, V] (capacity: Int)(implicit sgv: Semigroup[V])
+class SummingWithHitsCache[K, V](capacity: Int)(implicit sgv: Semigroup[V])
   extends SummingCache[K, V](capacity)(sgv) {
 
   def putWithHits(m: Map[K, V]): (Int, Option[Map[K, V]]) = {

--- a/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
@@ -42,7 +42,7 @@ object BaseProperties {
   }
 
   def isAssociativeEq[T: Semigroup, U <: T: Arbitrary](eqfn: (T, T) => Boolean) = {
-    forAll { (a: U, b: U, c: U) =>
+    'isAssociativeEq |: forAll { (a: U, b: U, c: U) =>
       val semi = implicitly[Semigroup[T]]
       eqfn(semi.plus(a, semi.plus(b, c)), semi.plus(semi.plus(a, b), c))
     }
@@ -53,13 +53,13 @@ object BaseProperties {
 
   def isAssociative[T: Semigroup: Arbitrary] = isAssociativeDifferentTypes[T, T]
 
-  def semigroupSumWorks[T: Semigroup: Arbitrary: Equiv] = forAll { (in: List[T]) =>
+  def semigroupSumWorks[T: Semigroup: Arbitrary: Equiv] = 'semigroupSumWorks |: forAll { (in: List[T]) =>
     in.isEmpty || {
       Equiv[T].equiv(Semigroup.sumOption(in).get, in.reduceLeft(Semigroup.plus(_, _)))
     }
   }
 
-  def isCommutativeEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = forAll { (a: T, b: T) =>
+  def isCommutativeEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = 'isCommutativeEq |: forAll { (a: T, b: T) =>
     val semi = implicitly[Semigroup[T]]
     eqfn(semi.plus(a, b), semi.plus(b, a))
   }
@@ -82,18 +82,18 @@ object BaseProperties {
     isAssociativeEq[T, T](eqfn) && isCommutativeEq[T](eqfn)
   def commutativeSemigroupLaws[T: Semigroup: Arbitrary] = commutativeSemigroupLawsEq[T](defaultEq _)
 
-  def isNonZeroWorksMonoid[T: Monoid: Arbitrary: Equiv] = forAll { (a: T, b: T) =>
+  def isNonZeroWorksMonoid[T: Monoid: Arbitrary: Equiv] = 'isNonZeroWorksMonoid |: forAll { (a: T, b: T) =>
     val aIsLikeZero = Monoid.zeroEquiv[T].equiv(Monoid.plus(a, b), b)
     Monoid.isNonZero(a) || aIsLikeZero
   }
 
-  def isNonZeroWorksRing[T: Ring: Arbitrary] = forAll { (a: T, b: T) =>
+  def isNonZeroWorksRing[T: Ring: Arbitrary] = 'isNonZeroWorksRing |: forAll { (a: T, b: T) =>
     implicit val monT: Monoid[T] = implicitly[Ring[T]]
     val prodZero = !monT.isNonZero(Ring.times(a, b))
     (Monoid.isNonZero(a) && Monoid.isNonZero(b)) || prodZero
   }
 
-  def weakZeroDifferentTypes[T: Monoid, U <: T: Arbitrary] = forAll { (a: U) =>
+  def weakZeroDifferentTypes[T: Monoid, U <: T: Arbitrary] = 'weakZeroDifferentTypes |: forAll { (a: U) =>
     val mon = implicitly[Monoid[T]]
     val zero = mon.zero
     // Some types, e.g. Maps, are not totally equal for all inputs (i.e. zero values removed)
@@ -102,7 +102,7 @@ object BaseProperties {
 
   def weakZero[T: Monoid: Arbitrary] = weakZeroDifferentTypes[T, T]
 
-  def validZeroEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = forAll { (a: T) =>
+  def validZeroEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) = 'validZeroEq |: forAll { (a: T) =>
     val mon = implicitly[Monoid[T]]
     val zero = mon.zero
     eqfn(a, mon.plus(a, zero)) && eqfn(mon.plus(zero, a), a) && eqfn(mon.plus(a, zero), mon.plus(zero, a))
@@ -132,23 +132,24 @@ object BaseProperties {
 
   def groupLaws[T: Group: Arbitrary] = monoidLaws[T] && hasAdditiveInverses[T]
   // Here are multiplicative properties:
-  def validOne[T: Ring: Arbitrary] = forAll { (a: T) =>
+  def validOne[T: Ring: Arbitrary] = 'validOne |: forAll { (a: T) =>
     val rng = implicitly[Ring[T]]
     (rng.times(rng.one, a) == rng.times(a, rng.one)) && (a == rng.times(a, rng.one))
   }
-  def zeroAnnihilates[T: Ring: Arbitrary] = forAll { (a: T) =>
+  def zeroAnnihilates[T: Ring: Arbitrary] = 'zeroAnnihilates |: forAll { (a: T) =>
     val ring = implicitly[Ring[T]]
     (!ring.isNonZero(ring.times(a, ring.zero))) &&
       (!ring.isNonZero(ring.times(ring.zero, a)))
   }
-  def isDistributiveDifferentTypes[T: Ring, U <: T: Arbitrary] = forAll { (a: U, b: U, c: U) =>
-    val rng = implicitly[Ring[T]]
-    (rng.times(a, rng.plus(b, c)) == rng.plus(rng.times(a, b), rng.times(a, c))) &&
-      (rng.times(rng.plus(b, c), a) == rng.plus(rng.times(b, a), rng.times(c, a)))
-  }
+  def isDistributiveDifferentTypes[T: Ring, U <: T: Arbitrary] = 'isDistributiveDifferentTypes |:
+    forAll { (a: U, b: U, c: U) =>
+      val rng = implicitly[Ring[T]]
+      (rng.times(a, rng.plus(b, c)) == rng.plus(rng.times(a, b), rng.times(a, c))) &&
+        (rng.times(rng.plus(b, c), a) == rng.plus(rng.times(b, a), rng.times(c, a)))
+    }
   def isDistributive[T: Ring: Arbitrary] = isDistributiveDifferentTypes[T, T]
 
-  def timesIsAssociative[T: Ring: Arbitrary] = forAll { (a: T, b: T, c: T) =>
+  def timesIsAssociative[T: Ring: Arbitrary] = 'timesIsAssociative |: forAll { (a: T, b: T, c: T) =>
     val rng = implicitly[Ring[T]]
     rng.times(a, rng.times(b, c)) == rng.times(rng.times(a, b), c)
   }
@@ -164,7 +165,7 @@ object BaseProperties {
 
   def ringLaws[T: Ring: Arbitrary] = validOne[T] && pseudoRingLaws[T]
 
-  def hasMultiplicativeInverse[T: Field: Arbitrary] = forAll { (a: T) =>
+  def hasMultiplicativeInverse[T: Field: Arbitrary] = 'hasMultiplicativeInverse |: forAll { (a: T) =>
     val fld = implicitly[Field[T]]
     (!fld.isNonZero(a)) || {
       val inva = fld.inverse(a)

--- a/algebird-test/src/test/scala/com/twitter/algebird/AdJoinedUnitRing.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AdJoinedUnitRing.scala
@@ -17,11 +17,10 @@ limitations under the License.
 package com.twitter.algebird
 
 import org.scalacheck.Arbitrary
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import org.scalacheck.Prop._
 
-class AdjoinedRingSpecification extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class AdjoinedRingSpecification extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   implicit def adjoined[T: Arbitrary]: Arbitrary[AdjoinedUnit[T]] = Arbitrary {
     implicitly[Arbitrary[T]].arbitrary.map { t => AdjoinedUnit(t) }
@@ -29,7 +28,7 @@ class AdjoinedRingSpecification extends PropSpec with PropertyChecks with Matche
   // AdjoinedUnit requires this method to be correct, so it is tested here:
   property("intTimes works correctly") {
     forAll { (bi0: BigInt, bi1: BigInt) =>
-      assert(Group.intTimes(bi0, bi1) == (bi0 * bi1))
+      Group.intTimes(bi0, bi1) == (bi0 * bi1)
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/AggregationMonoids.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AggregationMonoids.scala
@@ -4,7 +4,7 @@ import org.scalacheck.{ Gen, Arbitrary }
 import org.scalatest.{ PropSpec, Matchers }
 import org.scalatest.prop.PropertyChecks
 
-class AggregationMonoidSpecification extends PropSpec with PropertyChecks with Matchers {
+class AggregationMonoidSpecification extends CheckProperties {
   import BaseProperties._
   import Gen.choose
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
@@ -17,11 +17,9 @@ limitations under the License.
 package com.twitter.algebird
 
 import org.scalacheck.Arbitrary
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import org.scalacheck.Prop._
 
-class AggregatorLaws extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class AggregatorLaws extends CheckProperties {
 
   implicit def aggregator[A, B, C](implicit prepare: Arbitrary[A => B], sg: Semigroup[B], present: Arbitrary[B => C]): Arbitrary[Aggregator[A, B, C]] = Arbitrary {
     for {
@@ -37,21 +35,21 @@ class AggregatorLaws extends PropSpec with PropertyChecks with Matchers {
   property("composing before Aggregator is correct") {
     forAll { (in: List[Int], compose: (Int => Int), ag: Aggregator[Int, Int, Int]) =>
       val composed = ag.composePrepare(compose)
-      assert(in.isEmpty || composed(in) == ag(in.map(compose)))
+      in.isEmpty || composed(in) == ag(in.map(compose))
     }
   }
 
   property("andThen after Aggregator is correct") {
     forAll { (in: List[Int], andt: (Int => Int), ag: Aggregator[Int, Int, Int]) =>
       val ag1 = ag.andThenPresent(andt)
-      assert(in.isEmpty || ag1(in) == andt(ag(in)))
+      in.isEmpty || ag1(in) == andt(ag(in))
     }
   }
 
   property("composing two Aggregators is correct") {
     forAll { (in: List[Int], ag1: Aggregator[Int, String, Int], ag2: Aggregator[Int, Int, String]) =>
       val c = GeneratedTupleAggregator.from2(ag1, ag2)
-      assert(in.isEmpty || c(in) == (ag1(in), ag2(in)))
+      in.isEmpty || c(in) == (ag1(in), ag2(in))
     }
   }
 
@@ -59,7 +57,7 @@ class AggregatorLaws extends PropSpec with PropertyChecks with Matchers {
     forAll { (in: List[Int], ag1: Aggregator[Int, Set[Int], Int], ag2: Aggregator[Int, Unit, String]) =>
       type AggInt[T] = Aggregator[Int, _, T]
       val c = Applicative.join[AggInt, Int, String](ag1, ag2)
-      assert(in.isEmpty || c(in) == (ag1(in), ag2(in)))
+      in.isEmpty || c(in) == (ag1(in), ag2(in))
     }
   }
 
@@ -67,14 +65,14 @@ class AggregatorLaws extends PropSpec with PropertyChecks with Matchers {
     forAll { (in: List[(Int, String)], ag1: Aggregator[Int, Int, Int], ag2: Aggregator[String, Set[String], Double]) =>
       val c = ag1.zip(ag2)
       val (as, bs) = in.unzip
-      assert(in.isEmpty || c(in) == (ag1(as), ag2(bs)))
+      in.isEmpty || c(in) == (ag1(as), ag2(bs))
     }
   }
 
   property("Aggregator.lift works for empty sequences") {
     forAll { (in: List[Int], ag: Aggregator[Int, Int, Int]) =>
       val liftedAg = ag.lift
-      assert(in.isEmpty && liftedAg(in) == None || liftedAg(in) == Some(ag(in)))
+      in.isEmpty && liftedAg(in) == None || liftedAg(in) == Some(ag(in))
     }
   }
 
@@ -92,18 +90,18 @@ class AggregatorLaws extends PropSpec with PropertyChecks with Matchers {
   property("MonoidAggregator.sumBefore is correct") {
     forAll{ (in: List[List[Int]], ag: MonoidAggregator[Int, Int, Int]) =>
       val liftedAg = ag.sumBefore
-      assert(liftedAg(in) == ag(in.flatten))
+      liftedAg(in) == ag(in.flatten)
     }
   }
 
   property("Aggregator.applyCumulatively is correct") {
     forAll{ (in: List[Int], ag: Aggregator[Int, Int, Int]) =>
       val cumulative: List[Int] = ag.applyCumulatively(in)
-      assert(cumulative.size == in.size)
-      assert(cumulative.zipWithIndex.forall{
-        case (sum, i) =>
-          sum == ag.apply(in.take(i + 1))
-      })
+      cumulative.size == in.size &&
+        cumulative.zipWithIndex.forall{
+          case (sum, i) =>
+            sum == ag.apply(in.take(i + 1))
+        }
     }
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/ApplicativeProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/ApplicativeProperties.scala
@@ -20,7 +20,7 @@ import org.scalatest.{ PropSpec, Matchers }
 import org.scalatest.prop.PropertyChecks
 import org.scalacheck.Properties
 
-class ApplicativeProperties extends PropSpec with PropertyChecks with Matchers {
+class ApplicativeProperties extends CheckProperties {
   import ApplicativeLaws._
   import Monad._ // for Monad instances
   import MonadLaws._ // for Arbitrary instances

--- a/algebird-test/src/test/scala/com/twitter/algebird/ApproximateTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/ApproximateTest.scala
@@ -1,18 +1,16 @@
 package com.twitter.algebird
 
-import org.scalatest.{ DiagrammedAssertions, WordSpec, PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.Arbitrary
-import org.scalacheck.Gen
-import org.scalacheck.Prop
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalatest.{ Matchers, WordSpec }
+import org.scalacheck.Prop._
 
 // TODO add tests for scala check that uses a statistical test to check
 // that an ApproximateBoolean agrees with the correct Boolean at least as often
 // as it is claimed to
 
-class ApproximateLaws extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
-  import Gen.choose
+class ApproximateLaws extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
+  import org.scalacheck.Gen.choose
 
   implicit val approxGen =
     Arbitrary {
@@ -30,11 +28,11 @@ class ApproximateLaws extends PropSpec with PropertyChecks with Matchers {
   property("always contain estimate") {
     forAll {
       (ap1: Approximate[Long], ap2: Approximate[Long]) =>
-        assert(((ap1 + ap2) ~ (ap1.estimate + ap2.estimate)) &&
+        ((ap1 + ap2) ~ (ap1.estimate + ap2.estimate)) &&
           ((ap1 * ap2) ~ (ap1.estimate * ap2.estimate)) &&
           ap1 ~ (ap1.estimate) &&
           ap2 ~ (ap2.estimate) &&
-          ((ap1 + (ap1.negate)) ~ 0L) && ((ap2 + (ap2.negate)) ~ 0L))
+          ((ap1 + (ap1.negate)) ~ 0L) && ((ap2 + (ap2.negate)) ~ 0L)
     }
   }
   def boundsAreOrdered[N](ap: Approximate[N]) = {
@@ -50,7 +48,7 @@ class ApproximateLaws extends PropSpec with PropertyChecks with Matchers {
         (ap1 * ap2).probWithinBounds <=
           Ordering[Double].min(ap1.probWithinBounds, ap2.probWithinBounds)
 
-        assert(boundsAreOrdered(ap1 * ap2) && boundsAreOrdered(ap1 + ap2))
+        boundsAreOrdered(ap1 * ap2) && boundsAreOrdered(ap1 + ap2)
     }
   }
 
@@ -63,30 +61,30 @@ class ApproximateLaws extends PropSpec with PropertyChecks with Matchers {
 
   property("Boolean: &&") {
     forAll { (a: ApproximateBoolean) =>
-      assert(((a && ApproximateBoolean.exact(false)) == ApproximateBoolean.exact(false)) &&
+      ((a && ApproximateBoolean.exact(false)) == ApproximateBoolean.exact(false)) &&
         // Make sure when it is false, we don't lose precision:
-        (a && ApproximateBoolean(false, a.withProb / 2.0)).withProb >= (a.withProb / 2.0))
+        (a && ApproximateBoolean(false, a.withProb / 2.0)).withProb >= (a.withProb / 2.0)
     }
   }
 
   property("Boolean: ||") {
     forAll { (a: ApproximateBoolean) =>
-      assert((a || ApproximateBoolean.exact(true)) == ApproximateBoolean.exact(true) &&
+      (a || ApproximateBoolean.exact(true)) == ApproximateBoolean.exact(true) &&
         // Make sure when it is true, we don't lose precision:
-        (a || ApproximateBoolean(true, a.withProb / 2.0)).withProb >= (a.withProb / 2.0))
+        (a || ApproximateBoolean(true, a.withProb / 2.0)).withProb >= (a.withProb / 2.0)
     }
   }
 
   property("logic works") {
     forAll { (a: ApproximateBoolean, b: ApproximateBoolean) =>
-      assert((a ^ b).isTrue == (a.isTrue ^ b.isTrue) &&
+      (a ^ b).isTrue == (a.isTrue ^ b.isTrue) &&
         (a ^ b).withProb >= (a.withProb * b.withProb) &&
         (a || b).isTrue == (a.isTrue || b.isTrue) &&
         (a || b).withProb >= (a.withProb * b.withProb) &&
         (a && b).isTrue == (a.isTrue && b.isTrue) &&
         (a && b).withProb >= (a.withProb * b.withProb) &&
         (a.not).isTrue == (!(a.isTrue)) &&
-        (a.not.withProb) == a.withProb)
+        (a.not.withProb) == a.withProb
     }
   }
 }
@@ -95,11 +93,10 @@ class ApproximateTest extends WordSpec with Matchers {
 
   "Approximate" should {
     "Correctly identify exact" in {
-      assert(Approximate.exact(1.0) ~ 1.0)
-      assert(Approximate.exact(1.0).boundsContain(1.0))
-
-      assert(!(Approximate.exact(1.0).boundsContain(1.1)))
-      assert(!(Approximate.exact(1.0) ~ 1.1))
+      (Approximate.exact(1.0) ~ 1.0) &&
+        Approximate.exact(1.0).boundsContain(1.0) &&
+        !Approximate.exact(1.0).boundsContain(1.1) &&
+        (!(Approximate.exact(1.0) ~ 1.1))
     }
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -1,12 +1,13 @@
 package com.twitter.algebird
 
-import org.scalatest.{ DiagrammedAssertions, WordSpec, PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
-import java.io.{ ObjectOutputStream, ByteArrayOutputStream }
+import java.io.{ ByteArrayOutputStream, ObjectOutputStream }
 
-class BloomFilterLaws extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalatest.{ Matchers, WordSpec }
+import org.scalacheck.Prop._
+
+class BloomFilterLaws extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   val NUM_HASHES = 6
   val WIDTH = 32
@@ -23,7 +24,7 @@ class BloomFilterLaws extends PropSpec with PropertyChecks with Matchers {
   }
 }
 
-class BFHashIndices extends PropSpec with PropertyChecks with Matchers {
+class BFHashIndices extends CheckProperties {
   val NUM_HASHES = 10
   val WIDTH = 4752800
 
@@ -39,8 +40,8 @@ class BFHashIndices extends PropSpec with PropertyChecks with Matchers {
 
   property("Indices are non negative") {
     forAll { (hash: BFHash, v: Long) =>
-      hash.apply(v.toString).foreach { e =>
-        assert(e >= 0)
+      hash.apply(v.toString).forall { e =>
+        e >= 0
       }
     }
   }
@@ -89,7 +90,7 @@ class BFHashIndices extends PropSpec with PropertyChecks with Matchers {
       val s = v.toString
       val (hash, negativeHash) = pair
       val indices = negativeHash.apply(s)
-      assert(indices == hash.apply(s) || indices.exists(_ < 0))
+      indices == hash.apply(s) || indices.exists(_ < 0)
     }
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/CheckProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CheckProperties.scala
@@ -1,0 +1,13 @@
+package com.twitter.algebird
+
+import org.scalatest.PropSpec
+import org.scalatest.prop.Checkers
+
+/**
+ * @author Mansur Ashraf.
+ */
+trait CheckProperties extends PropSpec with Checkers {
+
+  def property(testName: String, testTags: org.scalatest.Tag*)(testFun: org.scalacheck.Prop): Unit =
+    super.property(testName, testTags: _*) { check { testFun } }
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
@@ -96,7 +96,9 @@ class CollectionSpecification extends CheckProperties {
   }
 
   property("Array Monoid laws") {
-    monoidLaws[Array[Int]]
+    monoidLawsEq[Array[Int]]{
+      case (a,b) => a.deep == b.deep
+    }
   }
 
   property("Set plus") {

--- a/algebird-test/src/test/scala/com/twitter/algebird/CombinatorTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CombinatorTest.scala
@@ -16,24 +16,10 @@ limitations under the License.
 
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
 import org.scalacheck.Arbitrary
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.Properties
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.Gen.choose
-
-class CombinatorTest extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class CombinatorTest extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   implicit def minArb[T: Arbitrary]: Arbitrary[Min[T]] = Arbitrary {
     Arbitrary.arbitrary[T].map { t => Min(t) }

--- a/algebird-test/src/test/scala/com/twitter/algebird/DecayedValueTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/DecayedValueTest.scala
@@ -1,12 +1,10 @@
 package com.twitter.algebird
 
-import org.scalacheck.{ Gen, Arbitrary }
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.Prop._
 
-class DecayedValueLaws extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
-  import Gen.choose
+class DecayedValueLaws extends CheckProperties {
+  import org.scalacheck.Gen.choose
 
   def approxEq(f1: Double, f2: Double) = {
     (scala.math.abs(f1 - f2) / scala.math.abs(f2)) < 0.1
@@ -20,7 +18,7 @@ class DecayedValueLaws extends PropSpec with PropertyChecks with Matchers {
         DecayedValue.build(params.mean + (params.mean * noise), t, params.halfLife)
       }
       val result = decayedMonoid.sum(data)
-      assert(approxEq(fn(result, params), params.mean))
+      approxEq(fn(result, params), params.mean)
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/DecayedVectorProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/DecayedVectorProperties.scala
@@ -16,12 +16,10 @@ limitations under the License.
 
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
+import org.scalacheck.{ Arbitrary, Gen }
 
-class DecayedVectorProperties extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class DecayedVectorProperties extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   implicit val mpint: Arbitrary[DecayedVector[({ type x[a] = Map[Int, a] })#x]] = Arbitrary {
     for {

--- a/algebird-test/src/test/scala/com/twitter/algebird/EventuallyTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/EventuallyTest.scala
@@ -4,7 +4,7 @@ import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 import org.scalacheck.{ Gen, Arbitrary }
 
-class EventuallyRingLaws extends PropSpec with PropertyChecks with Matchers {
+class EventuallyRingLaws extends CheckProperties {
   import BaseProperties._
 
   val eventuallyRing = new EventuallyRing[Long, Int](_.asInstanceOf[Long])(_ > 10000)
@@ -18,7 +18,7 @@ class EventuallyRingLaws extends PropSpec with PropertyChecks with Matchers {
 }
 
 // A lossy one:
-class EventuallyMonoidLaws extends PropSpec with PropertyChecks with Matchers {
+class EventuallyMonoidLaws extends CheckProperties {
   import BaseProperties._
 
   val eventuallyMonoid = new EventuallyMonoid[Int, String](_.length)(_.length > 100)

--- a/algebird-test/src/test/scala/com/twitter/algebird/FunctionMonoidTests.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/FunctionMonoidTests.scala
@@ -1,11 +1,9 @@
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Prop, Arbitrary }
+import org.scalacheck.{ Arbitrary, Prop }
 
-class FunctionMonoidTests extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class FunctionMonoidTests extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   // Generates an arbitrary linear function of the form f(x) = a * x + b,
   // where a and b are arbitrary integers.

--- a/algebird-test/src/test/scala/com/twitter/algebird/FunctorProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/FunctorProperties.scala
@@ -16,14 +16,9 @@ limitations under the License.
 
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.Properties
-
-class FunctorProperties extends PropSpec with PropertyChecks with Matchers {
-  import FunctorLaws._
-  import Monad._ // for Monad instances
-  import MonadLaws._ // for Arbitrary instances
+class FunctorProperties extends CheckProperties {
+  import com.twitter.algebird.FunctorLaws._
+  import com.twitter.algebird.Monad._ // for Arbitrary instances
 
   property("list") {
     functorLaws[List, Int, String, Long]()

--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -35,7 +35,7 @@ object ReferenceHyperLogLog {
 
 }
 
-class HyperLogLogLaws extends PropSpec with PropertyChecks with Matchers {
+class HyperLogLogLaws extends CheckProperties {
   import BaseProperties._
   import HyperLogLog._
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/IntervalLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/IntervalLaws.scala
@@ -15,95 +15,92 @@ limitations under the License.
 */
 
 package com.twitter.algebird
+import org.scalacheck.Prop._
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.Prop
-
-class IntervalLaws extends PropSpec with PropertyChecks with Matchers {
-  import Generators._
-  import Interval.GenIntersection
+class IntervalLaws extends CheckProperties {
+  import com.twitter.algebird.Generators._
+  import com.twitter.algebird.Interval.GenIntersection
 
   property("[x, x + 1) contains x") {
     forAll { y: Int =>
       val x = y.asInstanceOf[Long]
-      assert(Interval.leftClosedRightOpen(x, x + 1).contains(x))
+      Interval.leftClosedRightOpen(x, x + 1).contains(x)
     }
   }
 
   property("(x, x + 1] contains x + 1") {
     forAll { y: Int =>
       val x = y.asInstanceOf[Long]
-      assert(Interval.leftOpenRightClosed(x, x + 1).contains(x + 1))
+      Interval.leftOpenRightClosed(x, x + 1).contains(x + 1)
     }
   }
 
   property("[x, x + 1) does not contain x + 1") {
     forAll { x: Int =>
-      assert(!Interval.leftClosedRightOpen(x, x + 1).contains(x + 1))
+      !Interval.leftClosedRightOpen(x, x + 1).contains(x + 1)
     }
   }
 
   property("(x, x + 1] does not contain x") {
     forAll { x: Int =>
-      assert(!Interval.leftOpenRightClosed(x, x + 1).contains(x))
+      !Interval.leftOpenRightClosed(x, x + 1).contains(x)
     }
   }
 
   property("[x, x) is empty") {
     forAll { x: Int =>
-      assert(Interval.leftClosedRightOpen(x, x).isLeft)
+      Interval.leftClosedRightOpen(x, x).isLeft
     }
   }
 
   property("(x, x] is empty") {
     forAll { x: Int =>
-      assert(Interval.leftOpenRightClosed(x, x).isLeft)
+      Interval.leftOpenRightClosed(x, x).isLeft
     }
   }
 
   property("If an intersection contains, both of the intervals contain") {
     forAll { (item: Long, i1: Interval[Long], i2: Interval[Long]) =>
-      assert((i1 && i2).contains(item) == (i1(item) && i2(item)))
+      (i1 && i2).contains(item) == (i1(item) && i2(item))
     }
   }
 
   property("If an interval is empty, contains is false") {
     forAll { (item: Long, intr: Interval[Long]) =>
       intr match {
-        case Empty() => assert(!intr.contains(item))
-        case _ => assert(true) // may be here
+        case Empty() => !intr.contains(item)
+        case _ => true // may be here
       }
     }
   }
 
   property("[n, inf) and (-inf, n] intersect") {
     forAll { (n: Long) =>
-      assert(InclusiveLower(n).intersects(InclusiveUpper(n)))
+      InclusiveLower(n).intersects(InclusiveUpper(n))
     }
   }
 
   property("(x, inf) and (-inf, y) intersects if and only if y > x") {
     forAll { (x: Long, y: Long) =>
-      assert((y > x) == (ExclusiveLower(x).intersects(ExclusiveUpper(y))))
+      ((y > x) == ExclusiveLower(x).intersects(ExclusiveUpper(y)))
     }
   }
 
   property("(x, inf) and (-inf, y] intersect if and only if y > x") {
     forAll { (x: Long, y: Long) =>
-      assert((y > x) == (ExclusiveLower(x).intersects(InclusiveUpper(y))))
+      ((y > x) == ExclusiveLower(x).intersects(InclusiveUpper(y)))
     }
   }
 
   property("[x, inf) and (-inf, y) intersect if and only if y > x") {
     forAll { (x: Long, y: Long) =>
-      assert((y > x) == (InclusiveLower(x).intersects(ExclusiveUpper(y))))
+      ((y > x) == InclusiveLower(x).intersects(ExclusiveUpper(y)))
     }
   }
 
   property("[x, inf) and (-inf, y] intersect if and only if y >= x") {
     forAll { (x: Long, y: Long) =>
-      assert((y >= x) == (InclusiveLower(x).intersects(InclusiveUpper(y))))
+      ((y >= x) == InclusiveLower(x).intersects(InclusiveUpper(y)))
     }
   }
 
@@ -116,7 +113,7 @@ class IntervalLaws extends PropSpec with PropertyChecks with Matchers {
           Equiv[Option[Long]].equiv(Some(lb), upper.strictUpperBound)
         }
       }.getOrElse(true) &&
-        ((low && upper) match {
+        (low && upper match {
           case Intersection(_, _) => true
           case _ => false
         })
@@ -132,21 +129,21 @@ class IntervalLaws extends PropSpec with PropertyChecks with Matchers {
   }
   property("If an a Lower intersects an Upper, the intersection is non Empty") {
     forAll { (low: Lower[Long], upper: Upper[Long], items: List[Long]) =>
-      assert(lowerUpperIntersection(low, upper, items))
+      (lowerUpperIntersection(low, upper, items))
     }
   }
 
   // This specific case broke the tests before
   property("(n, n+1) follows the intersect law") {
     forAll { (n: Long) =>
-      assert((n == Long.MaxValue) ||
+      ((n == Long.MaxValue) ||
         lowerUpperIntersection(ExclusiveLower(n), ExclusiveUpper(n + 1L), Nil))
     }
   }
 
   property("toLeftClosedRightOpen is an Injection") {
     forAll { (intr: GenIntersection[Long], tests: List[Long]) =>
-      assert(intr.toLeftClosedRightOpen.map {
+      (intr.toLeftClosedRightOpen.map {
         case Intersection(InclusiveLower(low), ExclusiveUpper(high)) =>
           val intr2 = Interval.leftClosedRightOpen(low, high)
           tests.forall { t => intr(t) == intr2(t) }
@@ -156,10 +153,10 @@ class IntervalLaws extends PropSpec with PropertyChecks with Matchers {
 
   property("least is the smallest") {
     forAll { (lower: Lower[Long]) =>
-      assert((for {
+      ((for {
         le <- lower.least
         ple <- Predecessible.prev(le)
-      } yield (lower.contains(le) && !lower.contains(ple)))
+      } yield lower.contains(le) && !lower.contains(ple))
         .getOrElse {
           lower match {
             case InclusiveLower(l) => l == Long.MinValue
@@ -171,10 +168,10 @@ class IntervalLaws extends PropSpec with PropertyChecks with Matchers {
 
   property("greatest is the biggest") {
     forAll { (upper: Upper[Long]) =>
-      assert((for {
+      ((for {
         gr <- upper.greatest
         ngr <- Successible.next(gr)
-      } yield (upper.contains(gr) && !upper.contains(ngr)))
+      } yield upper.contains(gr) && !upper.contains(ngr))
         .getOrElse {
           upper match {
             case InclusiveUpper(l) => l == Long.MaxValue
@@ -187,9 +184,9 @@ class IntervalLaws extends PropSpec with PropertyChecks with Matchers {
   property("leastToGreatest and greatestToLeast are ordered and adjacent") {
     forAll { (intr: GenIntersection[Long]) =>
       val items1 = intr.leastToGreatest.take(100)
-      assert((items1.size < 2) || items1.sliding(2).forall { it =>
+      ((items1.size < 2) || items1.sliding(2).forall { it =>
         it.toList match {
-          case low :: high :: Nil if (low + 1L == high) => true
+          case low :: high :: Nil if low + 1L == high => true
           case _ => false
         }
       } &&
@@ -197,7 +194,7 @@ class IntervalLaws extends PropSpec with PropertyChecks with Matchers {
           val items2 = intr.greatestToLeast.take(100)
           (items2.size < 2) || items2.sliding(2).forall { it =>
             it.toList match {
-              case high :: low :: Nil if (low + 1L == high) => true
+              case high :: low :: Nil if low + 1L == high => true
               case _ => false
             }
           }

--- a/algebird-test/src/test/scala/com/twitter/algebird/JavaBoxedTests.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/JavaBoxedTests.scala
@@ -1,16 +1,14 @@
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
-
-import java.lang.{ Integer => JInt, Short => JShort, Long => JLong, Float => JFloat, Double => JDouble, Boolean => JBool }
+import java.lang.{ Boolean => JBool, Double => JDouble, Float => JFloat, Integer => JInt, Long => JLong, Short => JShort }
 import java.util.{ List => JList, Map => JMap }
+
+import org.scalacheck.{ Arbitrary, Gen }
 
 import scala.collection.JavaConverters._
 
-class JavaBoxedTests extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class JavaBoxedTests extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   implicit val jboolArg = Arbitrary { for (v <- Gen.oneOf(JBool.TRUE, JBool.FALSE)) yield v }
   implicit val jintArg = Arbitrary {

--- a/algebird-test/src/test/scala/com/twitter/algebird/MetricProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MetricProperties.scala
@@ -16,12 +16,10 @@ limitations under the License.
 
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.Prop._
 import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
 
-class BaseMetricProperties extends PropSpec with PropertyChecks with Matchers with MetricProperties {
+class BaseMetricProperties extends CheckProperties with MetricProperties {
   property("double metric") {
     metricLaws[Double](defaultEqFn)
   }

--- a/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
@@ -1,15 +1,10 @@
 package com.twitter.algebird
 
-import org.scalatest._
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalatest.{ Matchers, _ }
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
-
-import java.util.Arrays
-
-class MinHasherTest extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class MinHasherTest extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   implicit val mhMonoid = new MinHasher32(0.5, 512)
   implicit val mhGen = Arbitrary {

--- a/algebird-test/src/test/scala/com/twitter/algebird/MinPlusLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MinPlusLaws.scala
@@ -29,7 +29,7 @@ import org.scalatest.{ PropSpec, Matchers }
 import org.scalatest.prop.PropertyChecks
 import org.scalacheck.Gen.choose
 
-class MinPlusLaws extends PropSpec with PropertyChecks with Matchers {
+class MinPlusLaws extends CheckProperties {
   import BaseProperties._
 
   implicit val mpint: Arbitrary[MinPlus[Int]] = Arbitrary {

--- a/algebird-test/src/test/scala/com/twitter/algebird/MonadInstanceLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MonadInstanceLaws.scala
@@ -16,12 +16,10 @@
 
 package com.twitter.algebird.monad
 
-import com.twitter.algebird.Monad
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
+import com.twitter.algebird.CheckProperties
+import org.scalacheck.Prop._
 
-class MonadInstanceLaws extends PropSpec with PropertyChecks with Matchers {
+class MonadInstanceLaws extends CheckProperties {
 
   // Mutually recursive functions
   def ping(todo: Int, acc: Int): Trampoline[Int] =
@@ -33,7 +31,7 @@ class MonadInstanceLaws extends PropSpec with PropertyChecks with Matchers {
   property("Trampoline should run without stackoverflow") {
     forAll { (b: Int) =>
       val bsmall = b % 1000000
-      assert(ping(bsmall, 0).get == (bsmall max 0))
+      ping(bsmall, 0).get == (bsmall max 0)
     }
   }
 
@@ -44,7 +42,7 @@ class MonadInstanceLaws extends PropSpec with PropertyChecks with Matchers {
         oldState <- StateWithError.swapState[Int](start * 2)
       } yield oldState
 
-      assert(fn(i) == Right((2 * i, i)))
+      fn(i) == Right((2 * i, i))
     }
   }
 
@@ -55,9 +53,9 @@ class MonadInstanceLaws extends PropSpec with PropertyChecks with Matchers {
       val comp = mons.foldLeft(init) { (old, fn) =>
         old.flatMap { x => fn } // just bind
       }
-      assert(comp(in) == (fns.foldLeft(Right((in, head)): Either[String, (Int, Long)]) { (oldState, fn) =>
+      comp(in) == (fns.foldLeft(Right((in, head)): Either[String, (Int, Long)]) { (oldState, fn) =>
         oldState.right.flatMap { case (s, v) => fn(s) }
-      }))
+      })
     }
   }
 
@@ -88,7 +86,7 @@ class MonadInstanceLaws extends PropSpec with PropertyChecks with Matchers {
       fns.foreach { fn =>
         m2.inc(fn(m2.item))
       }
-      assert(m1.item == m2.item)
+      m1.item == m2.item
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/MonadProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MonadProperties.scala
@@ -22,7 +22,7 @@ import org.scalacheck.{ Gen, Arbitrary }
 
 import Monad.{ pureOp, operators }
 
-class MonadProperties extends PropSpec with PropertyChecks with Matchers {
+class MonadProperties extends CheckProperties {
   import MonadLaws._
 
   property("list") {

--- a/algebird-test/src/test/scala/com/twitter/algebird/PredecessibleTests.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/PredecessibleTests.scala
@@ -15,12 +15,8 @@ limitations under the License.
 */
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Arbitrary, Properties }
-
-class PredecessibleTests extends PropSpec with PropertyChecks with Matchers {
-  import PredecessibleLaws.{ predessibleLaws => laws }
+class PredecessibleTests extends CheckProperties {
+  import com.twitter.algebird.PredecessibleLaws.{ predessibleLaws => laws }
 
   property("Int is Predecessible") {
     laws[Int]

--- a/algebird-test/src/test/scala/com/twitter/algebird/PreparerLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/PreparerLaws.scala
@@ -17,11 +17,9 @@ limitations under the License.
 package com.twitter.algebird
 
 import org.scalacheck.Arbitrary
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import org.scalacheck.Prop._
 
-class PreparerLaws extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class PreparerLaws extends CheckProperties {
 
   implicit def aggregator[A, B, C](implicit prepare: Arbitrary[A => B], sg: Semigroup[B], present: Arbitrary[B => C]): Arbitrary[Aggregator[A, B, C]] = Arbitrary {
     for {
@@ -37,14 +35,14 @@ class PreparerLaws extends PropSpec with PropertyChecks with Matchers {
   property("mapping before aggregate is correct") {
     forAll { (in: List[Int], compose: (Int => Int), ag: Aggregator[Int, Int, Int]) =>
       val composed = Preparer[Int].map(compose).aggregate(ag)
-      assert(in.isEmpty || composed(in) == ag(in.map(compose)))
+      in.isEmpty || composed(in) == ag(in.map(compose))
     }
   }
 
   property("split with two aggregators is correct") {
     forAll { (in: List[Int], ag1: Aggregator[Int, Set[Int], Int], ag2: Aggregator[Int, Unit, String]) =>
       val c = Preparer[Int].split{ p => (p.aggregate(ag1), p.aggregate(ag2)) }
-      assert(in.isEmpty || c(in) == (ag1(in), ag2(in)))
+      in.isEmpty || c(in) == (ag1(in), ag2(in))
     }
   }
 
@@ -62,7 +60,7 @@ class PreparerLaws extends PropSpec with PropertyChecks with Matchers {
   property("flatten before aggregate is correct") {
     forAll{ (in: List[List[Int]], ag: MonoidAggregator[Int, Int, Int]) =>
       val flattenedAg = Preparer[List[Int]].flatten.aggregate(ag)
-      assert(flattenedAg(in) == ag(in.flatten))
+      flattenedAg(in) == ag(in.flatten)
     }
   }
 
@@ -75,7 +73,7 @@ class PreparerLaws extends PropSpec with PropertyChecks with Matchers {
           .split{ a => (a.aggregate(ag1), a.aggregate(ag2)) }
 
       val preSplit = in.map(mapFn).flatMap(flatMapFn)
-      assert(in.isEmpty || ag(in) == (ag1(preSplit), ag2(preSplit)))
+      in.isEmpty || ag(in) == (ag1(preSplit), ag2(preSplit))
     }
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/QTreeTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/QTreeTest.scala
@@ -33,7 +33,7 @@ import org.scalacheck.Gen.choose
 
 import java.util.Arrays
 
-class QTreeLaws extends PropSpec with PropertyChecks with Matchers {
+class QTreeLaws extends CheckProperties {
   import BaseProperties._
 
   implicit val qtSemigroup = new QTreeSemigroup[Long](6)

--- a/algebird-test/src/test/scala/com/twitter/algebird/ResetTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/ResetTest.scala
@@ -16,12 +16,11 @@ limitations under the License.
 
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
 import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
 
-class ResetTest extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class ResetTest extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   implicit def resetArb[T: Arbitrary]: Arbitrary[ResetState[T]] = Arbitrary {
     Arbitrary.arbitrary[T].map { t =>
@@ -44,12 +43,12 @@ class ResetTest extends PropSpec with PropertyChecks with Matchers {
   property("ResetState[Int] works as expected") {
     forAll { (a: ResetState[Int], b: ResetState[Int], c: ResetState[Int]) =>
       val result = Monoid.plus(Monoid.plus(a, b), c)
-      assert(((a, b, c) match {
+      ((a, b, c) match {
         case (SetValue(x), SetValue(y), SetValue(z)) => SetValue(x + y + z)
         case (ResetValue(x), SetValue(y), SetValue(z)) => ResetValue(x + y + z)
         case (_, ResetValue(y), SetValue(z)) => ResetValue(y + z)
         case (_, _, ResetValue(z)) => ResetValue(z)
-      }) == result)
+      }) == result
     }
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/RightFolded2Test.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/RightFolded2Test.scala
@@ -1,13 +1,12 @@
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
+import org.scalacheck.Prop._
+import org.scalacheck.{ Arbitrary, Gen }
 
 import scala.annotation.tailrec
 
-class RightFolded2Test extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class RightFolded2Test extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   def monFold(i: Int, l: Long) = l + i.toLong
   def mapFn(l: Long) = l / 2
@@ -73,7 +72,7 @@ class RightFolded2Test extends PropSpec with PropertyChecks with Matchers {
   property("RightFolded2 sum works as expected") {
     forAll { (ls: List[RightFolded2[Int, Long, Long]]) =>
       val accSum = accOf(rightFoldedMonoid.sum(ls)).getOrElse(0L)
-      assert(sum(ls)(monFold)(mapFn) == accSum)
+      sum(ls)(monFold)(mapFn) == accSum
     }
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/RightFoldedTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/RightFoldedTest.scala
@@ -1,11 +1,9 @@
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
+import org.scalacheck.{ Arbitrary, Gen }
 
-class RightFoldedTest extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class RightFoldedTest extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   implicit def rightFoldedValue[Out: Arbitrary]: Arbitrary[RightFoldedValue[Out]] =
     Arbitrary {

--- a/algebird-test/src/test/scala/com/twitter/algebird/SGDTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SGDTest.scala
@@ -1,15 +1,10 @@
 package com.twitter.algebird
 
-import org.scalatest._
+import org.scalacheck.Prop._
+import org.scalacheck.{ Arbitrary, Gen }
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
-import java.lang.AssertionError
-import java.util.Arrays
-
-class SGDLaws extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class SGDLaws extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   implicit val sgdMonoid = new SGDMonoid(SGD.constantStep(0.001), SGD.linearGradient)
   val zeroStepMonoid = new SGDMonoid(SGD.constantStep(0.0), SGD.linearGradient)
@@ -46,7 +41,7 @@ class SGDLaws extends PropSpec with PropertyChecks with Matchers {
       val b = w.weights(1)
       val y = m * x + b
 
-      assert(y.isInfinity || {
+      (y.isInfinity || {
         val pos = (y, IndexedSeq(x))
         val grad = SGD.linearGradient(w.weights, pos)
         (scala.math.abs(grad(0)) < eps) && (scala.math.abs(grad(1)) < eps)
@@ -56,7 +51,7 @@ class SGDLaws extends PropSpec with PropertyChecks with Matchers {
 
   property("Gradient at x=0 has zero first component") {
     forAll { (w: SGDWeights, y: Double) =>
-      assert(SGD.linearGradient(w.weights, (y, IndexedSeq(0.0)))(0) == 0.0)
+      (SGD.linearGradient(w.weights, (y, IndexedSeq(0.0)))(0) == 0.0)
     }
   }
 
@@ -64,7 +59,7 @@ class SGDLaws extends PropSpec with PropertyChecks with Matchers {
     forAll {
       (w: SGDWeights, pos: SGDPos[(Double, IndexedSeq[Double])]) =>
         val next = zeroStepMonoid.newWeights(w, pos.pos.head)
-        assert(next.weights == w.weights && next.count == (w.count + 1L))
+        (next.weights == w.weights && next.count == (w.count + 1L))
     }
   }
 
@@ -78,7 +73,7 @@ class SGDLaws extends PropSpec with PropertyChecks with Matchers {
     forAll {
       (w: SGDWeights, pos: SGDPos[(Double, IndexedSeq[Double])]) =>
         val next = oneStepMonoid.newWeights(w, pos.pos.head)
-        assert(next.weights == minus(w.weights, SGD.linearGradient(w.weights, pos.pos.head)))
+        next.weights == minus(w.weights, SGD.linearGradient(w.weights, pos.pos.head))
     }
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/SketchMapTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SketchMapTest.scala
@@ -11,7 +11,7 @@ object SketchMapTestImplicits {
   val HEAVY_HITTERS_COUNT = 10
 }
 
-class SketchMapLaws extends PropSpec with PropertyChecks with Matchers {
+class SketchMapLaws extends CheckProperties {
   import BaseProperties._
   import SketchMapTestImplicits._
   import HyperLogLog.int2Bytes

--- a/algebird-test/src/test/scala/com/twitter/algebird/SpaceSaverTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SpaceSaverTest.scala
@@ -1,11 +1,11 @@
 package com.twitter.algebird
 
+import org.scalacheck.Prop._
+import org.scalacheck.{ Arbitrary, Gen }
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
 
-class SpaceSaverLaws extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class SpaceSaverLaws extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
 
   // limit sizes to 100 to avoid large data structures in tests
   property("SpaceSaver is a Semigroup") {

--- a/algebird-test/src/test/scala/com/twitter/algebird/SuccessibleProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SuccessibleProperties.scala
@@ -16,12 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Arbitrary, Properties }
-
-class SuccessibleProperties extends PropSpec with PropertyChecks with Matchers {
-  import SuccessibleLaws.{ successibleLaws => laws }
+class SuccessibleProperties extends CheckProperties {
+  import com.twitter.algebird.SuccessibleLaws.{ successibleLaws => laws }
 
   property("Int is Successible") {
     laws[Int]

--- a/algebird-test/src/test/scala/com/twitter/algebird/SummingQueueTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SummingQueueTest.scala
@@ -19,25 +19,26 @@ package com.twitter.algebird
 import org.scalatest.{ PropSpec, Matchers }
 import org.scalatest.prop.PropertyChecks
 import org.scalacheck.{ Gen, Arbitrary }
+import org.scalacheck.Prop._
 
 object SummingCacheTest {
   case class Capacity(cap: Int) extends AnyVal
   implicit val capArb = Arbitrary { for (c <- Gen.choose(0, 1024)) yield Capacity(c) }
 }
 
-class SummingCacheTest extends PropSpec with PropertyChecks with Matchers {
+class SummingCacheTest extends CheckProperties {
   import SummingCacheTest._
 
   // Get the zero-aware map equiv
   import SummingIteratorTest.mapEquiv
 
   // Maps are tricky to compare equality for since zero values are often removed
-  def test[K, V: Monoid](c: Capacity, items: List[(K, V)]) {
+  def test[K, V: Monoid](c: Capacity, items: List[(K, V)]) = {
     val sc = SummingCache[K, V](c.cap)
     val mitems = items.map { Map(_) }
     implicit val mapEq = mapEquiv[K, V]
-    assert(StatefulSummerLaws.sumIsPreserved(sc, mitems) &&
-      StatefulSummerLaws.isFlushedIsConsistent(sc, mitems))
+    StatefulSummerLaws.sumIsPreserved(sc, mitems) &&
+      StatefulSummerLaws.isFlushedIsConsistent(sc, mitems)
   }
 
   property("puts are like sums (Int, Int)") {
@@ -67,11 +68,11 @@ class SummingWithHitsCacheTest extends SummingCacheTest {
   property("hit rates will always be 1 for stream with the same key") {
     forAll { (c: Capacity, values: List[Int]) =>
       // Only run this when we have at least 2 items and non-zero cap
-      if (values.size > 1 && c.cap > 1) {
+      (values.size > 1 && c.cap > 1) ==> {
         val key = RAND.nextInt
         val items = values.map { (key, _) }
         val keyHits = getHits(c, items)
-        assert(keyHits.filter{ _ != 1 }.size == 0)
+        !keyHits.exists(_ != 1)
       }
     }
   }
@@ -79,9 +80,9 @@ class SummingWithHitsCacheTest extends SummingCacheTest {
   property("hit rates will always be 0 when cap is 0") {
     forAll { items: List[(Int, Int)] =>
       // Only run this when we have at least 2 items
-      if (items.size > 1) {
+      (items.size > 1) ==> {
         val keyHits = getHits(Capacity(0), items)
-        assert(keyHits.filter{ _ != 0 }.size == 0)
+        !keyHits.exists(_ != 0)
       }
     }
   }
@@ -89,21 +90,21 @@ class SummingWithHitsCacheTest extends SummingCacheTest {
   property("hit rates in general should be between [0, 1] ") {
     forAll { (c: Capacity, items: List[(Int, Int)]) =>
       // Only run this when we have at least 2 items
-      if (items.size > 1) {
+      (items.size > 1) ==> {
         val keyHits = getHits(c, items)
         val hitRate = keyHits.sum / items.size.toDouble
-        assert(hitRate >= 0 && hitRate <= 1)
+        hitRate >= 0 && hitRate <= 1
       }
     }
   }
 }
 
-class SummingQueueTest extends PropSpec with PropertyChecks with Matchers {
+class SummingQueueTest extends CheckProperties {
   val zeroCapQueue = SummingQueue[Int](0) // passes all through
 
   property("0 capacity always returns") {
     forAll { i: Int =>
-      assert(zeroCapQueue(i) == Some(i))
+      zeroCapQueue(i) == Some(i)
     }
   }
 
@@ -111,20 +112,20 @@ class SummingQueueTest extends PropSpec with PropertyChecks with Matchers {
 
   property("puts are like sums") {
     forAll { (items: List[Int]) =>
-      assert(StatefulSummerLaws.sumIsPreserved(sb, items))
+      StatefulSummerLaws.sumIsPreserved(sb, items)
     }
   }
 
   property("puts are like sums(String)") {
     forAll { (items: List[String]) =>
       val sbs = SummingQueue[String](3) // buffers three at a time
-      assert(StatefulSummerLaws.sumIsPreserved(sbs, items))
+      StatefulSummerLaws.sumIsPreserved(sbs, items)
     }
   }
 
   property("isFlushed is consistent") {
     forAll { (items: List[Int]) =>
-      assert(StatefulSummerLaws.isFlushedIsConsistent(sb, items))
+      StatefulSummerLaws.isFlushedIsConsistent(sb, items)
     }
   }
 
@@ -138,7 +139,7 @@ class SummingQueueTest extends PropSpec with PropertyChecks with Matchers {
         .flatMap { s => s }
         .take(empties.size)
         .toList
-      assert(empties == correct)
+      empties == correct
     }
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/TopKTests.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/TopKTests.scala
@@ -16,18 +16,16 @@ limitations under the License.
 
 package com.twitter.algebird
 
-import com.twitter.algebird.mutable.PriorityQueueMonoid
 import java.util.PriorityQueue
+
+import com.twitter.algebird.mutable.PriorityQueueMonoid
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
 
 import scala.collection.JavaConverters._
 
-import org.scalatest._
-
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
-
-class TopKTests extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class TopKTests extends CheckProperties {
+  import com.twitter.algebird.BaseProperties._
   val SIZE = 10
 
   implicit def qmonoid = new PriorityQueueMonoid[Int](SIZE)
@@ -49,7 +47,7 @@ class TopKTests extends PropSpec with PropertyChecks with Matchers {
 
   property("PriorityQueueMonoid works") {
     forAll { (items: List[List[Int]]) =>
-      assert(pqIsCorrect(items))
+      pqIsCorrect(items)
     }
   }
   /**
@@ -74,7 +72,7 @@ class TopKTests extends PropSpec with PropertyChecks with Matchers {
   property("TopKMonoid works") {
     forAll { (its: List[List[Int]]) =>
       val correct = its.flatten.sorted.take(SIZE)
-      assert(Equiv[List[Int]].equiv(Monoid.sum(its.map { l => tkmonoid.build(l) }).items, correct))
+      Equiv[List[Int]].equiv(Monoid.sum(its.map { l => tkmonoid.build(l) }).items, correct)
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/VectorSpaceProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/VectorSpaceProperties.scala
@@ -16,12 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.Prop._
-
-class VectorSpaceProperties extends PropSpec with PropertyChecks with Matchers {
-  import BaseVectorSpaceProperties._
+class VectorSpaceProperties extends CheckProperties {
+  import com.twitter.algebird.BaseVectorSpaceProperties._
 
   // TODO: we won't need this when we have an Equatable trait
   def mapEqFn(a: Map[Int, Double], b: Map[Int, Double]) = {

--- a/algebird-test/src/test/scala/com/twitter/algebird/statistics/StatisticsTests.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/statistics/StatisticsTests.scala
@@ -1,17 +1,12 @@
 package com.twitter.algebird.statistics
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Arbitrary, Properties }
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import com.twitter.algebird.CheckProperties
+import org.scalacheck.Arbitrary
 import org.scalacheck.Gen._
-import org.scalatest._
+import org.scalatest.{ Matchers, _ }
 
-import com.twitter.algebird.BaseProperties
-
-class StatisticsRingLaws extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class StatisticsRingLaws extends CheckProperties with Matchers {
+  import com.twitter.algebird.BaseProperties._
 
   val statsRing = new StatisticsRing[Int]
   val gen = for (v <- choose(0, 1 << 30)) yield v
@@ -22,8 +17,8 @@ class StatisticsRingLaws extends PropSpec with PropertyChecks with Matchers {
 
 }
 
-class StatisticsMonoidLaws extends PropSpec with PropertyChecks with Matchers {
-  import BaseProperties._
+class StatisticsMonoidLaws extends CheckProperties with Matchers {
+  import com.twitter.algebird.BaseProperties._
 
   val statsMonoid = new StatisticsMonoid[Int]
 

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/PromiseLinkMonoidProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/PromiseLinkMonoidProperties.scala
@@ -16,10 +16,9 @@ limitations under the License.
 package com.twitter.algebird.util
 
 import com.twitter.algebird._
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import org.scalacheck.Prop._
 
-class PromiseLinkMonoidProperties extends PropSpec with PropertyChecks with Matchers {
+class PromiseLinkMonoidProperties extends CheckProperties {
   property("associative") {
     def makeTunnel(seed: Int) = PromiseLink.toPromiseLink(seed)
     def collapseFinalValues(finalTunnel: PromiseLink[Int], tunnels: Seq[PromiseLink[Int]], toFeed: Int) = {

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/TunnelMonoidProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/TunnelMonoidProperties.scala
@@ -17,10 +17,8 @@ package com.twitter.algebird.util
 
 import com.twitter.algebird._
 import com.twitter.util.{ Await, Future }
+
 import scala.util.Random
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.Arbitrary
 
 object TunnelMonoidProperties {
   def testTunnelMonoid[I, V](makeRandomInput: Int => I,
@@ -59,8 +57,7 @@ object TunnelMonoidProperties {
   }
 }
 
-class TunnelMonoidProperties extends PropSpec with PropertyChecks with Matchers {
-  import TunnelMonoidProperties._
+class TunnelMonoidPropertiesextends extends CheckProperties {
 
   implicit val monoid = new Monoid[Int] {
     val zero = 0

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/TunnelMonoidProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/TunnelMonoidProperties.scala
@@ -59,6 +59,7 @@ object TunnelMonoidProperties {
 
 class TunnelMonoidPropertiesextends extends CheckProperties {
 
+  import TunnelMonoidProperties._
   implicit val monoid = new Monoid[Int] {
     val zero = 0
     def plus(older: Int, newer: Int): Int = older + newer

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/UtilAlgebraProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/UtilAlgebraProperties.scala
@@ -16,14 +16,13 @@
 
 package com.twitter.algebird.util
 
+import com.twitter.algebird.CheckProperties
 import com.twitter.algebird.MonadLaws.monadLaws
-import com.twitter.util.{ Await, Future, Throw, Return, Try }
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Arbitrary, Properties }
+import com.twitter.util.{ Await, Future, Return, Try }
+import org.scalacheck.Arbitrary
 
-class UtilAlgebraProperties extends PropSpec with PropertyChecks with Matchers {
-  import UtilAlgebras._
+class UtilAlgebraProperties extends CheckProperties {
+  import com.twitter.algebird.util.UtilAlgebras._
 
   def toOption[T](f: Future[T]): Option[T] =
     try {

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListMMapSumProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListMMapSumProperties.scala
@@ -17,6 +17,7 @@
 package com.twitter.algebird.util.summer
 
 import com.twitter.algebird.CheckProperties
+import org.scalacheck.Prop.forAll
 
 class AsyncListMMapSumProperties extends CheckProperties {
 

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListMMapSumProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListMMapSumProperties.scala
@@ -16,12 +16,11 @@
 
 package com.twitter.algebird.util.summer
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import com.twitter.algebird.CheckProperties
 
-class AsyncListMMapSumProperties extends PropSpec with PropertyChecks with Matchers {
+class AsyncListMMapSumProperties extends CheckProperties {
 
-  import AsyncSummerLaws._
+  import com.twitter.algebird.util.summer.AsyncSummerLaws._
 
   property("Summing with and without the summer should match") {
     forAll { (inputs: List[List[(Int, Long)]],
@@ -41,7 +40,7 @@ class AsyncListMMapSumProperties extends PropSpec with PropertyChecks with Match
         tuplesOut,
         insertOp,
         sizeCounter, workPool)
-      assert(summingWithAndWithoutSummerShouldMatch(summer, inputs))
+      summingWithAndWithoutSummerShouldMatch(summer, inputs)
     }
   }
 }

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncListSumProperties.scala
@@ -16,10 +16,10 @@
 
 package com.twitter.algebird.util.summer
 
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ Matchers, PropSpec }
+import com.twitter.algebird.CheckProperties
+import org.scalacheck.Prop._
 
-class AsyncListSumProperties extends PropSpec with PropertyChecks with Matchers {
+class AsyncListSumProperties extends CheckProperties {
 
   import com.twitter.algebird.util.summer.AsyncSummerLaws._
 
@@ -48,7 +48,7 @@ class AsyncListSumProperties extends PropSpec with PropertyChecks with Matchers 
         workPool,
         Compact(false),
         CompactionSize(0))
-      assert(summingWithAndWithoutSummerShouldMatch(summer, inputs))
+      (summingWithAndWithoutSummerShouldMatch(summer, inputs))
     }
   }
 
@@ -78,7 +78,7 @@ class AsyncListSumProperties extends PropSpec with PropertyChecks with Matchers 
         workPool,
         Compact(true),
         compactionSize)
-      assert(summingWithAndWithoutSummerShouldMatch(summer, inputs))
+      summingWithAndWithoutSummerShouldMatch(summer, inputs)
     }
   }
 }

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncMapSumProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/AsyncMapSumProperties.scala
@@ -16,11 +16,11 @@
 
 package com.twitter.algebird.util.summer
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import com.twitter.algebird.CheckProperties
+import org.scalacheck.Prop._
 
-class AsyncMapSumProperties extends PropSpec with PropertyChecks with Matchers {
-  import AsyncSummerLaws._
+class AsyncMapSumProperties extends CheckProperties {
+  import com.twitter.algebird.util.summer.AsyncSummerLaws._
 
   property("Summing with and without the summer should match") {
     forAll { (inputs: List[List[(Int, Long)]],
@@ -42,7 +42,7 @@ class AsyncMapSumProperties extends PropSpec with PropertyChecks with Matchers {
         tuplesOut,
         sizeCounter,
         workPool)
-      assert(summingWithAndWithoutSummerShouldMatch(summer, inputs))
+      (summingWithAndWithoutSummerShouldMatch(summer, inputs))
     }
   }
 

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/HeavyHittersCachingSummerProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/HeavyHittersCachingSummerProperties.scala
@@ -16,11 +16,11 @@
 
 package com.twitter.algebird.util.summer
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import com.twitter.algebird.CheckProperties
+import org.scalacheck.Prop._
 
-class HeavyHittersCachingSummerProperties extends PropSpec with PropertyChecks with Matchers {
-  import AsyncSummerLaws._
+class HeavyHittersCachingSummerProperties extends CheckProperties  {
+  import com.twitter.algebird.util.summer.AsyncSummerLaws._
 
   property("Summing with and without the summer should match") {
     forAll { (inputs: List[List[(Int, Long)]],
@@ -56,7 +56,7 @@ class HeavyHittersCachingSummerProperties extends PropSpec with PropertyChecks w
         insertOp,
         sizeCounter,
         summer)
-      assert(summingWithAndWithoutSummerShouldMatch(heavyHittersCachingSummer, inputs))
+      (summingWithAndWithoutSummerShouldMatch(heavyHittersCachingSummer, inputs))
     }
   }
 

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/HeavyHittersCachingSummerProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/HeavyHittersCachingSummerProperties.scala
@@ -19,7 +19,7 @@ package com.twitter.algebird.util.summer
 import com.twitter.algebird.CheckProperties
 import org.scalacheck.Prop._
 
-class HeavyHittersCachingSummerProperties extends CheckProperties  {
+class HeavyHittersCachingSummerProperties extends CheckProperties {
   import com.twitter.algebird.util.summer.AsyncSummerLaws._
 
   property("Summing with and without the summer should match") {

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/NullSummerProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/NullSummerProperties.scala
@@ -27,7 +27,7 @@ class NullSummerProperties extends CheckProperties {
       val tuplesIn = Counter("tuplesIn")
       val tuplesOut = Counter("tuplesOut")
       val summer = new NullSummer[Int, Long](tuplesIn, tuplesOut)
-      s1ummingWithAndWithoutSummerShouldMatch(summer, inputs)
+      summingWithAndWithoutSummerShouldMatch(summer, inputs)
     }
   }
 

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/summer/NullSummerProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/summer/NullSummerProperties.scala
@@ -16,18 +16,18 @@
 
 package com.twitter.algebird.util.summer
 
-import org.scalatest.{ PropSpec, Matchers }
-import org.scalatest.prop.PropertyChecks
+import com.twitter.algebird.CheckProperties
+import org.scalacheck.Prop._
 
-class NullSummerProperties extends PropSpec with PropertyChecks with Matchers {
-  import AsyncSummerLaws._
+class NullSummerProperties extends CheckProperties {
+  import com.twitter.algebird.util.summer.AsyncSummerLaws._
 
   property("Summing with and without the summer should match") {
     forAll { (inputs: List[List[(Int, Long)]]) =>
       val tuplesIn = Counter("tuplesIn")
       val tuplesOut = Counter("tuplesOut")
       val summer = new NullSummer[Int, Long](tuplesIn, tuplesOut)
-      assert(summingWithAndWithoutSummerShouldMatch(summer, inputs))
+      s1ummingWithAndWithoutSummerShouldMatch(summer, inputs)
     }
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -155,11 +155,11 @@ object AlgebirdBuild extends Build {
 
   lazy val algebirdUtil = module("util").settings(
     libraryDependencies += "com.twitter" %% "util-core" % "6.20.0"
-  ).dependsOn(algebirdCore, algebirdTest % "test->compile")
+  ).dependsOn(algebirdCore, algebirdTest % "test->test")
 
   lazy val algebirdBijection = module("bijection").settings(
     libraryDependencies += "com.twitter" %% "bijection-core" % "0.7.2"
-  ).dependsOn(algebirdCore, algebirdTest % "test->compile")
+  ).dependsOn(algebirdCore, algebirdTest % "test->test")
 }
 
 


### PR DESCRIPTION
Most property tests such as monoidLaw, monadLaw etc were not running properly due to combination of `org.scalatest.prop.PropertyChecks` with `org.scalacheck.Prop.forAll`. Scalatest mark test as a failure only when an exception is thrown using various matchers etc, most Algebird laws indicate failure by returning `false` inside  `org.scalacheck.Prop.forAll`. Due to this mismatch Scalatest was passing all the laws even when they failed as no exception was thrown. I have changed the tests to use `org.scalatest.prop.Checkers` instead of `org.scalatest.prop.PropertyChecks` which delegates to Scalatest for test verification keeping the old behavior of `false` for failure `true` for success and `error` for exception  