### PR TITLE
Make Preparer extend Serializable

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Preparer.scala
@@ -9,7 +9,7 @@ package com.twitter.algebird
  * Uses of Preparer will always start with a call to Preparer[A], and end with a call to
  * monoidAggregate or a related method, to produce an Aggregator instance.
  */
-sealed trait Preparer[A, T] {
+sealed trait Preparer[A, T] extends java.io.Serializable {
   /**
    * Produce a new MonoidAggregator which includes the Preparer's transformation chain in its prepare stage.
    */


### PR DESCRIPTION
Aggregators created through the Preparer interface retain references to the original Map/FlatMap Preparer instance. For Summingbird Storm jobs, this causes issues since the aggregators need to be Java serializable.
While we could try to construct the instances such that we don't retain any unnecessary references, it seems simpler to just make Preparer extend Serializable to avoid any issues in the future.

cc @avibryant 