### PR TITLE
A couple of performance optimizations: HyperLogLog and BloomFilter

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -235,7 +235,12 @@ case class BFInstance(hashes: BFHash, bits: BitSet, width: Int) extends BF {
   }
 
   def +(item: String): BFInstance = {
-    val bitsToActivate = BitSet(hashes(item): _*)
+    val itemHashes = hashes(item)
+    this.+(itemHashes: _*)
+  }
+
+  private def +(itemHashes: Int*): BFInstance = {
+    val bitsToActivate = BitSet(itemHashes: _*)
 
     BFInstance(hashes,
       bits ++ bitsToActivate,
@@ -243,17 +248,23 @@ case class BFInstance(hashes: BFHash, bits: BitSet, width: Int) extends BF {
   }
 
   def checkAndAdd(item: String): (BF, ApproximateBoolean) = {
-    val contained = this.contains(item)
-    (this.+(item), contained)
+    val itemHashes = hashes(item)
+    val contained = this.contains(itemHashes: _*)
+    (this.+(itemHashes: _*), contained)
   }
 
-  def bitSetContains(bs: BitSet, il: Int*): Boolean = {
+  private def bitSetContains(bs: BitSet, il: Int*): Boolean = {
     il.foreach { i => if (!bs.contains(i)) return false }
     true
   }
 
-  def contains(item: String) = {
-    if (bitSetContains(bits, hashes(item): _*)) {
+  def contains(item: String): ApproximateBoolean = {
+    val itemHashes = hashes(item)
+    contains(itemHashes: _*)
+  }
+
+  private def contains(itemHashes: Int*): ApproximateBoolean = {
+    if (bitSetContains(bits, itemHashes: _*)) {
       // The false positive probability (the probability that the Bloom filter erroneously
       // claims that an element x is in the set when x is not) is roughly
       // p = (1 - e^(-numHashes * setCardinality / width))^numHashes

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -154,7 +154,13 @@ case class BFItem(item: String, hashes: BFHash, width: Int) extends BF {
 
   def +(other: String) = this ++ BFItem(other, hashes, width)
 
-  def checkAndAdd(other: String): (BF, ApproximateBoolean) = (this + other, ApproximateBoolean.exact(other == item))
+  def checkAndAdd(other: String): (BF, ApproximateBoolean) = {
+    if (other == item) {
+      (this, ApproximateBoolean.exactTrue)
+    } else {
+      (this + other, ApproximateBoolean.exactFalse)
+    }
+  }
 
   def contains(x: String) = ApproximateBoolean.exact(item == x)
 
@@ -237,13 +243,13 @@ case class BFInstance(hashes: BFHash, bits: BitSet, width: Int) extends BF {
   }
 
   def checkAndAdd(item: String): (BF, ApproximateBoolean) = {
-    val bitsToActivate = BitSet(hashes(item): _*)
     val contained = this.contains(item)
-    (BFInstance(hashes, bits ++ bitsToActivate, width), contained)
+    (this.+(item), contained)
   }
 
   def bitSetContains(bs: BitSet, il: Int*): Boolean = {
-    il.map{ i: Int => bs.contains(i) }.reduce{ _ && _ }
+    il.foreach { i => if (!bs.contains(i)) return false }
+    true
   }
 
   def contains(item: String) = {

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -199,10 +199,7 @@ case class BFSparse(hashes: BFHash, bits: CBitSet, width: Int) extends BF {
       width)
   }
 
-  def checkAndAdd(other: String): (BF, ApproximateBoolean) = {
-    val containedApproximate = this.contains(other)
-    (this + other, containedApproximate)
-  }
+  def checkAndAdd(other: String): (BF, ApproximateBoolean) = dense.checkAndAdd(other)
 
   def contains(item: String): ApproximateBoolean = dense.contains(item)
 
@@ -263,7 +260,7 @@ case class BFInstance(hashes: BFHash, bits: BitSet, width: Int) extends BF {
     contains(itemHashes: _*)
   }
 
-  private def contains(itemHashes: Int*): ApproximateBoolean = {
+  private[algebird] def contains(itemHashes: Int*): ApproximateBoolean = {
     if (bitSetContains(bits, itemHashes: _*)) {
       // The false positive probability (the probability that the Bloom filter erroneously
       // claims that an element x is in the set when x is not) is roughly

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -49,7 +49,7 @@ object HyperLogLog {
     pairLongs2Bytes(l0, l1)
   }
 
-  def pairLongs2Bytes(l0: Long, l1: Long): Array[Byte] = {
+  private[algebird] def pairLongs2Bytes(l0: Long, l1: Long): Array[Byte] = {
     val buf = new Array[Byte](16)
     ByteBuffer
       .wrap(buf)

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -46,6 +46,10 @@ object HyperLogLog {
   def hash(input: Array[Byte]): Array[Byte] = {
     val seed = 12345678
     val (l0, l1) = MurmurHash128(seed)(input)
+    pairLongs2Bytes(l0, l1)
+  }
+
+  def pairLongs2Bytes(l0: Long, l1: Long): Array[Byte] = {
     val buf = new Array[Byte](16)
     ByteBuffer
       .wrap(buf)
@@ -478,7 +482,16 @@ class HyperLogLogMonoid(val bits: Int) extends Monoid[HLL] {
     }
 
   def create(example: Array[Byte]): HLL = {
-    val hashed = hash(example)
+    val hashBytes = hash(example)
+    createFromHashBytes(hashBytes)
+  }
+
+  def createFromHashLongs(l0: Long, l1: Long): HLL = {
+    val hashBytes = pairLongs2Bytes(l0, l1)
+    createFromHashBytes(hashBytes)
+  }
+
+  def createFromHashBytes(hashed: Array[Byte]): HLL = {
     val (j, rhow) = jRhoW(hashed, bits)
     SparseHLL(bits, Map(j -> Max(rhow)))
   }

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -207,4 +207,32 @@ class BloomFilterTest extends WordSpec with Matchers {
       assert(index >= 0)
     }
   }
+
+  "BloomFilter method `checkAndAdd`" should {
+
+    "be identical to method `+`" in {
+      (0 to 100).foreach {
+        _ =>
+          {
+            val bfMonoid = new BloomFilterMonoid(RAND.nextInt(5) + 1, RAND.nextInt(64) + 32, SEED)
+            val numEntries = 5
+            val entries = (0 until numEntries).map(_ => RAND.nextInt.toString)
+            val bf = bfMonoid.create(entries: _*)
+            val bfWithCheckAndAdd = entries
+              .map { entry => (entry, bfMonoid.create(entry)) }
+              .foldLeft((bfMonoid.zero, bfMonoid.zero)) {
+                case ((left, leftAlt), (entry, right)) =>
+                  val (newLeftAlt, contained) = leftAlt.checkAndAdd(entry)
+                  left.contains(entry) shouldBe contained
+                  (left + entry, newLeftAlt)
+              }
+
+            entries.foreach { i =>
+              assert(bf.contains(i.toString).isTrue)
+            }
+          }
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Added possibility of HLL creation from pre-computed hashes to HyperLogLogMonoid.
This makes it possible to re-use pre-computed hashes and increase performance.