### PR TITLE
Speed up QTree

### DIFF
--- a/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/AsyncSummerBenchmark.scala
+++ b/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/AsyncSummerBenchmark.scala
@@ -4,11 +4,11 @@ import java.lang.Math._
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 
-import com.google.caliper.{Param, SimpleBenchmark}
-import com.twitter.algebird.{HyperLogLogMonoid, _}
+import com.google.caliper.{ Param, SimpleBenchmark }
+import com.twitter.algebird.{ HyperLogLogMonoid, _ }
 import com.twitter.algebird.util.summer._
 import com.twitter.bijection._
-import com.twitter.util.{Await, Duration, FuturePool}
+import com.twitter.util.{ Await, Duration, FuturePool }
 
 import scala.util.Random
 

--- a/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/CMSHashingBenchmark.scala
+++ b/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/CMSHashingBenchmark.scala
@@ -1,6 +1,6 @@
 package com.twitter.algebird.caliper
 
-import com.google.caliper.{Param, SimpleBenchmark}
+import com.google.caliper.{ Param, SimpleBenchmark }
 
 /**
  * Benchmarks the hashing algorithms used by Count-Min sketch for CMS[BigInt].
@@ -33,7 +33,7 @@ class CMSHashingBenchmark extends SimpleBenchmark {
   /**
    * Width of the counting table.
    */
-  @Param(Array("11" /* eps = 0.271 */ , "544" /* eps = 0.005 */ , "2719" /* eps = 1E-3 */ , "271829" /* eps = 1E-5 */))
+  @Param(Array("11" /* eps = 0.271 */ , "544" /* eps = 0.005 */ , "2719" /* eps = 1E-3 */ , "271829" /* eps = 1E-5 */ ))
   val width: Int = 0
 
   /**
@@ -54,7 +54,7 @@ class CMSHashingBenchmark extends SimpleBenchmark {
   override def setUp() {
     random = new scala.util.Random
     // We draw numbers randomly from a 2^maxBits address space.
-    inputs = (1 to operations).view.map { _ => scala.math.BigInt(maxBits, random)}
+    inputs = (1 to operations).view.map { _ => scala.math.BigInt(maxBits, random) }
   }
 
   private def murmurHashScala(a: Int, b: Int, width: Int)(x: BigInt) = {
@@ -82,7 +82,7 @@ class CMSHashingBenchmark extends SimpleBenchmark {
   def timeBrokenCurrentHashWithRandomMaxBitsNumbers(operations: Int): Int = {
     var dummy = 0
     while (dummy < operations) {
-      inputs.foreach { input => brokenCurrentHash(a, b, width)(input)}
+      inputs.foreach { input => brokenCurrentHash(a, b, width)(input) }
       dummy += 1
     }
     dummy
@@ -91,7 +91,7 @@ class CMSHashingBenchmark extends SimpleBenchmark {
   def timeMurmurHashScalaWithRandomMaxBitsNumbers(operations: Int): Int = {
     var dummy = 0
     while (dummy < operations) {
-      inputs.foreach { input => murmurHashScala(a, b, width)(input)}
+      inputs.foreach { input => murmurHashScala(a, b, width)(input) }
       dummy += 1
     }
     dummy

--- a/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/QTreeBenchmark.scala
+++ b/algebird-caliper/src/test/scala/com/twitter/algebird/caliper/QTreeBenchmark.scala
@@ -1,0 +1,61 @@
+package com.twitter.algebird.caliper
+
+import com.twitter.algebird._
+import scala.util.Random
+import com.twitter.bijection._
+
+import java.util.concurrent.Executors
+import com.twitter.algebird.util._
+import com.google.caliper.{ Param, SimpleBenchmark }
+import java.nio.ByteBuffer
+
+import scala.math._
+
+class OldQTreeSemigroup[A: Monoid](k: Int) extends QTreeSemigroup[A](k) {
+  override def sumOption(items: TraversableOnce[QTree[A]]) =
+    if (items.isEmpty) None
+    else Some(items.reduce(plus))
+}
+
+class QTreeBenchmark extends SimpleBenchmark {
+  var qtree: QTreeSemigroup[Long] = _
+  var oldqtree: QTreeSemigroup[Long] = _
+
+  @Param(Array("5", "10", "12"))
+  val depthK: Int = 0
+
+  @Param(Array("100", "10000"))
+  val numElements: Int = 0
+
+  var inputData: Seq[QTree[Long]] = _
+
+  override def setUp {
+    qtree = new QTreeSemigroup[Long](depthK)
+    oldqtree = new OldQTreeSemigroup(depthK)
+
+    val rng = new Random("qtree".hashCode)
+
+    inputData = (0L until numElements).map { _ =>
+      QTree(rng.nextInt(1000).toLong)
+    }
+  }
+
+  def timeSumOption(reps: Int): Int = {
+    var dummy = 0
+    while (dummy < reps) {
+      qtree.sumOption(inputData)
+      dummy += 1
+    }
+    dummy
+  }
+
+  /*
+  def timeOldSumOption(reps: Int): Int = {
+    var dummy = 0
+    while (dummy < reps) {
+      oldqtree.sumOption(inputData)
+      dummy += 1
+    }
+    dummy
+  } */
+}


### PR DESCRIPTION
This makes an algorithmic improvement, and uses sumOption to get pretty big wins in performance which should be enough for map/reduce applications. There are two tricks:

1) we don't need to scan the whole tree if the minCount is 1 or less, which is common, especially for smaller QTrees, which come up when you just add a few together which would be done in map-side aggregation.

2) in sumOption, we can wait to compress after we have added a number of items together. This can be controlled by the user but defaults to 25, which seems to be big enough to give a win in one of the benchmark cases, but also not so huge that I am nervous the QTree is going to get out of hand in size.

Also, I removed the `Monoid[A]` from the QTree instance, which was probably being serialized when people use Kryo, which is no good. Also, it really belongs in the Semigroup (which I think could be a Monoid if we needed, just make a zero with a zero count).

related to #385 

/cc @avibryant 

Benchmark results:
```
Old code:

[info] 0% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=5, numElements=100} 984899.57 ns;
σ=57042.22 ns @ 10 trials
[info] 17% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=10, numElements=100} 1083250.54
ns; σ=5840.94 ns @ 3 trials
[info] 33% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=12, numElements=100} 1137581.99
ns; σ=108320.10 ns @ 10 trials
[info] 50% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=5, numElements=10000} 61440033.33
ns; σ=2959694.26 ns @ 10 trials
[info] 67% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=10, numElements=10000}
1150803500.00 ns; σ=10953173.74 ns @ 4 trials
[info] 83% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=12, numElements=10000}
795943000.00 ns; σ=5517007.01 ns @ 3 trials
[info] 
[info] numElements depthK      us linear runtime
[info]         100      5     985 =
[info]         100     10    1083 =
[info]         100     12    1138 =
[info]       10000      5   61440 =
[info]       10000     10 1150804 ==============================
[info]       10000     12  795943 ====================
[info] 
[info] vm: java
[info] trial: 0
[info] benchmark: SumOption

New code: 
[info]  0% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=5, numElements=100} 131886.03 ns;
σ=189.18 ns @ 3 trials
[info] 17% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=10, numElements=100} 117297.16 ns;
σ=163.64 ns @ 3 trials
[info] 33% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=12, numElements=100} 118775.84 ns;
σ=637.37 ns @ 3 trials
[info] 50% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=5, numElements=10000} 15500888.37
ns; σ=428739.48 ns @ 10 trials
[info] 67% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=10, numElements=10000} 39304494.17
ns; σ=1701883.67 ns @ 10 trials
[info] 83% Scenario{vm=java, trial=0, benchmark=SumOption, depthK=12, numElements=10000} 23124595.24
ns; σ=273888.75 ns @ 10 trials
[info] 
[info] numElements depthK    us linear runtime
[info]         100      5   132 =
[info]         100     10   117 =
[info]         100     12   119 =
[info]       10000      5 15501 ===========
[info]       10000     10 39304 ==============================
[info]       10000     12 23125 =================
[info] 
[info] vm: java
[info] trial: 0
[info] benchmark: SumOption

if we compress after each sum (just looking at the other optimizations):

[info] numElements depthK     us linear runtime
[info]         100      5    227 =
[info]         100     10    119 =
[info]         100     12    125 =
[info]       10000      5  37222 ===
[info]       10000     10 357207 ==============================
[info]       10000     12  61052 =====
```