### PR TITLE
Moments returns NaN when count is too low for higher order statistics

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/MomentsGroup.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/MomentsGroup.scala
@@ -29,14 +29,23 @@ case class Moments(m0: Long, m1: Double, m2: Double, m3: Double, m4: Double) {
   def mean = m1
 
   // Population variance, not sample variance.
-  def variance = m2 / count
+  def variance = if (count > 1)
+    m2 / count
+  else /* don't return junk when the moment is not defined */
+    Double.NaN
 
   // Population standard deviation, not sample standard deviation.
   def stddev = math.sqrt(variance)
 
-  def skewness = math.sqrt(count) * m3 / math.pow(m2, 1.5)
+  def skewness = if (count > 2)
+    math.sqrt(count) * m3 / math.pow(m2, 1.5)
+  else /* don't return junk when the moment is not defined */
+    Double.NaN
 
-  def kurtosis = count * m4 / math.pow(m2, 2) - 3
+  def kurtosis = if (count > 3)
+    count * m4 / math.pow(m2, 2) - 3
+  else /* don't return junk when the moment is not defined */
+    Double.NaN
 }
 
 object Moments {

--- a/algebird-test/src/test/scala/com/twitter/algebird/MomentsGroupTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MomentsGroupTest.scala
@@ -75,6 +75,12 @@ class MomentsGroupTest extends WordSpec with Matchers {
     testApproxEq(m2.variance, 0.64)
     testApproxEq(m2.skewness, 0.84375)
     testApproxEq(m2.kurtosis, -0.921875)
+  }
 
+  "Moments should not return higher-order moments for small data sets" in {
+    val m1 = MomentsAggregator(List(1, 2))
+    testApproxEq(m1.count, 2)
+    assert(m1.skewness.isNaN)
+    assert(m1.kurtosis.isNaN)
   }
 }


### PR DESCRIPTION
Typically, we require at least N samples in order to compute the N'th order moment. Currently, Moments returns values even when fewer than N samples -- these values are not meaningful, and should not be relied upon for very small sample size. This PR returns NaN in these cases, instead.