### PR TITLE
Add HLL method to do error-based Aggregator

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -3,7 +3,7 @@ package com.twitter.algebird
 import org.scalatest._
 
 import org.scalatest.prop.PropertyChecks
-import org.scalacheck.{ Gen, Arbitrary }
+import org.scalacheck.{ Gen, Arbitrary, Prop }
 
 import scala.collection.BitSet
 
@@ -51,6 +51,12 @@ class HyperLogLogLaws extends CheckProperties {
     monoidLawsEq[HLL]{ _.toDenseHLL == _.toDenseHLL }
   }
 
+  property("bitsForError and error match") {
+    Prop.forAll(Gen.choose(0.0001, 0.999)) { err =>
+      val bits = HyperLogLog.bitsForError(err)
+      (HyperLogLog.error(bits) <= err) && (HyperLogLog.error(bits - 1) > err)
+    }
+  }
 }
 
 /* Ensure jRhoW matches referenceJRhoW */


### PR DESCRIPTION
This should make it easier to create an Aggregator or HLL based on a desired error-rate rather than serialized size.

This is just a first step in making some of the more powerful aggregators easier to use.