### PR TITLE
QTree quantileBounds assert percentile <= 1.0

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/QTree.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/QTree.scala
@@ -195,7 +195,7 @@ case class QTree[A](
    * an estimate of the median.
    */
   def quantileBounds(p: Double): (Double, Double) = {
-    require(p >= 0.0 && p < 1.0, "The given percentile must be of the form 0 <= p < 1.0")
+    require(p >= 0.0 && p <= 1.0, "The given percentile must be of the form 0 <= p <= 1.0")
 
     val rank = math.floor(count * p).toLong
     // get is safe below, because findRankLowerBound only returns

--- a/algebird-test/src/test/scala/com/twitter/algebird/QTreeTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/QTreeTest.scala
@@ -79,6 +79,14 @@ class QTreeTest extends WordSpec with Matchers {
         assert(truth >= lower)
         assert(truth <= upper)
       }
+      "return correct quantile bounds for two percentile extremes" in {
+        val list = randomList(10000)
+        val qt = buildQTree(k, list)
+        val (lower, _) = qt.quantileBounds(0.0)
+        val (_, upper) = qt.quantileBounds(1.0)
+        assert(lower == 0.0)
+        assert(upper == 1.0)
+      }
       "always contain the true range sum within its bounds" in {
         val list = randomList(10000)
         val qt = buildQTree(k, list)


### PR DESCRIPTION
Assertion fails if percentile == 1.0, should pass if 0 <= percentile <= 1.0