### PR TITLE
Add MapAggregator from 1 (key, aggregator) pair

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/TupleAggregatorsTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/TupleAggregatorsTest.scala
@@ -340,6 +340,13 @@ class TupleAggregatorsTest extends WordSpec with Matchers {
 
     val MinLongAgg = Aggregator.min[Int].andThenPresent{ _.toLong }
 
+    "Create an aggregator from 1 (key, aggregator) pair" in {
+      val agg: Aggregator[Int, Long, Map[String, Long]] = MapAggregator(
+        ("key1", SizeAgg))
+      val expectedMap = Map("key1" -> 6)
+      assert(agg(data) == expectedMap)
+    }
+
     "Create an aggregator from 2 (key, aggregator) pairs" in {
       val agg: Aggregator[Int, Tuple2[Int, Long], Map[String, Long]] = MapAggregator(
         ("key1", MinLongAgg),


### PR DESCRIPTION
- Make API easier to use (more consistent), by allowing to create a MapAggregator of one "metric"

improves: https://github.com/twitter/algebird/pull/411#issuecomment-104117951