### PR TITLE
Refactor MapAggregator

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/TupleAggregatorsTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/TupleAggregatorsTest.scala
@@ -341,24 +341,26 @@ class TupleAggregatorsTest extends WordSpec with Matchers {
     val MinLongAgg = Aggregator.min[Int].andThenPresent{ _.toLong }
 
     "Create an aggregator from 1 (key, aggregator) pair" in {
-      val agg: Aggregator[Int, Long, Map[String, Long]] = MapAggregator(
+      val agg: MapMonoidAggregator[Int, Long, String, Long] = MapAggregator(
         ("key1", SizeAgg))
       val expectedMap = Map("key1" -> 6)
       assert(agg(data) == expectedMap)
+      assert(agg.keys == expectedMap.keys)
     }
 
     "Create an aggregator from 2 (key, aggregator) pairs" in {
-      val agg: Aggregator[Int, Tuple2[Int, Long], Map[String, Long]] = MapAggregator(
+      val agg: MapAggregator[Int, Tuple2[Int, Long], String, Long] = MapAggregator(
         ("key1", MinLongAgg),
         ("key2", SizeAgg))
       val expectedMap = Map(
         "key1" -> 0,
         "key2" -> 6)
       assert(agg(data) == expectedMap)
+      assert(agg.keys == expectedMap.keys)
     }
 
     "Create an aggregator from 3 (key, aggregator) pairs" in {
-      val agg: Aggregator[Int, Tuple3[Int, Long, Int], Map[String, Long]] = MapAggregator(
+      val agg: MapAggregator[Int, Tuple3[Int, Long, Int], String, Long] = MapAggregator(
         ("key1", MinLongAgg),
         ("key2", SizeAgg),
         ("key3", MinLongAgg))
@@ -367,10 +369,11 @@ class TupleAggregatorsTest extends WordSpec with Matchers {
         "key2" -> 6,
         "key3" -> 0)
       assert(agg(data) == expectedMap)
+      assert(agg.keys == expectedMap.keys)
     }
 
     "Create an aggregator from 4 (key, aggregator) pairs" in {
-      val agg: Aggregator[Int, Tuple4[Int, Long, Int, Long], Map[String, Long]] = MapAggregator(
+      val agg: MapAggregator[Int, Tuple4[Int, Long, Int, Long], String, Long] = MapAggregator(
         ("key1", MinLongAgg),
         ("key2", SizeAgg),
         ("key3", MinLongAgg),
@@ -381,6 +384,7 @@ class TupleAggregatorsTest extends WordSpec with Matchers {
         "key3" -> 0,
         "key4" -> 6)
       assert(agg(data) == expectedMap)
+      assert(agg.keys == expectedMap.keys)
     }
 
     "Create an aggregator from 5 (key, aggregator) pairs" in {

--- a/project/GenTupleAggregators.scala
+++ b/project/GenTupleAggregators.scala
@@ -23,13 +23,25 @@ object MultiAggregator {
       genMethods(22, "def", Some("apply"), true) + "\n" + "}")
 
     val mapAggPlace = dir / "com" / "twitter" / "algebird" / "MapAggregator.scala"
-    IO.write(mapAggPlace,
-"""package com.twitter.algebird
-
-object MapAggregator {
-""" +
-      genMapMethods(22) + "\n" +
-      genMapMethods(22, true) + "\n" + "}")
+    IO.write(
+      mapAggPlace,
+      s"""
+      |package com.twitter.algebird
+      |
+      |trait MapAggregator[A, B, K, C] extends Aggregator[A, B, Map[K, C]] {
+      |  def keys: Set[K]
+      |}
+      |
+      |trait MapMonoidAggregator[A, B, K, C] extends MonoidAggregator[A, B, Map[K, C]] {
+      |  def keys: Set[K]
+      |}
+      |
+      |object MapAggregator {
+      |  ${genMapMethods(22)}
+      |  ${genMapMethods(22, isMonoid = true)}
+      |}
+      """.stripMargin
+    )
 
     Seq(tupleAggPlace, multiAggPlace, mapAggPlace)
   }
@@ -66,29 +78,35 @@ object MapAggregator {
   }
 
   def genMapMethods(max: Int, isMonoid: Boolean = false): String = {
-    val aggType = if (isMonoid) "Monoid" else ""
+    val inputAggregatorType = if (isMonoid) "MonoidAggregator" else "Aggregator"
+    val mapAggregatorType = if (isMonoid) "MapMonoidAggregator" else "MapAggregator"
+
+    val semigroupType = if (isMonoid) "monoid" else "semigroup"
 
     // there's no Semigroup[Tuple1[T]], so just use T as intermediary type instead of Tuple1[T]
+    // TODO: keys for 1 item
     val aggregatorForOneItem = s"""
-       |def apply[K, A, B, C](aggDef: (K, ${aggType}Aggregator[A, B, C])): ${aggType}Aggregator[A, B, Map[K, C]] = {
-       |  val (key, agg) = aggDef
-       |  agg.andThenPresent(value => Map(key -> value))
+       |def apply[K, A, B, C](agg: (K, ${inputAggregatorType}[A, B, C])): ${mapAggregatorType}[A, B, K, C] = {
+       |  new ${mapAggregatorType}[A, B, K, C] {
+       |    def prepare(a: A) = agg._2.prepare(a)
+       |    val ${semigroupType} = agg._2.${semigroupType}
+       |    def present(b: B) = Map(agg._1 -> agg._2.present(b))
+       |    def keys = Set(agg._1)
+       |  }
        |}
     """.stripMargin
 
     (2 to max).map(aggrCount => {
       val aggrNums = 1 to aggrCount
 
-      val inputAggs = aggrNums.map(i => s"agg$i: (K, ${aggType}Aggregator[A, B$i, C])").mkString(", ")
-
-      val semigroupType = if (isMonoid) "monoid" else "semigroup"
+      val inputAggs = aggrNums.map(i => s"agg$i: (K, ${inputAggregatorType}[A, B$i, C])").mkString(", ")
 
       val bs = aggrNums.map("B" + _).mkString(", ")
       val tupleBs = s"Tuple${aggrCount}[$bs]"
 
       s"""
-      |def apply[K, A, $bs, C]($inputAggs): ${aggType}Aggregator[A, $tupleBs, Map[K, C]] = {
-      |  new ${aggType}Aggregator[A, $tupleBs, Map[K, C]] {
+      |def apply[K, A, $bs, C]($inputAggs): ${mapAggregatorType}[A, $tupleBs, K, C] = {
+      |  new ${mapAggregatorType}[A, $tupleBs, K, C] {
       |    def prepare(a: A) = (
       |      ${aggrNums.map(i => s"agg${i}._2.prepare(a)").mkString(", ")}
       |    )
@@ -98,6 +116,9 @@ object MapAggregator {
       |    )
       |    def present(b: $tupleBs) = Map(
       |      ${aggrNums.map(i => s"agg${i}._1 -> agg${i}._2.present(b._${i})").mkString(", ")}
+      |    )
+      |    def keys: Set[K] = Set(
+      |      ${aggrNums.map(i => s"agg${i}._1").mkString(", ")}
       |    )
       |  }
       |}""".stripMargin

--- a/project/GenTupleAggregators.scala
+++ b/project/GenTupleAggregators.scala
@@ -91,14 +91,14 @@ object MapAggregator {
       |def apply[K, A, $bs, C]($inputAggs): ${aggType}Aggregator[A, $tupleBs, Map[K, C]] = {
       |  new ${aggType}Aggregator[A, $tupleBs, Map[K, C]] {
       |    def prepare(a: A) = (
-      |      ${aggrNums.map(i => s"agg$i._2.prepare(a)").mkString(", ")}
+      |      ${aggrNums.map(i => s"agg${i}._2.prepare(a)").mkString(", ")}
       |    )
       |    // a field for combined semigroup/monoid
       |    val $semigroup = new $semigroupType()(
-      |      ${aggrNums.map(i => s"agg$i._2.$semigroup").mkString(", ")}
+      |      ${aggrNums.map(i => s"agg${i}._2.$semigroup").mkString(", ")}
       |    )
       |    def present(b: $tupleBs) = Map(
-      |      ${aggrNums.map(i => s"agg$i._1 -> agg$i._2.present(b._$i)").mkString(", ")}
+      |      ${aggrNums.map(i => s"agg${i}._1 -> agg${i}._2.present(b._${i})").mkString(", ")}
       |    )
       |  }
       |}""".stripMargin

--- a/project/GenTupleAggregators.scala
+++ b/project/GenTupleAggregators.scala
@@ -81,8 +81,7 @@ object MapAggregator {
 
       val inputAggs = aggrNums.map(i => s"agg$i: (K, ${aggType}Aggregator[A, B$i, C])").mkString(", ")
 
-      val semigroup = if (isMonoid) "monoid" else "semigroup"
-      val semigroupType = s"Tuple${aggrCount}${semigroup.capitalize}"
+      val semigroupType = if (isMonoid) "monoid" else "semigroup"
 
       val bs = aggrNums.map("B" + _).mkString(", ")
       val tupleBs = s"Tuple${aggrCount}[$bs]"
@@ -93,9 +92,9 @@ object MapAggregator {
       |    def prepare(a: A) = (
       |      ${aggrNums.map(i => s"agg${i}._2.prepare(a)").mkString(", ")}
       |    )
-      |    // a field for combined semigroup/monoid
-      |    val $semigroup = new $semigroupType()(
-      |      ${aggrNums.map(i => s"agg${i}._2.$semigroup").mkString(", ")}
+      |    // a field for semigroup/monoid that combines all input aggregators
+      |    val $semigroupType = new Tuple${aggrCount}${semigroupType.capitalize}()(
+      |      ${aggrNums.map(i => s"agg${i}._2.$semigroupType").mkString(", ")}
       |    )
       |    def present(b: $tupleBs) = Map(
       |      ${aggrNums.map(i => s"agg${i}._1 -> agg${i}._2.present(b._${i})").mkString(", ")}


### PR DESCRIPTION
- use string interpolation instead of .format()
- inline `prepare`, `present`, `semigroup`
- use more clear variable names:
  - rename i to aggrCount
  - rename nums to aggrNums
  - rename semiType to semigroup (it refers to field name, not type), add semigroupType which actually refers to type

@johnynek 