### PR TITLE
Upgrade scalacheck and scalatest

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/VectorSpaceProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/VectorSpaceProperties.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird
 
+import org.scalacheck.{ Gen, Arbitrary }
+
 class VectorSpaceProperties extends CheckProperties {
   import com.twitter.algebird.BaseVectorSpaceProperties._
 
@@ -30,6 +32,8 @@ class VectorSpaceProperties extends CheckProperties {
       }
     }
   }
+
+  implicit val genDouble = Arbitrary{ Gen.choose(-1.0E50, 1.0E50) }
 
   property("map int double scaling") {
     vectorSpaceLaws[Double, ({ type x[a] = Map[Int, a] })#x](mapEqFn(_, _))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -157,8 +157,8 @@ object AlgebirdBuild extends Build {
 
   lazy val algebirdTest = module("test").settings(
     libraryDependencies <++= (scalaVersion) { scalaVersion =>
-      Seq("org.scalacheck" %% "scalacheck" % "1.11.5",
-          "org.scalatest" %% "scalatest" % "2.2.2") ++ {
+      Seq("org.scalacheck" %% "scalacheck" % "1.12.4",
+          "org.scalatest" %% "scalatest" % "2.2.4") ++ {
         if (isScala210x(scalaVersion))
           Seq("org.scalamacros" %% "quasiquotes" % quasiquotesVersion)
         else


### PR DESCRIPTION
Supersedes https://github.com/twitter/algebird/pull/431 as per @ianoc's suggestion, now with an even newer version of scalacheck and all tests passing locally (at least).