### PR TITLE
Speed up HLL presentation by 100x

### DIFF
--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/HLLPresentBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/HLLPresentBenchmark.scala
@@ -1,6 +1,6 @@
 package com.twitter.algebird.benchmark
 
-import com.twitter.algebird.{ HyperLogLogMonoid, HLL }
+import com.twitter.algebird.{ HyperLogLogMonoid, HLL, SparseHLL, DenseHLL }
 import com.twitter.bijection._
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
@@ -38,10 +38,18 @@ object HLLPresentBenchmark {
 class HLLPresentBenchmark {
   import HLLPresentBenchmark._
 
+  //don't cache the lazy values
+  def clone(hll: HLL): HLL = {
+    hll match {
+      case SparseHLL(bits, maxRhow) => SparseHLL(bits, maxRhow)
+      case DenseHLL(bits, v) => DenseHLL(bits, v)
+    }
+  }
+
   @Benchmark
   def timeBatchCreate(state: HLLPresentState, bh: Blackhole) = {
     state.data.foreach { hll =>
-      bh.consume(hll.approximateSize)
+      bh.consume(clone(hll).approximateSize)
     }
   }
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -358,7 +358,7 @@ case class SparseHLL(bits: Int, maxRhow: Map[Int, Max[Byte]]) extends HLL {
 
   lazy val zeroCnt = size - maxRhow.size
 
-  lazy val z = 1.0 / (zeroCnt.toDouble + maxRhow.values.map { mj => HyperLogLog.twopow(-mj.get) }.sum)
+  lazy val z = 1.0 / (zeroCnt.toDouble + maxRhow.values.map { mj => 1.0 / (1 << mj.get) }.sum)
 
   def +(other: HLL) = {
 
@@ -447,7 +447,7 @@ case class DenseHLL(bits: Int, v: Bytes) extends HLL {
         count += 1
         res += 1.0
       } else {
-        res += java.lang.Math.pow(2.0, -mj)
+        res += 1.0 / (1 << mj)
       }
       idx += 1
     }

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -43,6 +43,8 @@ object HyperLogLog {
   /* Size of the hash in bits */
   val hashSize = 128
 
+  val powersOfNegativeTwo: Array[Double] = 0.until(hashSize).map{ i => math.pow(2.0, -i) }.toArray
+
   def hash(input: Array[Byte]): Array[Byte] = {
     val (l0, l1) = Hash128.arrayByteHash.hash(input)
     pairLongs2Bytes(l0, l1)
@@ -358,7 +360,7 @@ case class SparseHLL(bits: Int, maxRhow: Map[Int, Max[Byte]]) extends HLL {
 
   lazy val zeroCnt = size - maxRhow.size
 
-  lazy val z = 1.0 / (zeroCnt.toDouble + maxRhow.values.map { mj => 1.0 / (1 << mj.get) }.sum)
+  lazy val z = 1.0 / (zeroCnt.toDouble + maxRhow.values.map { mj => HyperLogLog.powersOfNegativeTwo(mj.get) }.sum)
 
   def +(other: HLL) = {
 
@@ -447,7 +449,7 @@ case class DenseHLL(bits: Int, v: Bytes) extends HLL {
         count += 1
         res += 1.0
       } else {
-        res += 1.0 / (1 << mj)
+        res += HyperLogLog.powersOfNegativeTwo(mj)
       }
       idx += 1
     }


### PR DESCRIPTION
This changes the use of `math.pow(2.0,-mj)` when computing the estimates in `SparseHLL` and `DenseHLL` to `1.0 / (1 << mj)`.

To benchmark the difference this makes, I first had to change the `HLLPresentBenchmark` to clone the `HLL` instances before asking for their `approximateSize`, otherwise the estimate gets cached as a lazy val and the benchmarks are meaningless.

Having done that, you can see a dramatic difference. Because I'm impatient I have so far only run this with a single set of parameters, where it led to a 40x speedup.

Before:
````
[info] Benchmark                            (bits)  (max)  (numHLL)   Mode  Cnt    Score   Error  Units
[info] HLLPresentBenchmark.timeBatchCreate      12  10000        10  thrpt  200  141.569 ± 5.010  ops/s
````

After:
````
[info] Benchmark                            (bits)  (max)  (numHLL)   Mode  Cnt     Score    Error  Units
[info] HLLPresentBenchmark.timeBatchCreate      12  10000        10  thrpt  200  5984.351 ± 60.770  ops/s
````