### PR TITLE
Add Accurate Count-Distinct aggregator (RoaringBitmap)

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/RoaringBitmapAggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/RoaringBitmapAggregator.scala
@@ -1,0 +1,41 @@
+/*
+Copyright 2015 Vinted.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird
+
+import org.roaringbitmap._
+
+object ExactCountDistinct {
+  implicit val monoid = new RoaringBitampMonoid()
+
+  /**
+   * Accurate Count-Distinct for integer values (<= 2,147,483,646)
+   * Internally, this uses `RoaringBitmap`, a compressed alternative to `BitSet`.
+   */
+  def accurateDistinctAggregator: MonoidAggregator[Int, RoaringBitmap, Int] = {
+    Aggregator.prepareMonoid { value: Int =>
+      RoaringBitmap.bitmapOf(value)
+    }.andThenPresent(_.getCardinality)
+  }
+}
+
+class RoaringBitampSemigroup extends Semigroup[RoaringBitmap] {
+  def plus(l: RoaringBitmap, r: RoaringBitmap): RoaringBitmap = RoaringBitmap.or(l, r)
+}
+
+class RoaringBitampMonoid extends RoaringBitampSemigroup with Monoid[RoaringBitmap] {
+  def zero = new RoaringBitmap()
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -143,7 +143,7 @@ object AlgebirdBuild extends Build {
                        """.stripMargin('|'),
     libraryDependencies <++= (scalaVersion) { scalaVersion =>
       Seq("com.googlecode.javaewah" % "JavaEWAH" % "0.6.6",
-          "org.roaringbitmap" % "RoaringBitmap" % "0.4.9",
+          "org.roaringbitmap" % "RoaringBitmap" % "0.5.4",
           "org.scala-lang" % "scala-reflect" % scalaVersion) ++ {
         if (isScala210x(scalaVersion))
           Seq("org.scalamacros" %% "quasiquotes" % quasiquotesVersion)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -143,6 +143,7 @@ object AlgebirdBuild extends Build {
                        """.stripMargin('|'),
     libraryDependencies <++= (scalaVersion) { scalaVersion =>
       Seq("com.googlecode.javaewah" % "JavaEWAH" % "0.6.6",
+          "org.roaringbitmap" % "RoaringBitmap" % "0.4.9",
           "org.scala-lang" % "scala-reflect" % scalaVersion) ++ {
         if (isScala210x(scalaVersion))
           Seq("org.scalamacros" %% "quasiquotes" % quasiquotesVersion)


### PR DESCRIPTION
Internally, this uses `RoaringBitmap`, a compressed alternative to `BitSet` (it's rather fast, and used commonly in projects as `spark`, `druid` etc).

This is very simple, but IMHO algebird is still missing this :)

I'll add tests if you'll be willing to merge it (our tests are currently Spark/DataFrame dependent)

@johnynek
