### PR TITLE
A Library of Binary Tree Algorithms as Mixable Scala Traits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: scala
 sudo: false
-matrix:
-  include:
-    - scala: 2.10.5
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean test
-
-    - scala: 2.11.7
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean test
+scala:
+  - 2.10.5
+  - 2.11.7
+script:
+  - ./sbt ++$TRAVIS_SCALA_VERSION clean compile
+  - ./sbt ++$TRAVIS_SCALA_VERSION test

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
@@ -84,6 +84,7 @@ package tree {
 import tree._
 
 package infra {
+  /** Dependency injection for [[IncrementMap]].  Supplies implementations of all abstract methods */
   class Inject[K, V](val keyOrdering: Ordering[K], val valueMonoid: Monoid[V])
     extends Serializable {
     def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
@@ -123,19 +123,7 @@ trait IncrementMapLike[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, I
 sealed trait IncrementMap[K, V] extends SortedMap[K, V]
   with IncrementMapLike[K, V, INodeInc[K, V], IncrementMap[K, V]] {
 
-  type IN2[V2] = INodeInc[K, V2]
-  type M2[V2] = IncrementMap[K, V2]
-
   override def empty = IncrementMap.key(keyOrdering).value(valueMonoid)
-
-  def +[V2 >: V](kv2: (K, V2)) = kv2 match {
-    case kv: (K, V) => this.insert(
-      new DataMap[K, V] {
-        val key = kv._1
-        val value = kv._2
-      }).asInstanceOf[IncrementMap[K, V2]]
-    case _ => throw new Exception("insertion may not widen type of IncrementMap")
-  }
 
   override def toString =
     "IncrementMap(" +

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
@@ -30,7 +30,7 @@ object tree {
   /** Base trait of R/B tree nodes supporting increment */
   trait NodeInc[K, V] extends NodeMap[K, V] {
     /** The monoid that defines what it means to increment a value */
-    val valueMonoid: Monoid[V]
+    def valueMonoid: Monoid[V]
 
     /** Increment the value at a key, by another value */
     private[increment] final def incr(di: DataMap[K, V]) = blacken(inc(di))
@@ -51,8 +51,8 @@ object tree {
 
   /** Internal R/B node supporting increment */
   trait INodeInc[K, V] extends NodeInc[K, V] with INodeMap[K, V] {
-    val lsub: NodeInc[K, V]
-    val rsub: NodeInc[K, V]
+    def lsub: NodeInc[K, V]
+    def rsub: NodeInc[K, V]
 
     final def inc(di: DataMap[K, V]) =
       if (color == R) {

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
@@ -26,7 +26,7 @@ import com.twitter.algebird.maps.redblack.tree._
 import com.twitter.algebird.maps.ordered._
 import com.twitter.algebird.maps.ordered.tree.DataMap
 
-object tree {
+package tree {
   import com.twitter.algebird.maps.ordered.tree._
 
   /** Base trait of R/B tree nodes supporting increment */
@@ -83,7 +83,7 @@ object tree {
 
 import tree._
 
-object infra {
+package infra {
   class Inject[K, V](val keyOrdering: Ordering[K], val valueMonoid: Monoid[V])
     extends Serializable {
     def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
@@ -1,0 +1,153 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.maps.increment
+
+import math.Ordering
+
+import com.twitter.algebird.Monoid
+
+import com.twitter.algebird.maps.redblack.tree._
+import com.twitter.algebird.maps.ordered._
+import com.twitter.algebird.maps.ordered.tree.DataMap
+
+object tree {
+  import com.twitter.algebird.maps.ordered.tree._
+
+  /** Base trait of R/B tree nodes supporting increment */
+  trait NodeInc[K, V] extends NodeMap[K, V] {
+    /** The monoid that defines what it means to increment a value */
+    val valueMonoid: Monoid[V]
+
+    /** Increment the value at a key, by another value */
+    private[increment] final def incr(di: DataMap[K, V]) = blacken(inc(di))
+
+    private[tree] def inc(di: DataMap[K, V]): Node[K]
+  }
+
+  /** Leaf R/B node supporting increment */
+  trait LNodeInc[K, V] extends NodeInc[K, V] with LNodeMap[K, V] {
+    final def inc(di: DataMap[K, V]) = {
+      val d = new DataMap[K, V] {
+        val key = di.key
+        val value = valueMonoid.plus(valueMonoid.zero, di.value)
+      }
+      rNode(d, this, this)
+    }
+  }
+
+  /** Internal R/B node supporting increment */
+  trait INodeInc[K, V] extends NodeInc[K, V] with INodeMap[K, V] {
+    val lsub: NodeInc[K, V]
+    val rsub: NodeInc[K, V]
+
+    final def inc(di: DataMap[K, V]) =
+      if (color == R) {
+        if (keyOrdering.lt(di.key, data.key)) rNode(data, lsub.inc(di), rsub)
+        else if (keyOrdering.gt(di.key, data.key)) rNode(data, lsub, rsub.inc(di))
+        else {
+          val d = new DataMap[K, V] {
+            val key = data.key
+            val value = valueMonoid.plus(data.value, di.value)
+          }
+          rNode(d, lsub, rsub)
+        }
+      } else {
+        if (keyOrdering.lt(di.key, data.key)) balance(bNode(data, lsub.inc(di), rsub))
+        else if (keyOrdering.gt(di.key, data.key)) balance(bNode(data, lsub, rsub.inc(di)))
+        else {
+          val d = new DataMap[K, V] {
+            val key = data.key
+            val value = valueMonoid.plus(data.value, di.value)
+          }
+          bNode(d, lsub, rsub)
+        }
+      }
+  }
+}
+
+import tree._
+
+object infra {
+  class Inject[K, V](val keyOrdering: Ordering[K], val valueMonoid: Monoid[V])
+    extends Serializable {
+    def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
+      new Inject[K, V](keyOrdering, valueMonoid) with INodeInc[K, V] with IncrementMap[K, V] {
+        // INode[K]
+        val color = clr
+        val lsub = ls.asInstanceOf[NodeInc[K, V]]
+        val rsub = rs.asInstanceOf[NodeInc[K, V]]
+        val data = dat.asInstanceOf[DataMap[K, V]]
+      }
+  }
+}
+
+import infra._
+
+/**
+ * An inheritable and mixable trait for adding increment operation to ordered maps
+ * @tparam K The key type
+ * @tparam V The value type
+ * @tparam IN The node type of the concrete internal R/B tree subclass
+ * @tparam M The map self-type of the concrete map subclass
+ */
+trait IncrementMapLike[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, IN, M]]
+  extends NodeInc[K, V] with OrderedMapLike[K, V, IN, M] {
+
+  /**
+   * Add (w.r.t. valueMonoid) a given value to the value currently stored at key.
+   * @note If key is not present, equivalent to insert(k, valueMonoid.plus(valueMonoid.zero, iv)
+   */
+  def increment(k: K, iv: V) = this.incr(
+    new DataMap[K, V] {
+      val key = k
+      val value = iv
+    }).asInstanceOf[M]
+}
+
+sealed trait IncrementMap[K, V] extends IncrementMapLike[K, V, INodeInc[K, V], IncrementMap[K, V]] {
+  override def toString =
+    "IncrementMap(" +
+      nodesIterator.map(n => s"${n.data.key} -> ${n.data.value}").mkString(", ") +
+      ")"
+}
+
+object IncrementMap {
+  /**
+   * Instantiate a new empty IncrementMap from key and value types
+   * {{{
+   * import com.twitter.algebird.maps.increment._
+   *
+   * // map strings to integers, using default string ordering and default value monoid
+   * val map1 = IncrementMap.key[String].value[Int]
+   * // Use a custom ordering
+   * val ord: Ordering[String] = ...
+   * val map2 = IncrementMap.key(ord).value[Int]
+   * // A custom value monoid, defines what 'increment' means
+   * val mon: Monoid[Int] = ...
+   * val map2 = IncrementMap.key[String].value(mon)
+   * }}}
+   */
+  def key[K](implicit ord: Ordering[K]) = infra.GetValue(ord)
+
+  object infra {
+    /** Mediating class between key method and value method */
+    case class GetValue[K](ord: Ordering[K]) {
+      def value[V](implicit mon: Monoid[V]): IncrementMap[K, V] =
+        new Inject[K, V](ord, mon) with LNodeInc[K, V] with IncrementMap[K, V]
+    }
+  }
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
@@ -113,7 +113,7 @@ trait IncrementMapLike[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, I
    * Add (w.r.t. valueMonoid) a given value to the value currently stored at key.
    * @note If key is not present, equivalent to insert(k, valueMonoid.plus(valueMonoid.zero, iv)
    */
-  def increment(k: K, iv: V) = this.incr(
+  def increment(k: K, iv: V): M = this.incr(
     new DataMap[K, V] {
       val key = k
       val value = iv
@@ -147,7 +147,7 @@ object IncrementMap {
    * val map2 = IncrementMap.key[String].value(mon)
    * }}}
    */
-  def key[K](implicit ord: Ordering[K]) = infra.GetValue(ord)
+  def key[K](implicit ord: Ordering[K]): infra.GetValue[K] = infra.GetValue(ord)
 
   object infra {
     /** Mediating class between key method and value method */

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/increment.scala
@@ -18,6 +18,8 @@ package com.twitter.algebird.maps.increment
 
 import math.Ordering
 
+import scala.collection.SortedMap
+
 import com.twitter.algebird.Monoid
 
 import com.twitter.algebird.maps.redblack.tree._
@@ -104,7 +106,7 @@ import infra._
  * @tparam IN The node type of the concrete internal R/B tree subclass
  * @tparam M The map self-type of the concrete map subclass
  */
-trait IncrementMapLike[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, IN, M] with Map[K, V]]
+trait IncrementMapLike[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, IN, M] with SortedMap[K, V]]
   extends NodeInc[K, V] with OrderedMapLike[K, V, IN, M] {
 
   /**
@@ -118,7 +120,8 @@ trait IncrementMapLike[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, I
     }).asInstanceOf[M]
 }
 
-sealed trait IncrementMap[K, V] extends Map[K, V] with IncrementMapLike[K, V, INodeInc[K, V], IncrementMap[K, V]] {
+sealed trait IncrementMap[K, V] extends SortedMap[K, V]
+  with IncrementMapLike[K, V, INodeInc[K, V], IncrementMap[K, V]] {
 
   type IN2[V2] = INodeInc[K, V2]
   type M2[V2] = IncrementMap[K, V2]

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
@@ -28,7 +28,7 @@ case class Cover[+T](l: Option[T], r: Option[T]) {
   def map[U](f: T => U) = Cover(l.map(f), r.map(f))
 }
 
-object tree {
+package tree {
   import com.twitter.algebird.maps.ordered.tree._
 
   /** Base trait of R/B tree nodes supporting nearest-key query */
@@ -140,7 +140,7 @@ object tree {
 
 import tree._
 
-object infra {
+package infra {
   class InjectSet[K](val keyOrdering: Numeric[K]) extends Serializable {
     def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
       new InjectSet[K](keyOrdering) with INodeNear[K] with NearestSet[K] {

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
@@ -141,6 +141,7 @@ package tree {
 import tree._
 
 package infra {
+  /** Dependency injection for [[NearestSet]].  Supplies implementations of all abstract methods */
   class InjectSet[K](val keyOrdering: Numeric[K]) extends Serializable {
     def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
       new InjectSet[K](keyOrdering) with INodeNear[K] with NearestSet[K] {
@@ -161,6 +162,7 @@ package infra {
       }
   }
 
+  /** Dependency injection for [[NearestMap]].  Supplies implementations of all abstract methods */
   class InjectMap[K, V](val keyOrdering: Numeric[K]) extends Serializable {
     def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
       new InjectMap[K, V](keyOrdering) with INodeNearMap[K, V] with NearestMap[K, V] {

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
@@ -32,7 +32,7 @@ object tree {
   /** Base trait of R/B tree nodes supporting nearest-key query */
   trait NodeNear[K] extends Node[K] {
     /** Ordering that also supports linear distance |x-y| */
-    val keyOrdering: Numeric[K] // <: Ordering[K]
+    def keyOrdering: Numeric[K] // <: Ordering[K]
 
     /** Obtain the nearest nodes to a given key */
     private[nearest] def near(k: K): Seq[INodeNear[K]]
@@ -52,11 +52,11 @@ object tree {
 
   /** Internal R/B tree nodes supporting nearest-key query */
   trait INodeNear[K] extends NodeNear[K] with INode[K] {
-    val lsub: NodeNear[K]
-    val rsub: NodeNear[K]
+    def lsub: NodeNear[K]
+    def rsub: NodeNear[K]
 
-    val kmin: K
-    val kmax: K
+    def kmin: K
+    def kmax: K
 
     final def covL(k: K) = {
       if (keyOrdering.lteq(k, data.key)) {

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
@@ -18,6 +18,8 @@ package com.twitter.algebird.maps.nearest
 
 import math.Numeric
 
+import scala.collection.{ SortedSet, SortedMap }
+
 import com.twitter.algebird.maps.redblack.tree._
 import com.twitter.algebird.maps.ordered._
 import com.twitter.algebird.maps.ordered.tree.DataMap
@@ -216,7 +218,7 @@ trait NearestLike[K, +IN <: INodeNear[K], +M <: NearestLike[K, IN, M]]
  * @tparam IN The node type of the concrete internal R/B tree subclass
  * @tparam M The self-type of the concrete container
  */
-trait NearestSetLike[K, IN <: INodeNear[K], M <: NearestSetLike[K, IN, M] with Set[K]]
+trait NearestSetLike[K, IN <: INodeNear[K], M <: NearestSetLike[K, IN, M] with SortedSet[K]]
   extends NearestLike[K, IN, M] with OrderedSetLike[K, IN, M] {
 
   /**
@@ -238,7 +240,7 @@ trait NearestSetLike[K, IN <: INodeNear[K], M <: NearestSetLike[K, IN, M] with S
  * @tparam IN The node type of the concrete internal R/B tree subclass
  * @tparam M The self-type of the concrete container
  */
-trait NearestMapLike[K, +V, +IN <: INodeNearMap[K, V], +M <: NearestMapLike[K, V, IN, M] with Map[K, V]]
+trait NearestMapLike[K, +V, +IN <: INodeNearMap[K, V], +M <: NearestMapLike[K, V, IN, M] with SortedMap[K, V]]
   extends NodeNearMap[K, V] with NearestLike[K, IN, M] with OrderedMapLike[K, V, IN, M] {
 
   /**
@@ -262,7 +264,8 @@ trait NearestMapLike[K, +V, +IN <: INodeNearMap[K, V], +M <: NearestMapLike[K, V
   }
 }
 
-sealed trait NearestSet[K] extends Set[K] with NearestSetLike[K, INodeNear[K], NearestSet[K]] {
+sealed trait NearestSet[K] extends SortedSet[K]
+  with NearestSetLike[K, INodeNear[K], NearestSet[K]] {
 
   override def empty = NearestSet.key(keyOrdering)
 
@@ -272,7 +275,7 @@ sealed trait NearestSet[K] extends Set[K] with NearestSetLike[K, INodeNear[K], N
       ")"
 }
 
-sealed trait NearestMap[K, +V] extends Map[K, V]
+sealed trait NearestMap[K, +V] extends SortedMap[K, V]
   with NearestMapLike[K, V, INodeNearMap[K, V], NearestMap[K, V]] {
 
   type IN2[V2] = INodeNearMap[K, V2]

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
@@ -278,16 +278,7 @@ sealed trait NearestSet[K] extends SortedSet[K]
 sealed trait NearestMap[K, +V] extends SortedMap[K, V]
   with NearestMapLike[K, V, INodeNearMap[K, V], NearestMap[K, V]] {
 
-  type IN2[V2] = INodeNearMap[K, V2]
-  type M2[V2] = NearestMap[K, V2]
-
   override def empty = NearestMap.key(keyOrdering).value[V]
-
-  def +[V2 >: V](kv: (K, V2)) = this.asInstanceOf[NearestMap[K, V2]].insert(
-    new DataMap[K, V2] {
-      val key = kv._1
-      val value = kv._2
-    }).asInstanceOf[NearestMap[K, V2]]
 
   override def toString =
     "NearestMap(" +

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
@@ -25,7 +25,7 @@ import com.twitter.algebird.maps.ordered._
 import com.twitter.algebird.maps.ordered.tree.DataMap
 
 case class Cover[+T](l: Option[T], r: Option[T]) {
-  def map[U](f: T => U) = Cover(l.map(f), r.map(f))
+  def map[U](f: T => U): Cover[U] = Cover(l.map(f), r.map(f))
 }
 
 package tree {
@@ -194,10 +194,10 @@ trait NearestLike[K, +IN <: INodeNear[K], +M <: NearestLike[K, IN, M]]
   extends NodeNear[K] with OrderedLike[K, IN, M] {
 
   /** Obtain the nodes nearest to a key */
-  def nearestNodes(k: K) = this.near(k).map(_.asInstanceOf[IN])
+  def nearestNodes(k: K): Seq[IN] = this.near(k).map(_.asInstanceOf[IN])
 
-  def coverLNodes(k: K) = this.covL(k)
-  def coverRNodes(k: K) = this.covR(k)
+  def coverLNodes(k: K): Cover[IN] = this.covL(k).map(_.asInstanceOf[IN])
+  def coverRNodes(k: K): Cover[IN] = this.covR(k).map(_.asInstanceOf[IN])
 
   /** Minimum key stored in this collection */
   def keyMin: Option[K] = this match {
@@ -227,10 +227,10 @@ trait NearestSetLike[K, IN <: INodeNear[K], M <: NearestSetLike[K, IN, M] with S
    * nearest will be returned (in key order).  If container is empty, an empty sequence
    * will be returned.
    */
-  def nearest(k: K) = this.near(k).map(_.data.key)
+  def nearest(k: K): Seq[K] = this.near(k).map(_.data.key)
 
-  def coverL(k: K) = this.covL(k).map(_.data.key)
-  def coverR(k: K) = this.covR(k).map(_.data.key)
+  def coverL(k: K): Cover[K] = this.covL(k).map(_.data.key)
+  def coverR(k: K): Cover[K] = this.covR(k).map(_.data.key)
 }
 
 /**
@@ -249,16 +249,16 @@ trait NearestMapLike[K, +V, +IN <: INodeNearMap[K, V], +M <: NearestMapLike[K, V
    * nearest will be returned (in key order).  If container is empty, an empty sequence
    * will be returned.
    */
-  def nearest(k: K) = this.near(k).map { n =>
+  def nearest(k: K): Seq[(K, V)] = this.near(k).map { n =>
     val dm = n.data.asInstanceOf[DataMap[K, V]]
     (dm.key, dm.value)
   }
 
-  def coverL(k: K) = this.covL(k).map { n =>
+  def coverL(k: K): Cover[(K, V)] = this.covL(k).map { n =>
     val dm = n.data.asInstanceOf[DataMap[K, V]]
     (dm.key, dm.value)
   }
-  def coverR(k: K) = this.covR(k).map { n =>
+  def coverR(k: K): Cover[(K, V)] = this.covR(k).map { n =>
     val dm = n.data.asInstanceOf[DataMap[K, V]]
     (dm.key, dm.value)
   }
@@ -316,7 +316,7 @@ object NearestMap {
    * val map2 = NearestMap.key(num).value[String]
    * }}}
    */
-  def key[K](implicit num: Numeric[K]) = infra.GetValue(num)
+  def key[K](implicit num: Numeric[K]): infra.GetValue[K] = infra.GetValue(num)
 
   object infra {
     /** Mediating class between key method and value method */

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/nearest.scala
@@ -1,0 +1,318 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.maps.nearest
+
+import math.Numeric
+
+import com.twitter.algebird.maps.redblack.tree._
+import com.twitter.algebird.maps.ordered._
+import com.twitter.algebird.maps.ordered.tree.DataMap
+
+case class Cover[T](l: Option[T], r: Option[T]) {
+  def map[U](f: T => U) = Cover(l.map(f), r.map(f))
+}
+
+object tree {
+  import com.twitter.algebird.maps.ordered.tree._
+
+  /** Base trait of R/B tree nodes supporting nearest-key query */
+  trait NodeNear[K] extends Node[K] {
+    /** Ordering that also supports linear distance |x-y| */
+    val keyOrdering: Numeric[K] // <: Ordering[K]
+
+    /** Obtain the nearest nodes to a given key */
+    private[nearest] def near(k: K): Seq[INodeNear[K]]
+
+    private[nearest] def covL(k: K): Cover[INodeNear[K]]
+    private[nearest] def covR(k: K): Cover[INodeNear[K]]
+
+    private[tree] final def dist(k1: K, k2: K) = keyOrdering.abs(keyOrdering.minus(k1, k2))
+  }
+
+  /** Leaf R/B tree nodes supporting nearest-key query */
+  trait LNodeNear[K] extends NodeNear[K] with LNode[K] {
+    final def near(k: K) = Seq.empty[INodeNear[K]]
+    final def covL(k: K) = Cover(None, None)
+    final def covR(k: K) = Cover(None, None)
+  }
+
+  /** Internal R/B tree nodes supporting nearest-key query */
+  trait INodeNear[K] extends NodeNear[K] with INode[K] {
+    val lsub: NodeNear[K]
+    val rsub: NodeNear[K]
+
+    val kmin: K
+    val kmax: K
+
+    final def covL(k: K) = {
+      if (keyOrdering.lteq(k, data.key)) {
+        lsub match {
+          case ls: INodeNear[K] => {
+            if (keyOrdering.lteq(k, ls.kmax)) ls.covL(k)
+            else Cover(Some(ls.node(ls.kmax).get.asInstanceOf[INodeNear[K]]), Some(this))
+          }
+          case _ => Cover(None, Some(this))
+        }
+      } else { // keyOrdering.gt(k, data.key)
+        rsub match {
+          case rs: INodeNear[K] => {
+            if (keyOrdering.gt(k, rs.kmin)) rs.covL(k)
+            else Cover(Some(this), Some(rs.node(rs.kmin).get.asInstanceOf[INodeNear[K]]))
+          }
+          case _ => Cover(Some(this), None)
+        }
+      }
+    }
+
+    final def covR(k: K) = {
+      if (keyOrdering.lt(k, data.key)) {
+        lsub match {
+          case ls: INodeNear[K] => {
+            if (keyOrdering.lt(k, ls.kmax)) ls.covR(k)
+            else Cover(Some(ls.node(ls.kmax).get.asInstanceOf[INodeNear[K]]), Some(this))
+          }
+          case _ => Cover(None, Some(this))
+        }
+      } else { // keyOrdering.gteq(k, data.key)
+        rsub match {
+          case rs: INodeNear[K] => {
+            if (keyOrdering.gteq(k, rs.kmin)) rs.covR(k)
+            else Cover(Some(this), Some(rs.node(rs.kmin).get.asInstanceOf[INodeNear[K]]))
+          }
+          case _ => Cover(Some(this), None)
+        }
+      }
+    }
+
+    final def near(k: K) = {
+      if (keyOrdering.lt(k, data.key)) {
+        lsub match {
+          case ls: INodeNear[K] => {
+            if (keyOrdering.lteq(k, ls.kmax)) ls.near(k)
+            else {
+              val (dk, ldk) = (dist(k, data.key), dist(k, ls.kmax))
+              if (keyOrdering.lt(dk, ldk)) Seq(this)
+              else if (keyOrdering.gt(dk, ldk))
+                Seq(ls.node(ls.kmax).get.asInstanceOf[INodeNear[K]])
+              else Seq(ls.node(ls.kmax).get.asInstanceOf[INodeNear[K]], this)
+            }
+          }
+          case _ => Seq(this)
+        }
+      } else if (keyOrdering.gt(k, data.key)) {
+        rsub match {
+          case rs: INodeNear[K] => {
+            if (keyOrdering.gteq(k, rs.kmin)) rs.near(k)
+            else {
+              val (dk, rdk) = (dist(k, data.key), dist(k, rs.kmin))
+              if (keyOrdering.lt(dk, rdk)) Seq(this)
+              else if (keyOrdering.gt(dk, rdk))
+                Seq(rs.node(rs.kmin).get.asInstanceOf[INodeNear[K]])
+              else Seq(this, rs.node(rs.kmin).get.asInstanceOf[INodeNear[K]])
+            }
+          }
+          case _ => Seq(this)
+        }
+      } else Seq(this)
+    }
+  }
+
+  trait NodeNearMap[K, V] extends NodeNear[K] with NodeMap[K, V]
+  trait LNodeNearMap[K, V] extends NodeNearMap[K, V] with LNodeNear[K] with LNodeMap[K, V]
+  trait INodeNearMap[K, V] extends NodeNearMap[K, V] with INodeNear[K] with INodeMap[K, V]
+}
+
+import tree._
+
+object infra {
+  class InjectSet[K](val keyOrdering: Numeric[K]) extends Serializable {
+    def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
+      new InjectSet[K](keyOrdering) with INodeNear[K] with NearestSet[K] {
+        // INode
+        val color = clr
+        val lsub = ls.asInstanceOf[NodeNear[K]]
+        val rsub = rs.asInstanceOf[NodeNear[K]]
+        val data = dat
+        // INodeNear
+        val kmin = lsub match {
+          case n: INodeNear[K] => n.kmin
+          case _ => data.key
+        }
+        val kmax = rsub match {
+          case n: INodeNear[K] => n.kmax
+          case _ => data.key
+        }
+      }
+  }
+
+  class InjectMap[K, V](val keyOrdering: Numeric[K]) extends Serializable {
+    def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
+      new InjectMap[K, V](keyOrdering) with INodeNearMap[K, V] with NearestMap[K, V] {
+        // INode
+        val color = clr
+        val lsub = ls.asInstanceOf[NodeNear[K]]
+        val rsub = rs.asInstanceOf[NodeNear[K]]
+        val data = dat.asInstanceOf[DataMap[K, V]]
+        // INodeNear
+        val kmin = lsub match {
+          case n: INodeNear[K] => n.kmin
+          case _ => data.key
+        }
+        val kmax = rsub match {
+          case n: INodeNear[K] => n.kmax
+          case _ => data.key
+        }
+      }
+  }
+}
+
+import infra._
+
+/**
+ * An inheritable and mixable trait for adding nearest-key query to ordered containers
+ * @tparam K The key type
+ * @tparam IN The node type of the concrete internal R/B tree subclass
+ * @tparam M The self-type of the concrete container
+ */
+trait NearestLike[K, IN <: INodeNear[K], M <: NearestLike[K, IN, M]]
+  extends NodeNear[K] with OrderedLike[K, IN, M] {
+
+  /** Obtain the nodes nearest to a key */
+  def nearestNodes(k: K) = this.near(k).map(_.asInstanceOf[IN])
+
+  def coverLNodes(k: K) = this.covL(k)
+  def coverRNodes(k: K) = this.covR(k)
+
+  /** Minimum key stored in this collection */
+  def keyMin: Option[K] = this match {
+    case n: INodeNear[K] => Some(n.kmin)
+    case _ => None
+  }
+
+  /** Maximum key stored in this collection */
+  def keyMax: Option[K] = this match {
+    case n: INodeNear[K] => Some(n.kmax)
+    case _ => None
+  }
+}
+
+/**
+ * An inheritable and mixable trait for adding nearest-key query to an ordered set
+ * @tparam K The key type
+ * @tparam IN The node type of the concrete internal R/B tree subclass
+ * @tparam M The self-type of the concrete container
+ */
+trait NearestSetLike[K, IN <: INodeNear[K], M <: NearestSetLike[K, IN, M]]
+  extends NearestLike[K, IN, M] with OrderedSetLike[K, IN, M] {
+
+  /**
+   * Return entries nearest to a given key.  The sequence that is returned may
+   * have zero, one or two elements.  If (k) is at the midpoint between two keys, the two
+   * nearest will be returned (in key order).  If container is empty, an empty sequence
+   * will be returned.
+   */
+  def nearest(k: K) = this.near(k).map(_.data.key)
+
+  def coverL(k: K) = this.covL(k).map(_.data.key)
+  def coverR(k: K) = this.covR(k).map(_.data.key)
+}
+
+/**
+ * An inheritable and mixable trait for adding nearest-key query to an ordered map
+ * @tparam K The key type
+ * @tparam V The value type
+ * @tparam IN The node type of the concrete internal R/B tree subclass
+ * @tparam M The self-type of the concrete container
+ */
+trait NearestMapLike[K, V, IN <: INodeNearMap[K, V], M <: NearestMapLike[K, V, IN, M]]
+  extends NodeNearMap[K, V] with NearestLike[K, IN, M] with OrderedMapLike[K, V, IN, M] {
+
+  /**
+   * Return entries nearest to a given key.  The sequence that is returned may
+   * have zero, one or two elements.  If (k) is at the midpoint between two keys, the two
+   * nearest will be returned (in key order).  If container is empty, an empty sequence
+   * will be returned.
+   */
+  def nearest(k: K) = this.near(k).map { n =>
+    val dm = n.data.asInstanceOf[DataMap[K, V]]
+    (dm.key, dm.value)
+  }
+
+  def coverL(k: K) = this.covL(k).map { n =>
+    val dm = n.data.asInstanceOf[DataMap[K, V]]
+    (dm.key, dm.value)
+  }
+  def coverR(k: K) = this.covR(k).map { n =>
+    val dm = n.data.asInstanceOf[DataMap[K, V]]
+    (dm.key, dm.value)
+  }
+}
+
+sealed trait NearestSet[K] extends NearestSetLike[K, INodeNear[K], NearestSet[K]] {
+  override def toString =
+    "NearestSet(" +
+      nodesIterator.map(n => s"${n.data.key}").mkString(", ") +
+      ")"
+}
+
+sealed trait NearestMap[K, V] extends NearestMapLike[K, V, INodeNearMap[K, V], NearestMap[K, V]] {
+  override def toString =
+    "NearestMap(" +
+      nodesIterator.map(n => s"${n.data.key} -> ${n.data.value}").mkString(", ") +
+      ")"
+}
+
+object NearestSet {
+  /**
+   * Instantiate a new empty NearestSet
+   * {{{
+   * import com.twitter.algebird.maps.nearest._
+   *
+   * // set of integers, using default Numeric[Int]
+   * val map1 = NearestSet.key[Int]
+   * // Use a custom numeric
+   * val num: Numeric[Int] = ...
+   * val map2 = NearestSet.key(num)
+   * }}}
+   */
+  def key[K](implicit num: Numeric[K]): NearestSet[K] =
+    new InjectSet[K](num) with LNodeNear[K] with NearestSet[K]
+}
+
+object NearestMap {
+  /**
+   * Instantiate a new empty NearestMap from key and value types
+   * {{{
+   * import com.twitter.algebird.maps.nearest._
+   *
+   * // map integers to strings, using default Numeric[Int]
+   * val map1 = NearestMap.key[Int].value[String]
+   * // Use a custom numeric
+   * val num: Numeric[Int] = ...
+   * val map2 = NearestMap.key(num).value[String]
+   * }}}
+   */
+  def key[K](implicit num: Numeric[K]) = infra.GetValue(num)
+
+  object infra {
+    /** Mediating class between key method and value method */
+    case class GetValue[K](num: Numeric[K]) {
+      def value[V]: NearestMap[K, V] =
+        new InjectMap[K, V](num) with LNodeNearMap[K, V] with NearestMap[K, V]
+    }
+  }
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/ordered.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/ordered.scala
@@ -110,6 +110,7 @@ package infra {
     }
   }
 
+  /** Dependency injection for [[OrderedSet]].  Supplies implementations of all abstract methods */
   class InjectSet[K](val keyOrdering: Ordering[K]) extends Serializable {
     def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
       new InjectSet[K](keyOrdering) with INode[K] with OrderedSet[K] {
@@ -121,6 +122,7 @@ package infra {
       }
   }
 
+  /** Dependency injection for [[OrderedMap]].  Supplies implementations of all abstract methods */
   class InjectMap[K, V](val keyOrdering: Ordering[K]) extends Serializable {
     def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
       new InjectMap[K, V](keyOrdering) with INodeMap[K, V] with OrderedMap[K, V] {

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/ordered.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/ordered.scala
@@ -23,7 +23,7 @@ import com.twitter.algebird.maps.redblack.tree._
 object tree {
   /** Trees that back a map-like object have a value as well as a key */
   trait DataMap[K, V] extends Data[K] {
-    val value: V
+    def value: V
 
     override def hashCode = key.hashCode + value.hashCode
     override def equals(that: Any) = that match {
@@ -42,7 +42,7 @@ object tree {
   trait LNodeMap[K, V] extends NodeMap[K, V] with LNode[K]
 
   trait INodeMap[K, V] extends NodeMap[K, V] with INode[K] {
-    val data: DataMap[K, V]
+    def data: DataMap[K, V]
   }
 }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/ordered.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/ordered.scala
@@ -1,0 +1,273 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.maps.ordered
+
+import math.Ordering
+
+import com.twitter.algebird.maps.redblack.tree._
+
+object tree {
+  /** Trees that back a map-like object have a value as well as a key */
+  trait DataMap[K, V] extends Data[K] {
+    val value: V
+
+    override def hashCode = key.hashCode + value.hashCode
+    override def equals(that: Any) = that match {
+      case data: DataMap[K, V] => this.key.equals(data.key) && this.value.equals(data.value)
+      case _ => false
+    }
+  }
+
+  /**
+   * Base class of ordered K/V tree node
+   * @tparam K The key type
+   * @tparam V The value type
+   */
+  trait NodeMap[K, V] extends Node[K]
+
+  trait LNodeMap[K, V] extends NodeMap[K, V] with LNode[K]
+
+  trait INodeMap[K, V] extends NodeMap[K, V] with INode[K] {
+    val data: DataMap[K, V]
+  }
+}
+
+import tree._
+
+object infra {
+  /** Iterator over internal nodes in a Red Black tree, performing in-order traversal */
+  class INodeIterator[K, IN <: INode[K]](node: IN) extends Iterator[IN] {
+    // At any point in time, only one iterator is stored, which is important because
+    // otherwise we'd instantiate all sub-iterators over the entire tree.  This way iterators
+    // get GC'd once they are spent, and only a linear stack is instantiated at any one time.
+    private var state = INodeIterator.stateL
+    private var itr = itrNext
+
+    def hasNext = itr.hasNext
+
+    def next = {
+      val v = itr.next
+      if (!itr.hasNext) itr = itrNext
+      v
+    }
+
+    // Get the next non-empty iterator if it exists, or an empty iterator otherwise
+    // Adhere to in-order state transition: left-subtree -> current -> right-subtree 
+    private def itrNext = {
+      var n = itrState
+      while (!n.hasNext && state < INodeIterator.stateR) n = itrState
+      n
+    }
+
+    // Get the iterator corresponding to next iteration state
+    private def itrState = {
+      val i = state match {
+        case INodeIterator.stateL => INodeIterator.apply[K, IN](node.lsub) // left subtree
+        case INodeIterator.stateC => Iterator.single(node) // current node
+        case INodeIterator.stateR => INodeIterator.apply[K, IN](node.rsub) // right subtree
+        case _ => Iterator.empty
+      }
+      state += 1
+      i
+    }
+  }
+
+  /** Factory and constants for INodeIterator */
+  object INodeIterator {
+    // Iteration states corresponding to in-order tree traversal 
+    private[infra] val stateL = 1 // iterating over left subtree
+    private[infra] val stateC = 2 // current node
+    private[infra] val stateR = 3 // iterating over right subtree
+
+    def apply[K, IN <: INode[K]](node: Node[K]) = node match {
+      case n: LNode[K] => Iterator.empty
+      case _ => new INodeIterator[K, IN](node.asInstanceOf[IN])
+    }
+  }
+
+  class InjectSet[K](val keyOrdering: Ordering[K]) extends Serializable {
+    def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
+      new InjectSet[K](keyOrdering) with INode[K] with OrderedSet[K] {
+        // INode
+        val color = clr
+        val lsub = ls
+        val rsub = rs
+        val data = dat
+      }
+  }
+
+  class InjectMap[K, V](val keyOrdering: Ordering[K]) extends Serializable {
+    def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
+      new InjectMap[K, V](keyOrdering) with INodeMap[K, V] with OrderedMap[K, V] {
+        // INode
+        val color = clr
+        val lsub = ls
+        val rsub = rs
+        val data = dat.asInstanceOf[DataMap[K, V]]
+      }
+  }
+}
+
+import infra._
+
+/**
+ * An inheritable (and mixable) trait representing Ordered container functionality that is
+ * backed by a Red/Black tree implemenation.
+ * @tparam K The key type
+ * @tparam IN The internal node type of the underlying R/B tree subclass
+ * @tparam M The container self-type of the concrete map subclass
+ */
+trait OrderedLike[K, IN <: INode[K], M <: OrderedLike[K, IN, M]] extends Node[K] {
+
+  /** Obtain a new container with key removed */
+  def -(k: K) = this.delete(k).asInstanceOf[M]
+
+  /** Get the internal node stored at at key, or None if key is not present */
+  def getNode(k: K) = this.node(k).map(_.asInstanceOf[IN])
+
+  /** Returns true if key is present in the container, false otherwise */
+  def contains(k: K) = this.node(k).isDefined
+
+  /** A container of underlying nodes, in key order */
+  def nodes = nodesIterator.toIterable
+
+  /** Iterator over nodes, in key order */
+  def nodesIterator: Iterator[IN] = INodeIterator.apply[K, IN](this)
+
+  /** A container of keys, in key order */
+  def keys = keysIterator.toIterable
+
+  /** Iterator over keys, in key order */
+  def keysIterator = nodesIterator.map(_.data.key)
+}
+
+/**
+ * An inheritable (and mixable) trait representing Ordered Set functionality that is
+ * backed by a Red/Black tree implemenation.
+ * @tparam K The key type
+ * @tparam IN The internal node type of the underlying R/B tree subclass
+ * @tparam M The map self-type of the concrete map subclass
+ */
+trait OrderedSetLike[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M]]
+  extends OrderedLike[K, IN, M] with Iterable[K] {
+
+  /** Obtain a new container with key inserted */
+  def +(k: K) = this.insert(
+    new Data[K] {
+      val key = k
+    }).asInstanceOf[M]
+
+  /** Iterator over keys, in key order */
+  def iterator: Iterator[K] = nodesIterator.map(_.data.key)
+
+  override def hashCode = scala.util.hashing.MurmurHash3.orderedHash(nodesIterator.map(_.data))
+  override def equals(that: Any) = that match {
+    case coll: OrderedSetLike[K, IN, M] => coll.sameElements(this)
+    case _ => false
+  }
+}
+
+/**
+ * An inheritable (and mixable) trait representing Ordered Map functionality that is
+ * backed by a Red/Black tree implemenation.
+ * @tparam K The key type
+ * @tparam V The value type
+ * @tparam IN The internal node type of the underlying R/B tree subclass
+ * @tparam M The map self-type of the concrete map subclass
+ */
+trait OrderedMapLike[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M]]
+  extends NodeMap[K, V] with OrderedLike[K, IN, M] with Iterable[(K, V)] {
+
+  /** Obtain a new map with a (key, val) pair inserted */
+  def +(kv: (K, V)) = this.insert(
+    new DataMap[K, V] {
+      val key = kv._1
+      val value = kv._2
+    }).asInstanceOf[M]
+
+  /** Get the value stored at a key, or None if key is not present */
+  def get(k: K) = this.getNode(k).map(_.data.value)
+
+  /** Iterator over (key,val) pairs, in key order */
+  def iterator: Iterator[(K, V)] = nodesIterator.map(n => ((n.data.key, n.data.value)))
+
+  /** Container of values, in key order */
+  def values = valuesIterator.toIterable
+
+  /** Iterator over values, in key order */
+  def valuesIterator = nodesIterator.map(_.data.value)
+
+  override def hashCode = scala.util.hashing.MurmurHash3.orderedHash(nodesIterator.map(_.data))
+  override def equals(that: Any) = that match {
+    case coll: OrderedMapLike[K, V, IN, M] => coll.sameElements(this)
+    case _ => false
+  }
+}
+
+sealed trait OrderedSet[K] extends OrderedSetLike[K, INode[K], OrderedSet[K]] {
+  override def toString =
+    "OrderedSet(" +
+      nodesIterator.map(n => s"${n.data.key}").mkString(", ") +
+      ")"
+}
+sealed trait OrderedMap[K, V] extends OrderedMapLike[K, V, INodeMap[K, V], OrderedMap[K, V]] {
+  override def toString =
+    "OrderedMap(" +
+      nodesIterator.map(n => s"${n.data.key} -> ${n.data.value}").mkString(", ") +
+      ")"
+}
+
+object OrderedSet {
+  /**
+   * Instantiate a new empty OrderedSet from key and value types
+   * {{{
+   * import com.twitter.algebird.maps.ordered._
+   *
+   * // map strings to integers, using default string ordering
+   * val set1 = OrderedSet.key[String]
+   * // Use a custom ordering
+   * val ord: Ordering[String] = ...
+   * val map2 = OrderedSet.key(ord)
+   * }}}
+   */
+  def key[K](implicit ord: Ordering[K]): OrderedSet[K] =
+    new InjectSet[K](ord) with LNode[K] with OrderedSet[K]
+}
+
+object OrderedMap {
+  /**
+   * Instantiate a new empty OrderedMap from key and value types
+   * {{{
+   * import com.twitter.algebird.maps.ordered._
+   *
+   * // map strings to integers, using default string ordering
+   * val map1 = OrderedMap.key[String].value[Int]
+   * // Use a custom ordering
+   * val ord: Ordering[String] = ...
+   * val map2 = OrderedMap.key(ord).value[Int]
+   * }}}
+   */
+  def key[K](implicit ord: Ordering[K]) = infra.GetValue(ord)
+
+  object infra {
+    /** Mediating class between key method and value method */
+    case class GetValue[K](ord: Ordering[K]) {
+      def value[V]: OrderedMap[K, V] =
+        new InjectMap[K, V](ord) with LNodeMap[K, V] with OrderedMap[K, V]
+    }
+  }
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/ordered.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/ordered.scala
@@ -25,7 +25,7 @@ import scala.collection.{ SortedSet, SortedMap, SetLike, SortedSetLike, SortedMa
 
 import com.twitter.algebird.maps.redblack.tree._
 
-object tree {
+package tree {
   /** Trees that back a map-like object have a value as well as a key */
   trait DataMap[K, +V] extends Data[K] {
     def value: V
@@ -53,7 +53,7 @@ object tree {
 
 import tree._
 
-object infra {
+package infra {
   class INodeIterator[IN <: INode[_]] extends Iterator[IN] {
     private[infra] val stack = scala.collection.mutable.Stack.empty[INode[_]]
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
@@ -79,6 +79,7 @@ import tree._
 package infra {
   import com.twitter.algebird.maps.ordered.tree.DataMap
 
+  /** Dependency injection for [[PrefixSumMap]].  Supplies implementations of all abstract methods */
   class Inject[K, V, P](val keyOrdering: Ordering[K], val prefixAggregator: MonoidAggregator[V, P, P])
     extends Serializable {
     def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
@@ -1,0 +1,219 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.maps.prefixsum
+
+import math.Ordering
+
+import com.twitter.algebird.{ Monoid, MonoidAggregator }
+
+import com.twitter.algebird.maps.redblack.tree._
+import com.twitter.algebird.maps.ordered._
+
+object tree {
+  import com.twitter.algebird.maps.ordered.tree._
+
+  /** Base trait for R/B nodes supporting prefix-sum query */
+  trait NodePS[K, V, P] extends NodeMap[K, V] {
+    /** Monoid with increment-by-element that defines semantics of prefix sum */
+    val prefixMonoid: IncrementingMonoid[P, V]
+
+    /**
+     * Obtain the prefix (cumulative) sum of values <= a given key 'k'.
+     * If 'open' is true, sums the open interval for keys strictly < k.
+     * If 'k' is not present in the map, then the sum for keys < k is returned.
+     */
+    final def prefixSum(k: K, open: Boolean = false) = pfSum(k, prefixMonoid.zero, open)
+
+    private[tree] def pfSum(k: K, sum: P, open: Boolean): P
+
+    // this has to be public to support injection
+    def pfs: P
+  }
+
+  /** Leaf node for R/B nodes supporting prefix-sum query */
+  trait LNodePS[K, V, P] extends NodePS[K, V, P] with LNodeMap[K, V] {
+    final def pfSum(k: K, sum: P, open: Boolean) = sum
+    final def pfs = prefixMonoid.zero
+  }
+
+  /** Internal node for R/B nodes supporting prefix-sum query */
+  trait INodePS[K, V, P] extends NodePS[K, V, P] with INodeMap[K, V] {
+    val lsub: NodePS[K, V, P]
+    val rsub: NodePS[K, V, P]
+
+    val prefix: P
+
+    final def pfSum(k: K, sum: P, open: Boolean) =
+      if (keyOrdering.lt(k, data.key))
+        lsub.pfSum(k, sum, open)
+      else if (keyOrdering.gt(k, data.key))
+        rsub.pfSum(k, prefixMonoid.inc(prefixMonoid.plus(sum, lsub.pfs), data.value), open)
+      else if (open)
+        prefixMonoid.plus(sum, lsub.pfs)
+      else
+        prefixMonoid.inc(prefixMonoid.plus(sum, lsub.pfs), data.value)
+
+    final def pfs = prefix
+  }
+}
+
+import tree._
+
+object infra {
+  import com.twitter.algebird.maps.ordered.tree.DataMap
+
+  class Inject[K, V, P](val keyOrdering: Ordering[K], val prefixMonoid: IncrementingMonoid[P, V])
+    extends Serializable {
+    def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
+      new Inject[K, V, P](keyOrdering, prefixMonoid) with INodePS[K, V, P] with PrefixSumMap[K, V, P] {
+        // INode[K]
+        val color = clr
+        val lsub = ls.asInstanceOf[NodePS[K, V, P]]
+        val rsub = rs.asInstanceOf[NodePS[K, V, P]]
+        val data = dat.asInstanceOf[DataMap[K, V]]
+        // INodePS[K, V, P]
+        val prefix = prefixMonoid.inc(prefixMonoid.plus(lsub.pfs, rsub.pfs), data.value)
+      }
+  }
+
+}
+
+import infra._
+
+/**
+ * An inheritable and mixable trait for adding prefix sum query to ordered maps
+ * @tparam K The key type
+ * @tparam V The value type
+ * @tparam P The prefix sum type
+ * @tparam IN The node type of the concrete internal R/B tree subclass
+ * @tparam M The map self-type of the concrete map subclass
+ */
+trait PrefixSumMapLike[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K, V, P, IN, M]]
+  extends NodePS[K, V, P] with OrderedMapLike[K, V, IN, M] {
+
+  /**
+   * A container of all prefix sums over the stored values.  If 'open' is true,
+   * the sums will be for strictly < each key.
+   */
+  def prefixSums(open: Boolean = false) = prefixSumsIterator(open).toIterable
+
+  /**
+   * Iterate over prefix sums for stored values.  If 'open' is true,
+   * the sums will be for strictly < each key.
+   */
+  def prefixSumsIterator(open: Boolean = false) = {
+    val itr = valuesIterator.scanLeft(prefixMonoid.zero)((p, e) => prefixMonoid.inc(p, e))
+    if (open) itr.takeWhile(_ => itr.hasNext) else itr.drop(1)
+  }
+
+  /** equivalent to prefixSum of the right-most key */
+  def sum = this match {
+    case n: INodePS[K, V, P] => n.prefix
+    case _ => prefixMonoid.zero
+  }
+}
+
+sealed trait PrefixSumMap[K, V, P]
+  extends PrefixSumMapLike[K, V, P, INodePS[K, V, P], PrefixSumMap[K, V, P]] {
+
+  override def toString =
+    "PrefixSumMap(" +
+      iterator.zip(prefixSumsIterator())
+      .map(x => s"${x._1._1} -> (${x._1._2}, ${x._2})").mkString(", ") +
+      ")"
+}
+
+object PrefixSumMap {
+  /**
+   * Instantiate a new empty PrefixSumMap from key, value and prefix types
+   * {{{
+   * import com.twitter.algebird.maps.prefixsum._
+   *
+   * // map strings to integers, using default ordering and standard integer monoid
+   * val map1 = PrefixSumMap.key[String].value[Int].prefix(IncrementingMonoid.fromMonoid[Int])
+   * // Use a custom ordering
+   * val ord: Ordering[String] = ...
+   * val map2 = PrefixSumMap.key(ord).value[Int].prefix(IncrementingMonoid.fromMonoid[Int])
+   * }}}
+   */
+  def key[K](implicit ord: Ordering[K]) = infra.GetValue(ord)
+
+  object infra {
+    /** Mediating class between key method and value method */
+    case class GetValue[K](ord: Ordering[K]) {
+      def value[V] = GetPrefix[K, V](ord)
+    }
+
+    /** Mediating class between value method and prefix method */
+    case class GetPrefix[K, V](ord: Ordering[K]) {
+      def prefix[P](implicit mon: IncrementingMonoid[P, V]): PrefixSumMap[K, V, P] =
+        new Inject[K, V, P](ord, mon) with LNodePS[K, V, P] with PrefixSumMap[K, V, P]
+    }
+  }
+}
+
+/**
+ * A monoid that also supports an 'increment' operation.  This class is intended to encode
+ * semantics similar to Scala's seq.aggregate(z)(seqop,combop), where the standard
+ * Monoid 'plus' corresponds to 'combop' and the 'inc' method corresponds to 'seqop'.
+ */
+trait IncrementingMonoid[T, E] extends Monoid[T] {
+  /** increment a monoid 't' by an element value 'e', and return the result */
+  def inc(t: T, e: E): T
+}
+
+/** Factory methods for instantiating incrementing monoids */
+object IncrementingMonoid {
+  /**
+   * Create an incrementing monoid from a MonoidAggregator object.
+   * 'zero' and 'plus' are inherited from agg.monoid.
+   * 'inc' is defined by: agg.monoid.plus(t,agg.prepare(e))
+   */
+  def fromMonoidAggregator[T, E](agg: MonoidAggregator[E, T, T]) = new IncrementingMonoid[T, E] {
+    def zero = agg.monoid.zero
+    def plus(l: T, r: T) = agg.monoid.plus(l, r)
+    def inc(t: T, e: E) = agg.monoid.plus(t, agg.prepare(e))
+  }
+
+  /**
+   * Create an incrementing monoid from a Monoid object.
+   * 'zero' and 'plus' are inherited from monoid.
+   * 'inc' is equivalent to 'plus'
+   */
+  def fromMonoid[T](implicit monoid: Monoid[T]) = new IncrementingMonoid[T, T] {
+    def zero = monoid.zero
+    def plus(l: T, r: T) = monoid.plus(l, r)
+    def inc(t: T, e: T) = monoid.plus(t, e)
+  }
+
+  /**
+   * Create an incrementing monoid from zero, plus and inc
+   * {{{
+   * IncrementingMonoid.zero(0).plus(_ + _).inc(_ + _)
+   * IncrementingMonoid.zero(Set.empty[Int].plus(_ ++ _).inc[Int](_ + _)
+   * }}}
+   */
+  def zero[T](z: T) = new AnyRef {
+    def plus(p: (T, T) => T) = new AnyRef {
+      def inc[E](i: (T, E) => T) = new IncrementingMonoid[T, E] {
+        def zero = z
+        def plus(l: T, r: T) = p(l, r)
+        def inc(t: T, e: E) = i(t, e)
+      }
+    }
+  }
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
@@ -26,7 +26,7 @@ import com.twitter.algebird.maps.redblack.tree._
 import com.twitter.algebird.maps.ordered._
 import com.twitter.algebird.maps.ordered.tree.DataMap
 
-object tree {
+package tree {
   import com.twitter.algebird.maps.ordered.tree._
 
   /** Base trait for R/B nodes supporting prefix-sum query */
@@ -76,7 +76,7 @@ object tree {
 
 import tree._
 
-object infra {
+package infra {
   import com.twitter.algebird.maps.ordered.tree.DataMap
 
   class Inject[K, V, P](val keyOrdering: Ordering[K], val prefixMonoid: IncrementingMonoid[P, V])

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
@@ -133,19 +133,7 @@ trait PrefixSumMapLike[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K,
 sealed trait PrefixSumMap[K, V, P] extends SortedMap[K, V]
   with PrefixSumMapLike[K, V, P, INodePS[K, V, P], PrefixSumMap[K, V, P]] {
 
-  type IN2[V2] = INodePS[K, V2, P]
-  type M2[V2] = PrefixSumMap[K, V2, P]
-
   override def empty = PrefixSumMap.key(keyOrdering).value[V].prefix(prefixMonoid)
-
-  def +[V2 >: V](kv2: (K, V2)) = kv2 match {
-    case kv: (K, V) => this.insert(
-      new DataMap[K, V] {
-        val key = kv._1
-        val value = kv._2
-      }).asInstanceOf[PrefixSumMap[K, V2, P]]
-    case _ => throw new Exception("insertion may not widen type of PrefixSumMap")
-  }
 
   override def toString =
     "PrefixSumMap(" +

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
@@ -39,7 +39,7 @@ package tree {
      * If 'open' is true, sums the open interval for keys strictly < k.
      * If 'k' is not present in the map, then the sum for keys < k is returned.
      */
-    final def prefixSum(k: K, open: Boolean = false) = pfSum(k, prefixMonoid.zero, open)
+    final def prefixSum(k: K, open: Boolean = false): P = pfSum(k, prefixMonoid.zero, open)
 
     private[tree] def pfSum(k: K, sum: P, open: Boolean): P
 
@@ -112,19 +112,19 @@ trait PrefixSumMapLike[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K,
    * A container of all prefix sums over the stored values.  If 'open' is true,
    * the sums will be for strictly < each key.
    */
-  def prefixSums(open: Boolean = false) = prefixSumsIterator(open).toIterable
+  def prefixSums(open: Boolean = false): Iterable[P] = prefixSumsIterator(open).toIterable
 
   /**
    * Iterate over prefix sums for stored values.  If 'open' is true,
    * the sums will be for strictly < each key.
    */
-  def prefixSumsIterator(open: Boolean = false) = {
+  def prefixSumsIterator(open: Boolean = false): Iterator[P] = {
     val itr = valuesIterator.scanLeft(prefixMonoid.zero)((p, e) => prefixMonoid.inc(p, e))
     if (open) itr.takeWhile(_ => itr.hasNext) else itr.drop(1)
   }
 
   /** equivalent to prefixSum of the right-most key */
-  def sum = this match {
+  def sum: P = this match {
     case n: INodePS[K, V, P] => n.prefix
     case _ => prefixMonoid.zero
   }
@@ -155,12 +155,12 @@ object PrefixSumMap {
    * val map2 = PrefixSumMap.key(ord).value[Int].prefix(IncrementingMonoid.fromMonoid[Int])
    * }}}
    */
-  def key[K](implicit ord: Ordering[K]) = infra.GetValue(ord)
+  def key[K](implicit ord: Ordering[K]): infra.GetValue[K] = infra.GetValue(ord)
 
   object infra {
     /** Mediating class between key method and value method */
     case class GetValue[K](ord: Ordering[K]) {
-      def value[V] = GetPrefix[K, V](ord)
+      def value[V]: GetPrefix[K, V] = GetPrefix[K, V](ord)
     }
 
     /** Mediating class between value method and prefix method */

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
@@ -18,6 +18,8 @@ package com.twitter.algebird.maps.prefixsum
 
 import math.Ordering
 
+import scala.collection.SortedMap
+
 import com.twitter.algebird.{ Monoid, MonoidAggregator }
 
 import com.twitter.algebird.maps.redblack.tree._
@@ -103,7 +105,7 @@ import infra._
  * @tparam IN The node type of the concrete internal R/B tree subclass
  * @tparam M The map self-type of the concrete map subclass
  */
-trait PrefixSumMapLike[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K, V, P, IN, M] with Map[K, V]]
+trait PrefixSumMapLike[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K, V, P, IN, M] with SortedMap[K, V]]
   extends NodePS[K, V, P] with OrderedMapLike[K, V, IN, M] {
 
   /**
@@ -128,7 +130,7 @@ trait PrefixSumMapLike[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K,
   }
 }
 
-sealed trait PrefixSumMap[K, V, P] extends Map[K, V]
+sealed trait PrefixSumMap[K, V, P] extends SortedMap[K, V]
   with PrefixSumMapLike[K, V, P, INodePS[K, V, P], PrefixSumMap[K, V, P]] {
 
   type IN2[V2] = INodePS[K, V2, P]

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/prefixsum.scala
@@ -29,7 +29,7 @@ object tree {
   /** Base trait for R/B nodes supporting prefix-sum query */
   trait NodePS[K, V, P] extends NodeMap[K, V] {
     /** Monoid with increment-by-element that defines semantics of prefix sum */
-    val prefixMonoid: IncrementingMonoid[P, V]
+    def prefixMonoid: IncrementingMonoid[P, V]
 
     /**
      * Obtain the prefix (cumulative) sum of values <= a given key 'k'.
@@ -52,10 +52,10 @@ object tree {
 
   /** Internal node for R/B nodes supporting prefix-sum query */
   trait INodePS[K, V, P] extends NodePS[K, V, P] with INodeMap[K, V] {
-    val lsub: NodePS[K, V, P]
-    val rsub: NodePS[K, V, P]
+    def lsub: NodePS[K, V, P]
+    def rsub: NodePS[K, V, P]
 
-    val prefix: P
+    def prefix: P
 
     final def pfSum(k: K, sum: P, open: Boolean) =
       if (keyOrdering.lt(k, data.key))

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/redblack.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/redblack.scala
@@ -49,10 +49,10 @@ package tree {
     protected def iNode(color: Color, d: Data[K], lsub: Node[K], rsub: Node[K]): INode[K]
 
     /** Insert a node into the tree */
-    private[maps] final def insert(d: Data[K]) = blacken(ins(d))
+    private[maps] final def insert(d: Data[K]): Node[K] = blacken(ins(d))
 
     /** Delete the key from the tree */
-    private[maps] final def delete(k: K) = if (node(k).isDefined) blacken(del(k)) else this
+    private[maps] final def delete(k: K): Node[K] = if (node(k).isDefined) blacken(del(k)) else this
 
     /** Obtain the node stored at a given key if it exists, None otherwise */
     def node(k: K): Option[INode[K]]
@@ -65,16 +65,16 @@ package tree {
     private[tree] def del(k: K): Node[K]
 
     /** create a new Red node from a key, value, left subtree and right subtree */
-    final protected def rNode(d: Data[K], lsub: Node[K], rsub: Node[K]) = iNode(R, d, lsub, rsub)
+    final protected def rNode(d: Data[K], lsub: Node[K], rsub: Node[K]): INode[K] = iNode(R, d, lsub, rsub)
 
     /** create a new Black node from a key, value, left subtree and right subtree */
-    final protected def bNode(d: Data[K], lsub: Node[K], rsub: Node[K]) = iNode(B, d, lsub, rsub)
+    final protected def bNode(d: Data[K], lsub: Node[K], rsub: Node[K]): INode[K] = iNode(B, d, lsub, rsub)
 
-    final protected def blacken(node: Node[K]) = node match {
+    final protected def blacken(node: Node[K]): Node[K] = node match {
       case n: INode[K] if (n.color == R) => bNode(n.data, n.lsub, n.rsub)
       case n => n
     }
-    final protected def redden(node: Node[K]) = node match {
+    final protected def redden(node: Node[K]): Node[K] = node match {
       case n: INode[K] => if (n.color == R) n else rNode(n.data, n.lsub, n.rsub)
       case _ => throw new Exception("illegal attempt to make a leaf node red")
     }

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/redblack.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/redblack.scala
@@ -18,7 +18,7 @@ package com.twitter.algebird.maps.redblack
 
 import math.Ordering
 
-object tree {
+package tree {
   /** The color (red or black) of a node in a Red/Black tree */
   sealed trait Color extends Serializable
   case object R extends Color

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/redblack.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/redblack.scala
@@ -27,7 +27,7 @@ object tree {
   /** Defines the data payload of a tree node */
   trait Data[K] extends Serializable {
     /** The axiomatic unit of data for R/B trees is a key */
-    val key: K
+    def key: K
 
     override def hashCode = key.hashCode
     override def equals(that: Any) = that match {
@@ -43,7 +43,7 @@ object tree {
   trait Node[K] extends Serializable {
 
     /** The ordering that is applied to key values */
-    val keyOrdering: Ordering[K]
+    def keyOrdering: Ordering[K]
 
     /** Instantiate an internal node. */
     protected def iNode(color: Color, d: Data[K], lsub: Node[K], rsub: Node[K]): INode[K]
@@ -167,13 +167,13 @@ object tree {
   /** Represents an internal node (Red or Black) in the Red Black tree system */
   trait INode[K] extends Node[K] {
     /** The Red/Black color of this node */
-    val color: Color
+    def color: Color
     /** Including, but not limited to, the key */
-    val data: Data[K]
+    def data: Data[K]
     /** The left sub-tree */
-    val lsub: Node[K]
+    def lsub: Node[K]
     /** The right sub-tree */
-    val rsub: Node[K]
+    def rsub: Node[K]
 
     final def node(k: K) =
       if (keyOrdering.lt(k, data.key)) lsub.node(k)

--- a/algebird-core/src/main/scala/com/twitter/algebird/maps/redblack.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/maps/redblack.scala
@@ -1,0 +1,219 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.maps.redblack
+
+import math.Ordering
+
+object tree {
+  /** The color (red or black) of a node in a Red/Black tree */
+  sealed trait Color extends Serializable
+  case object R extends Color
+  case object B extends Color
+
+  /** Defines the data payload of a tree node */
+  trait Data[K] extends Serializable {
+    /** The axiomatic unit of data for R/B trees is a key */
+    val key: K
+
+    override def hashCode = key.hashCode
+    override def equals(that: Any) = that match {
+      case data: Data[K] => this.key.equals(data.key)
+      case _ => false
+    }
+  }
+
+  /**
+   * Base class of a Red/Black tree node
+   * @tparam K The key type
+   */
+  trait Node[K] extends Serializable {
+
+    /** The ordering that is applied to key values */
+    val keyOrdering: Ordering[K]
+
+    /** Instantiate an internal node. */
+    protected def iNode(color: Color, d: Data[K], lsub: Node[K], rsub: Node[K]): INode[K]
+
+    /** Insert a node into the tree */
+    private[maps] final def insert(d: Data[K]) = blacken(ins(d))
+
+    /** Delete the key from the tree */
+    private[maps] final def delete(k: K) = if (node(k).isDefined) blacken(del(k)) else this
+
+    /** Obtain the node stored at a given key if it exists, None otherwise */
+    def node(k: K): Option[INode[K]]
+
+    def nodeMin: Option[INode[K]]
+    def nodeMax: Option[INode[K]]
+
+    // internal
+    private[tree] def ins(d: Data[K]): Node[K]
+    private[tree] def del(k: K): Node[K]
+
+    /** create a new Red node from a key, value, left subtree and right subtree */
+    final protected def rNode(d: Data[K], lsub: Node[K], rsub: Node[K]) = iNode(R, d, lsub, rsub)
+
+    /** create a new Black node from a key, value, left subtree and right subtree */
+    final protected def bNode(d: Data[K], lsub: Node[K], rsub: Node[K]) = iNode(B, d, lsub, rsub)
+
+    final protected def blacken(node: Node[K]) = node match {
+      case n: INode[K] if (n.color == R) => bNode(n.data, n.lsub, n.rsub)
+      case n => n
+    }
+    final protected def redden(node: Node[K]) = node match {
+      case n: INode[K] => if (n.color == R) n else rNode(n.data, n.lsub, n.rsub)
+      case _ => throw new Exception("illegal attempt to make a leaf node red")
+    }
+
+    // balance for insertion
+    final protected def balance(node: Node[K]) = node match {
+      case BNode(dG, RNode(dP, RNode(dC, lC, rC), rP), rG) =>
+        rNode(dP, bNode(dC, lC, rC), bNode(dG, rP, rG))
+      case BNode(dG, RNode(dP, lP, RNode(dC, lC, rC)), rG) =>
+        rNode(dC, bNode(dP, lP, lC), bNode(dG, rC, rG))
+      case BNode(dG, lG, RNode(dP, RNode(dC, lC, rC), rP)) =>
+        rNode(dC, bNode(dG, lG, lC), bNode(dP, rC, rP))
+      case BNode(dG, lG, RNode(dP, lP, RNode(dC, lC, rC))) =>
+        rNode(dP, bNode(dG, lG, lP), bNode(dC, lC, rC))
+      case _ => node
+    }
+
+    final protected def balanceDel(x: Data[K], tl: Node[K], tr: Node[K]) =
+      (tl, tr) match {
+        case (RNode(y, a, b), RNode(z, c, d)) => rNode(x, bNode(y, a, b), bNode(z, c, d))
+        case (RNode(y, RNode(z, a, b), c), d) => rNode(y, bNode(z, a, b), bNode(x, c, d))
+        case (RNode(y, a, RNode(z, b, c)), d) => rNode(z, bNode(y, a, b), bNode(x, c, d))
+        case (a, RNode(y, b, RNode(z, c, d))) => rNode(y, bNode(x, a, b), bNode(z, c, d))
+        case (a, RNode(y, RNode(z, b, c), d)) => rNode(z, bNode(x, a, b), bNode(y, c, d))
+        case (a, b) => bNode(x, a, b)
+      }
+
+    final protected def balanceLeft(x: Data[K], tl: Node[K], tr: Node[K]) =
+      (tl, tr) match {
+        case (RNode(y, a, b), c) => rNode(x, bNode(y, a, b), c)
+        case (bl, BNode(y, a, b)) => balanceDel(x, bl, rNode(y, a, b))
+        case (bl, RNode(y, BNode(z, a, b), c)) =>
+          rNode(z, bNode(x, bl, a), balanceDel(y, b, redden(c)))
+        case _ => throw new Exception(s"undefined pattern in tree pair: ($tl, $tr)")
+      }
+
+    final protected def balanceRight(x: Data[K], tl: Node[K], tr: Node[K]) =
+      (tl, tr) match {
+        case (a, RNode(y, b, c)) => rNode(x, a, bNode(y, b, c))
+        case (BNode(y, a, b), bl) => balanceDel(x, rNode(y, a, b), bl)
+        case (RNode(y, a, BNode(z, b, c)), bl) =>
+          rNode(z, balanceDel(y, redden(a), b), bNode(x, c, bl))
+        case _ => throw new Exception(s"undefined pattern in tree pair: ($tl, $tr)")
+      }
+
+    final protected def append(tl: Node[K], tr: Node[K]): Node[K] = (tl, tr) match {
+      case (LNode(), n) => n
+      case (n, LNode()) => n
+      case (RNode(x, a, b), RNode(y, c, d)) => append(b, c) match {
+        case RNode(z, bb, cc) => rNode(z, rNode(x, a, bb), rNode(y, cc, d))
+        case bc => rNode(x, a, rNode(y, bc, d))
+      }
+      case (BNode(x, a, b), BNode(y, c, d)) => append(b, c) match {
+        case RNode(z, bb, cc) => rNode(z, bNode(x, a, bb), bNode(y, cc, d))
+        case bc => balanceLeft(x, a, bNode(y, bc, d))
+      }
+      case (a, RNode(x, b, c)) => rNode(x, append(a, b), c)
+      case (RNode(x, a, b), c) => rNode(x, a, append(b, c))
+    }
+
+    // NOTE: the balancing rules for node deletion all assume that the case of deleting a key
+    // that is not in the map is addressed elsewhere.  If these balancing functions are applied
+    // to a key that isn't present, they will fail destructively and uninformatively.
+    final protected def delLeft(node: INode[K], k: K) = node.lsub match {
+      case n: INode[K] if (n.color == B) => balanceLeft(node.data, node.lsub.del(k), node.rsub)
+      case _ => rNode(node.data, node.lsub.del(k), node.rsub)
+    }
+
+    final protected def delRight(node: INode[K], k: K) = node.rsub match {
+      case n: INode[K] if (n.color == B) => balanceRight(node.data, node.lsub, node.rsub.del(k))
+      case _ => rNode(node.data, node.lsub, node.rsub.del(k))
+    }
+  }
+
+  /** Represents a leaf node in the Red Black tree system */
+  trait LNode[K] extends Node[K] {
+    final def node(k: K) = None
+
+    final def nodeMin = None
+    final def nodeMax = None
+
+    final def ins(d: Data[K]) = rNode(d, this, this)
+    final def del(k: K) = this
+  }
+
+  private object LNode {
+    def unapply[K](node: LNode[K]): Boolean = true
+  }
+
+  /** Represents an internal node (Red or Black) in the Red Black tree system */
+  trait INode[K] extends Node[K] {
+    /** The Red/Black color of this node */
+    val color: Color
+    /** Including, but not limited to, the key */
+    val data: Data[K]
+    /** The left sub-tree */
+    val lsub: Node[K]
+    /** The right sub-tree */
+    val rsub: Node[K]
+
+    final def node(k: K) =
+      if (keyOrdering.lt(k, data.key)) lsub.node(k)
+      else if (keyOrdering.gt(k, data.key)) rsub.node(k)
+      else Some(this)
+
+    final def nodeMin = lsub match {
+      case LNode() => Some(this)
+      case _ => lsub.nodeMin
+    }
+
+    final def nodeMax = rsub match {
+      case LNode() => Some(this)
+      case _ => rsub.nodeMax
+    }
+
+    final def del(k: K) =
+      if (keyOrdering.lt(k, data.key)) delLeft(this, k)
+      else if (keyOrdering.gt(k, data.key)) delRight(this, k)
+      else append(lsub, rsub)
+
+    final def ins(d: Data[K]) =
+      if (color == R) {
+        if (keyOrdering.lt(d.key, data.key)) rNode(data, lsub.ins(d), rsub)
+        else if (keyOrdering.gt(d.key, data.key)) rNode(data, lsub, rsub.ins(d))
+        else rNode(d, lsub, rsub)
+      } else {
+        if (keyOrdering.lt(d.key, data.key)) balance(bNode(data, lsub.ins(d), rsub))
+        else if (keyOrdering.gt(d.key, data.key)) balance(bNode(data, lsub, rsub.ins(d)))
+        else bNode(d, lsub, rsub)
+      }
+  }
+
+  private object RNode {
+    def unapply[K](node: INode[K]): Option[(Data[K], Node[K], Node[K])] =
+      if (node.color == R) Some((node.data, node.lsub, node.rsub)) else None
+  }
+
+  private object BNode {
+    def unapply[K](node: INode[K]): Option[(Data[K], Node[K], Node[K])] =
+      if (node.color == B) Some((node.data, node.lsub, node.rsub)) else None
+  }
+}

--- a/algebird-test/src/main/scala/com/twitter/algebird/SerDe.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/SerDe.scala
@@ -1,0 +1,41 @@
+/*
+Copyright 2015 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird
+
+object SerDe {
+  def roundTripSerDe[T](v: T) = {
+    import java.io._
+
+    class ObjectInputStreamWithCustomClassLoader(
+      inputStream: InputStream) extends ObjectInputStream(inputStream) {
+      override def resolveClass(desc: java.io.ObjectStreamClass): Class[_] = {
+        try { Class.forName(desc.getName, false, getClass.getClassLoader) }
+        catch { case ex: ClassNotFoundException => super.resolveClass(desc) }
+      }
+    }
+
+    val bufout = new ByteArrayOutputStream()
+    val obout = new ObjectOutputStream(bufout)
+
+    obout.writeObject(v)
+
+    val bufin = new ByteArrayInputStream(bufout.toByteArray)
+    val obin = new ObjectInputStreamWithCustomClassLoader(bufin)
+
+    obin.readObject().asInstanceOf[T]
+  }
+}

--- a/algebird-test/src/main/scala/com/twitter/algebird/matchers/seq.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/matchers/seq.scala
@@ -1,0 +1,48 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.matchers
+
+object seq {
+  import org.scalatest.matchers.{ Matcher, MatchResult }
+
+  class EqSeqMatcher[E](ref: TraversableOnce[E]) extends Matcher[TraversableOnce[E]] {
+    private def elist(s: Seq[E]) = "(" + s.mkString(", ") + ")"
+    def apply(left: TraversableOnce[E]) = {
+      val (ls, rs) = (left.toSeq, ref.toSeq)
+      MatchResult(
+        ls.equals(rs),
+        s"Seq${elist(ls)} did not match Seq${elist(rs)}",
+        "sequences matched")
+    }
+  }
+
+  def beEqSeq[E](ref: TraversableOnce[E]) = new EqSeqMatcher(ref)
+
+  class EqNumSeqMatcher(ref: TraversableOnce[Double], eps: Double) extends Matcher[TraversableOnce[Double]] {
+    private def elist(s: Seq[Double]) = "(" + s.mkString(", ") + ")"
+    def apply(left: TraversableOnce[Double]) = {
+      val (ls, rs) = (left.toSeq, ref.toSeq)
+      MatchResult(
+        ls.zip(rs).map(p => math.abs(p._1 - p._2)).max < eps,
+        s"Seq${elist(ls)} did not match Seq${elist(rs)}",
+        "sequences matched")
+    }
+  }
+
+  def beEqNumSeq[N](ref: TraversableOnce[N], eps: Double)(implicit td: N => Double) =
+    new EqNumSeqMatcher(ref.map(td), eps)
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/increment.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/increment.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird.maps.increment
 
+import scala.collection.SortedMap
+
 import org.scalatest._
 
 import com.twitter.algebird.Monoid
@@ -26,9 +28,9 @@ object IncrementMapProperties extends FlatSpec with Matchers {
   import tree._
   import infra._
 
-  def testIncrement[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, IN, M] with Map[K, V]](
+  def testIncrement[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, IN, M] with SortedMap[K, V]](
     data: Seq[(K, V)],
-    map: IncrementMapLike[K, V, IN, M] with Map[K, V]) {
+    map: IncrementMapLike[K, V, IN, M] with SortedMap[K, V]) {
     val mon = map.valueMonoid
 
     // add values to themselves w.r.t. monoid

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/increment.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/increment.scala
@@ -26,9 +26,9 @@ object IncrementMapProperties extends FlatSpec with Matchers {
   import tree._
   import infra._
 
-  def testIncrement[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, IN, M]](
+  def testIncrement[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, IN, M] with Map[K, V]](
     data: Seq[(K, V)],
-    map: IncrementMapLike[K, V, IN, M]) {
+    map: IncrementMapLike[K, V, IN, M] with Map[K, V]) {
     val mon = map.valueMonoid
 
     // add values to themselves w.r.t. monoid

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/increment.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/increment.scala
@@ -1,0 +1,84 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.maps.increment
+
+import org.scalatest._
+
+import com.twitter.algebird.Monoid
+
+import com.twitter.algebird.matchers.seq._
+
+object IncrementMapProperties extends FlatSpec with Matchers {
+  import tree._
+  import infra._
+
+  def testIncrement[K, V, IN <: INodeInc[K, V], M <: IncrementMapLike[K, V, IN, M]](
+    data: Seq[(K, V)],
+    map: IncrementMapLike[K, V, IN, M]) {
+    val mon = map.valueMonoid
+
+    // add values to themselves w.r.t. monoid
+    val incTruth1 = data.map(_._2).zip(data.map(_._2)).map(x => mon.plus(x._1, x._2))
+    val map1 = data.foldLeft(map)((m, e) => m.increment(e._1, e._2))
+    map1.values should beEqSeq(incTruth1)
+
+    // add values to a shuffle
+    val v2 = scala.util.Random.shuffle(data.map(_._2))
+    val data2 = data.map(_._1).zip(v2)
+    val incTruth2 = data.map(_._2).zip(v2).map(x => mon.plus(x._1, x._2))
+    val map2 = data2.foldLeft(map)((m, e) => m.increment(e._1, e._2))
+    map2.values should beEqSeq(incTruth2)
+  }
+}
+
+class IncrementMapSpec extends FlatSpec with Matchers {
+  import com.twitter.algebird.maps.ordered.RBProperties._
+  import com.twitter.algebird.maps.ordered.OrderedMapProperties._
+
+  import IncrementMapProperties._
+
+  def mapType1 = IncrementMap.key[Int].value[Int]
+
+  it should "pass randomized tree patterns" in {
+    val data = Vector.tabulate(50)(j => (j, j))
+    (1 to 1000).foreach { u =>
+      val shuffled = scala.util.Random.shuffle(data)
+      // incrementing new key is same as insertion:
+      val map = shuffled.foldLeft(mapType1)((m, e) => m.increment(e._1, e._2))
+
+      testRB(map)
+      testKV(data, map)
+      testDel(data, map)
+      testEq(data, mapType1)
+      testIncrement(data, map)
+    }
+  }
+
+  it should "serialize and deserialize" in {
+    import com.twitter.algebird.SerDe.roundTripSerDe
+
+    val data = Vector.tabulate(50)(j => (j, j))
+    val omap = data.foldLeft(mapType1)((m, e) => m + e)
+    val imap = roundTripSerDe(omap)
+
+    (imap == omap) should be (true)
+    testRB(imap)
+    testKV(data, imap)
+    testDel(data, imap)
+    testIncrement(data, imap)
+  }
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/mixed.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/mixed.scala
@@ -82,10 +82,24 @@ object mixed {
 
   import infra._
 
-  sealed trait MixedMap[K, V, P]
-    extends IncrementMapLike[K, V, INodeMix[K, V, P], MixedMap[K, V, P]]
+  sealed trait MixedMap[K, V, P] extends Map[K, V]
+    with IncrementMapLike[K, V, INodeMix[K, V, P], MixedMap[K, V, P]]
     with PrefixSumMapLike[K, V, P, INodeMix[K, V, P], MixedMap[K, V, P]]
     with NearestMapLike[K, V, INodeMix[K, V, P], MixedMap[K, V, P]] {
+
+    type IN2[V2] = INodeMix[K, V2, P]
+    type M2[V2] = MixedMap[K, V2, P]
+
+    override def empty = MixedMap.key(keyOrdering).value(valueMonoid).prefix(prefixMonoid)
+
+    def +[V2 >: V](kv2: (K, V2)) = kv2 match {
+      case kv: (K, V) => this.insert(
+        new com.twitter.algebird.maps.ordered.tree.DataMap[K, V] {
+          val key = kv._1
+          val value = kv._2
+        }).asInstanceOf[MixedMap[K, V2, P]]
+      case _ => throw new Exception("cannot widen type of MixedMap")
+    }
 
     override def toString =
       "MixedMap(" +

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/mixed.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/mixed.scala
@@ -40,8 +40,8 @@ object mixed {
 
     trait INodeMix[K, V, P] extends NodeMix[K, V, P]
       with INodePS[K, V, P] with INodeInc[K, V] with INodeNearMap[K, V] {
-      val lsub: NodeMix[K, V, P]
-      val rsub: NodeMix[K, V, P]
+      def lsub: NodeMix[K, V, P]
+      def rsub: NodeMix[K, V, P]
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/mixed.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/mixed.scala
@@ -1,0 +1,159 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.maps
+
+import org.scalatest._
+
+import com.twitter.algebird.Monoid
+
+import com.twitter.algebird.matchers.seq._
+
+object mixed {
+  import math.Numeric
+  import com.twitter.algebird.maps.increment._
+  import com.twitter.algebird.maps.prefixsum._
+  import com.twitter.algebird.maps.nearest._
+
+  object tree {
+    import com.twitter.algebird.maps.increment.tree._
+    import com.twitter.algebird.maps.prefixsum.tree._
+    import com.twitter.algebird.maps.nearest.tree._
+
+    trait NodeMix[K, V, P] extends NodePS[K, V, P] with NodeInc[K, V] with NodeNearMap[K, V]
+
+    trait LNodeMix[K, V, P] extends NodeMix[K, V, P]
+      with LNodePS[K, V, P] with LNodeInc[K, V] with LNodeNearMap[K, V]
+
+    trait INodeMix[K, V, P] extends NodeMix[K, V, P]
+      with INodePS[K, V, P] with INodeInc[K, V] with INodeNearMap[K, V] {
+      val lsub: NodeMix[K, V, P]
+      val rsub: NodeMix[K, V, P]
+    }
+  }
+
+  import tree._
+
+  object infra {
+    import com.twitter.algebird.maps.redblack.tree._
+    import com.twitter.algebird.maps.ordered.tree.DataMap
+
+    class Inject[K, V, P](
+      val keyOrdering: Numeric[K],
+      val valueMonoid: Monoid[V],
+      val prefixMonoid: IncrementingMonoid[P, V]) extends Serializable {
+
+      def iNode(clr: Color, dat: Data[K], ls: Node[K], rs: Node[K]) =
+        new Inject[K, V, P](keyOrdering, valueMonoid, prefixMonoid) with INodeMix[K, V, P] with MixedMap[K, V, P] {
+
+          // INode[K]
+          val color = clr
+          val lsub = ls.asInstanceOf[NodeMix[K, V, P]]
+          val rsub = rs.asInstanceOf[NodeMix[K, V, P]]
+          val data = dat.asInstanceOf[DataMap[K, V]]
+          // INodePS[K, V, P]
+          val prefix = prefixMonoid.inc(prefixMonoid.plus(lsub.pfs, rsub.pfs), data.value)
+          // INodeNear[K, V]
+          val kmin = lsub match {
+            case n: INodeMix[K, V, P] => n.kmin
+            case _ => data.key
+          }
+          val kmax = rsub match {
+            case n: INodeMix[K, V, P] => n.kmax
+            case _ => data.key
+          }
+        }
+    }
+
+  }
+
+  import infra._
+
+  sealed trait MixedMap[K, V, P]
+    extends IncrementMapLike[K, V, INodeMix[K, V, P], MixedMap[K, V, P]]
+    with PrefixSumMapLike[K, V, P, INodeMix[K, V, P], MixedMap[K, V, P]]
+    with NearestMapLike[K, V, INodeMix[K, V, P], MixedMap[K, V, P]] {
+
+    override def toString =
+      "MixedMap(" +
+        iterator.zip(prefixSumsIterator())
+        .map(x => s"${x._1._1} -> (${x._1._2}, ${x._2})").mkString(", ") +
+        ")"
+  }
+
+  object MixedMap {
+    def key[K](implicit num: Numeric[K]) = infra.GetValue(num)
+
+    object infra {
+      case class GetValue[K](num: Numeric[K]) {
+        def value[V](implicit vm: Monoid[V]) = GetPrefix(num, vm)
+      }
+
+      case class GetPrefix[K, V](num: Numeric[K], vm: Monoid[V]) {
+        def prefix[P](implicit im: IncrementingMonoid[P, V]): MixedMap[K, V, P] =
+          new Inject[K, V, P](num, vm, im) with LNodeMix[K, V, P] with MixedMap[K, V, P]
+      }
+    }
+  }
+}
+
+class MixedMapSpec extends FlatSpec with Matchers {
+  import com.twitter.algebird.maps.prefixsum.IncrementingMonoid
+
+  import com.twitter.algebird.maps.ordered.RBProperties._
+  import com.twitter.algebird.maps.ordered.OrderedMapProperties._
+  import com.twitter.algebird.maps.prefixsum.PrefixSumMapProperties._
+  import com.twitter.algebird.maps.increment.IncrementMapProperties._
+  import com.twitter.algebird.maps.nearest.NearestMapProperties._
+
+  import mixed.MixedMap
+
+  def mapType1 =
+    MixedMap.key[Double].value[Int]
+      .prefix(IncrementingMonoid.fromMonoid(implicitly[Monoid[Int]]))
+
+  it should "pass randomized tree patterns" in {
+    val data = Vector.tabulate(50)(j => (j.toDouble, j))
+    (1 to 1000).foreach { u =>
+      val shuffled = scala.util.Random.shuffle(data)
+      val map = shuffled.foldLeft(mapType1)((m, e) => m + e)
+
+      testRB(map)
+      testKV(data, map)
+      testDel(data, map)
+      testEq(data, mapType1)
+      testPrefix(data, map)
+      testIncrement(data, map)
+      testNearest(data, map)
+    }
+  }
+
+  it should "serialize and deserialize" in {
+    import com.twitter.algebird.SerDe.roundTripSerDe
+
+    val data = Vector.tabulate(50)(j => (j.toDouble, j))
+    val omap = data.foldLeft(mapType1)((m, e) => m + e)
+    val imap = roundTripSerDe(omap)
+
+    (imap == omap) should be (true)
+    testRB(imap)
+    testKV(data, imap)
+    testDel(data, imap)
+    testPrefix(data, imap)
+    testIncrement(data, imap)
+    testNearest(data, imap)
+  }
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/mixed.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/mixed.scala
@@ -89,19 +89,7 @@ object mixed {
     with PrefixSumMapLike[K, V, P, INodeMix[K, V, P], MixedMap[K, V, P]]
     with NearestMapLike[K, V, INodeMix[K, V, P], MixedMap[K, V, P]] {
 
-    type IN2[V2] = INodeMix[K, V2, P]
-    type M2[V2] = MixedMap[K, V2, P]
-
     override def empty = MixedMap.key(keyOrdering).value(valueMonoid).prefix(prefixMonoid)
-
-    def +[V2 >: V](kv2: (K, V2)) = kv2 match {
-      case kv: (K, V) => this.insert(
-        new com.twitter.algebird.maps.ordered.tree.DataMap[K, V] {
-          val key = kv._1
-          val value = kv._2
-        }).asInstanceOf[MixedMap[K, V2, P]]
-      case _ => throw new Exception("cannot widen type of MixedMap")
-    }
 
     override def toString =
       "MixedMap(" +

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/mixed.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/mixed.scala
@@ -24,6 +24,8 @@ import com.twitter.algebird.matchers.seq._
 
 object mixed {
   import math.Numeric
+  import scala.collection.SortedMap
+
   import com.twitter.algebird.maps.increment._
   import com.twitter.algebird.maps.prefixsum._
   import com.twitter.algebird.maps.nearest._
@@ -82,7 +84,7 @@ object mixed {
 
   import infra._
 
-  sealed trait MixedMap[K, V, P] extends Map[K, V]
+  sealed trait MixedMap[K, V, P] extends SortedMap[K, V]
     with IncrementMapLike[K, V, INodeMix[K, V, P], MixedMap[K, V, P]]
     with PrefixSumMapLike[K, V, P, INodeMix[K, V, P], MixedMap[K, V, P]]
     with NearestMapLike[K, V, INodeMix[K, V, P], MixedMap[K, V, P]] {

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/nearest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/nearest.scala
@@ -1,0 +1,154 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.maps.nearest
+
+import org.scalatest._
+
+import com.twitter.algebird.matchers.seq._
+
+object NearestSetProperties extends FlatSpec with Matchers {
+  import tree._
+  import infra._
+
+  def testNearest[IN <: INodeNear[Double], M <: NearestSetLike[Double, IN, M]](
+    data: Seq[Double],
+    map: NearestSetLike[Double, IN, M]) {
+    val n = data.length
+    // I'm writing this test assuming Double keys (0.0, 1.0, 2.0, ... (n-1))
+    data should beEqSeq(Vector.tabulate(n)(j => j.toDouble))
+    map.keys should beEqSeq(Vector.tabulate(n)(j => j.toDouble))
+
+    map.nearest(-1e100) should beEqSeq(Seq(0.0))
+    map.nearest(+1e100) should beEqSeq(Seq((n - 1).toDouble))
+
+    (0.0 to (n - 2).toDouble by 1.0).foreach { j =>
+      map.nearest(j) should beEqSeq(Seq(j))
+      map.nearest(j + 0.4) should beEqSeq(Seq(j))
+      map.nearest(j + 0.5) should beEqSeq(Seq(j, j + 1.0))
+      map.nearest(j + 0.6) should beEqSeq(Seq(j + 1.0))
+      map.nearest(j + 1.0) should beEqSeq(Seq(j + 1.0))
+    }
+  }
+}
+
+object NearestMapProperties extends FlatSpec with Matchers {
+  import tree._
+  import infra._
+
+  def testNearest[V, IN <: INodeNearMap[Double, V], M <: NearestMapLike[Double, V, IN, M]](
+    data: Seq[(Double, V)],
+    map: NearestMapLike[Double, V, IN, M]) {
+    val n = data.length
+    // I'm writing this test assuming Double keys (0.0, 1.0, 2.0, ... (n-1))
+    data.map(_._1) should beEqSeq(Vector.tabulate(n)(j => j.toDouble))
+    map.keys should beEqSeq(Vector.tabulate(n)(j => j.toDouble))
+
+    map.nearest(-1e100) should beEqSeq(Seq(((0.0, map.get(0.0).get))))
+    map.nearest(+1e100) should beEqSeq(Seq((((n - 1).toDouble, map.get((n - 1).toDouble).get))))
+
+    (0.0 to (n - 2).toDouble by 1.0).foreach { j =>
+      val (vj, vj1) = (map.get(j).get, map.get(j + 1.0).get)
+      map.nearest(j) should beEqSeq(Seq(((j, vj))))
+      map.nearest(j + 0.4) should beEqSeq(Seq(((j, vj))))
+      map.nearest(j + 0.5) should beEqSeq(Seq(((j, vj)), ((j + 1.0, vj1))))
+      map.nearest(j + 0.6) should beEqSeq(Seq(((j + 1.0, vj1))))
+      map.nearest(j + 1.0) should beEqSeq(Seq(((j + 1.0, vj1))))
+    }
+  }
+}
+
+class NearestSetSpec extends FlatSpec with Matchers {
+  import com.twitter.algebird.maps.ordered.RBProperties._
+  import com.twitter.algebird.maps.ordered.OrderedSetProperties._
+
+  import NearestSetProperties._
+
+  def mapType1 = NearestSet.key[Double]
+
+  it should "pass randomized tree patterns" in {
+
+    // empty map returns empty seq
+    mapType1.nearest(1.0) should beEqSeq(Seq.empty[Double])
+
+    val data = Vector.tabulate(50)(j => j.toDouble)
+    (1 to 1000).foreach { u =>
+      val shuffled = scala.util.Random.shuffle(data)
+      val map = shuffled.foldLeft(mapType1)((m, e) => m + e)
+
+      testRB(map)
+      testK(data, map)
+      testDel(data, map)
+      testEq(data, mapType1)
+      testNearest(data, map)
+    }
+  }
+
+  it should "serialize and deserialize" in {
+    import com.twitter.algebird.SerDe.roundTripSerDe
+
+    val data = Vector.tabulate(50)(j => j.toDouble)
+    val omap = data.foldLeft(mapType1)((m, e) => m + e)
+    val imap = roundTripSerDe(omap)
+
+    (imap == omap) should be (true)
+    testRB(imap)
+    testK(data, imap)
+    testDel(data, imap)
+    testNearest(data, imap)
+  }
+}
+
+class NearestMapSpec extends FlatSpec with Matchers {
+  import com.twitter.algebird.maps.ordered.RBProperties._
+  import com.twitter.algebird.maps.ordered.OrderedMapProperties._
+
+  import NearestMapProperties._
+
+  def mapType1 = NearestMap.key[Double].value[Int]
+
+  it should "pass randomized tree patterns" in {
+
+    // empty map returns empty seq
+    mapType1.nearest(1.0) should beEqSeq(Seq.empty[(Double, Int)])
+
+    val data = Vector.tabulate(50)(j => (j.toDouble, j))
+    (1 to 1000).foreach { u =>
+      val shuffled = scala.util.Random.shuffle(data)
+      val map = shuffled.foldLeft(mapType1)((m, e) => m + e)
+
+      testRB(map)
+      testKV(data, map)
+      testDel(data, map)
+      testEq(data, mapType1)
+      testNearest(data, map)
+    }
+  }
+
+  it should "serialize and deserialize" in {
+    import com.twitter.algebird.SerDe.roundTripSerDe
+
+    val data = Vector.tabulate(50)(j => (j.toDouble, j))
+    val omap = data.foldLeft(mapType1)((m, e) => m + e)
+    val imap = roundTripSerDe(omap)
+
+    (imap == omap) should be (true)
+    testRB(imap)
+    testKV(data, imap)
+    testDel(data, imap)
+    testNearest(data, imap)
+  }
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/nearest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/nearest.scala
@@ -24,9 +24,9 @@ object NearestSetProperties extends FlatSpec with Matchers {
   import tree._
   import infra._
 
-  def testNearest[IN <: INodeNear[Double], M <: NearestSetLike[Double, IN, M]](
+  def testNearest[IN <: INodeNear[Double], M <: NearestSetLike[Double, IN, M] with Set[Double]](
     data: Seq[Double],
-    map: NearestSetLike[Double, IN, M]) {
+    map: NearestSetLike[Double, IN, M] with Set[Double]) {
     val n = data.length
     // I'm writing this test assuming Double keys (0.0, 1.0, 2.0, ... (n-1))
     data should beEqSeq(Vector.tabulate(n)(j => j.toDouble))
@@ -49,9 +49,9 @@ object NearestMapProperties extends FlatSpec with Matchers {
   import tree._
   import infra._
 
-  def testNearest[V, IN <: INodeNearMap[Double, V], M <: NearestMapLike[Double, V, IN, M]](
+  def testNearest[V, IN <: INodeNearMap[Double, V], M <: NearestMapLike[Double, V, IN, M] with Map[Double, V]](
     data: Seq[(Double, V)],
-    map: NearestMapLike[Double, V, IN, M]) {
+    map: NearestMapLike[Double, V, IN, M] with Map[Double, V]) {
     val n = data.length
     // I'm writing this test assuming Double keys (0.0, 1.0, 2.0, ... (n-1))
     data.map(_._1) should beEqSeq(Vector.tabulate(n)(j => j.toDouble))

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/nearest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/nearest.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird.maps.nearest
 
+import scala.collection.{ SortedSet, SortedMap }
+
 import org.scalatest._
 
 import com.twitter.algebird.matchers.seq._
@@ -24,9 +26,9 @@ object NearestSetProperties extends FlatSpec with Matchers {
   import tree._
   import infra._
 
-  def testNearest[IN <: INodeNear[Double], M <: NearestSetLike[Double, IN, M] with Set[Double]](
+  def testNearest[IN <: INodeNear[Double], M <: NearestSetLike[Double, IN, M] with SortedSet[Double]](
     data: Seq[Double],
-    map: NearestSetLike[Double, IN, M] with Set[Double]) {
+    map: NearestSetLike[Double, IN, M] with SortedSet[Double]) {
     val n = data.length
     // I'm writing this test assuming Double keys (0.0, 1.0, 2.0, ... (n-1))
     data should beEqSeq(Vector.tabulate(n)(j => j.toDouble))
@@ -49,9 +51,9 @@ object NearestMapProperties extends FlatSpec with Matchers {
   import tree._
   import infra._
 
-  def testNearest[V, IN <: INodeNearMap[Double, V], M <: NearestMapLike[Double, V, IN, M] with Map[Double, V]](
+  def testNearest[V, IN <: INodeNearMap[Double, V], M <: NearestMapLike[Double, V, IN, M] with SortedMap[Double, V]](
     data: Seq[(Double, V)],
-    map: NearestMapLike[Double, V, IN, M] with Map[Double, V]) {
+    map: NearestMapLike[Double, V, IN, M] with SortedMap[Double, V]) {
     val n = data.length
     // I'm writing this test assuming Double keys (0.0, 1.0, 2.0, ... (n-1))
     data.map(_._1) should beEqSeq(Vector.tabulate(n)(j => j.toDouble))

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/ordered.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/ordered.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird.maps.ordered
 
+import scala.collection.{ SortedSet, SortedMap }
+
 import org.scalatest._
 
 import com.twitter.algebird.matchers.seq._
@@ -103,18 +105,18 @@ object OrderedSetProperties extends FlatSpec with Matchers {
   import RBProperties._
 
   // Assumes 'data' is in key order
-  def testK[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M] with Set[K]](
+  def testK[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M] with SortedSet[K]](
     data: Seq[K],
-    omap: OrderedSetLike[K, IN, M] with Set[K]) {
+    omap: OrderedSetLike[K, IN, M] with SortedSet[K]) {
 
     // verify the map elements are ordered by key
     omap.keys should beEqSeq(data)
   }
 
   // Assumes 'data' is in key order
-  def testDel[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M] with Set[K]](
+  def testDel[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M] with SortedSet[K]](
     data: Seq[K],
-    omap: OrderedSetLike[K, IN, M] with Set[K]) {
+    omap: OrderedSetLike[K, IN, M] with SortedSet[K]) {
 
     data.foreach { key =>
       val delMap = omap - key
@@ -124,9 +126,9 @@ object OrderedSetProperties extends FlatSpec with Matchers {
     }
   }
 
-  def testEq[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M] with Set[K]](
+  def testEq[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M] with SortedSet[K]](
     data: Seq[K],
-    map: OrderedSetLike[K, IN, M] with Set[K]) {
+    map: OrderedSetLike[K, IN, M] with SortedSet[K]) {
 
     val map1 = scala.util.Random.shuffle(data)
       .foldLeft(map.empty)((m, e) => (m + e).asInstanceOf[M])
@@ -146,9 +148,9 @@ object OrderedSetProperties extends FlatSpec with Matchers {
   }
 
   // assumes data is of form 0.0, 1.0, 2.0 ...
-  def testFrom[IN <: INode[Double], M <: OrderedSetLike[Double, IN, M] with Set[Double]](
+  def testFrom[IN <: INode[Double], M <: OrderedSetLike[Double, IN, M] with SortedSet[Double]](
     data: Seq[Double],
-    map: OrderedSetLike[Double, IN, M] with Set[Double]) {
+    map: OrderedSetLike[Double, IN, M] with SortedSet[Double]) {
 
     data.foreach { k =>
       map.keysIteratorFrom(k).toSeq should beEqSeq(data.filter(_ >= k))
@@ -164,9 +166,9 @@ object OrderedMapProperties extends FlatSpec with Matchers {
   import RBProperties._
 
   // Assumes 'data' is in key order
-  def testKV[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M] with Map[K, V]](
+  def testKV[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M] with SortedMap[K, V]](
     data: Seq[(K, V)],
-    omap: OrderedMapLike[K, V, IN, M] with Map[K, V]) {
+    omap: OrderedMapLike[K, V, IN, M] with SortedMap[K, V]) {
 
     // verify the map elements are ordered by key
     omap.keys should beEqSeq(data.map(_._1))
@@ -177,9 +179,9 @@ object OrderedMapProperties extends FlatSpec with Matchers {
   }
 
   // Assumes 'data' is in key order
-  def testDel[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M] with Map[K, V]](
+  def testDel[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M] with SortedMap[K, V]](
     data: Seq[(K, V)],
-    omap: OrderedMapLike[K, V, IN, M] with Map[K, V]) {
+    omap: OrderedMapLike[K, V, IN, M] with SortedMap[K, V]) {
 
     data.iterator.map(_._1).foreach { key =>
       val delMap = omap - key
@@ -189,9 +191,9 @@ object OrderedMapProperties extends FlatSpec with Matchers {
     }
   }
 
-  def testEq[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M] with Map[K, V]](
+  def testEq[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M] with SortedMap[K, V]](
     data: Seq[(K, V)],
-    map: OrderedMapLike[K, V, IN, M] with Map[K, V]) {
+    map: OrderedMapLike[K, V, IN, M] with SortedMap[K, V]) {
 
     val map1 = scala.util.Random.shuffle(data)
       .foldLeft(map.empty)((m, e) => (m + e).asInstanceOf[M])
@@ -217,9 +219,9 @@ object OrderedMapProperties extends FlatSpec with Matchers {
   }
 
   // assumes data is of form (0.0, 0), (1.0, 1), (2.0, 2) ...
-  def testFrom[IN <: INodeMap[Double, Int], M <: OrderedMapLike[Double, Int, IN, M] with Map[Double, Int]](
+  def testFrom[IN <: INodeMap[Double, Int], M <: OrderedMapLike[Double, Int, IN, M] with SortedMap[Double, Int]](
     data: Seq[(Double, Int)],
-    map: OrderedMapLike[Double, Int, IN, M] with Map[Double, Int]) {
+    map: OrderedMapLike[Double, Int, IN, M] with SortedMap[Double, Int]) {
 
     data.foreach { p =>
       val (k, v) = p

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/ordered.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/ordered.scala
@@ -98,18 +98,18 @@ object OrderedSetProperties extends FlatSpec with Matchers {
   import RBProperties._
 
   // Assumes 'data' is in key order
-  def testK[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M]](
+  def testK[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M] with Set[K]](
     data: Seq[K],
-    omap: OrderedSetLike[K, IN, M]) {
+    omap: OrderedSetLike[K, IN, M] with Set[K]) {
 
     // verify the map elements are ordered by key
     omap.keys should beEqSeq(data)
   }
 
   // Assumes 'data' is in key order
-  def testDel[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M]](
+  def testDel[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M] with Set[K]](
     data: Seq[K],
-    omap: OrderedSetLike[K, IN, M]) {
+    omap: OrderedSetLike[K, IN, M] with Set[K]) {
 
     data.foreach { key =>
       val delMap = omap - key
@@ -119,12 +119,14 @@ object OrderedSetProperties extends FlatSpec with Matchers {
     }
   }
 
-  def testEq[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M]](
+  def testEq[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M] with Set[K]](
     data: Seq[K],
-    empty: OrderedSetLike[K, IN, M]) {
+    map: OrderedSetLike[K, IN, M] with Set[K]) {
 
-    val map1 = scala.util.Random.shuffle(data).foldLeft(empty)((m, e) => m + e)
-    val map2 = scala.util.Random.shuffle(data).foldLeft(empty)((m, e) => m + e)
+    val map1 = scala.util.Random.shuffle(data)
+      .foldLeft(map.empty)((m, e) => (m + e).asInstanceOf[M])
+    val map2 = scala.util.Random.shuffle(data)
+      .foldLeft(map.empty)((m, e) => (m + e).asInstanceOf[M])
 
     (map1 == map2) should be (true)
 
@@ -145,9 +147,9 @@ object OrderedMapProperties extends FlatSpec with Matchers {
   import RBProperties._
 
   // Assumes 'data' is in key order
-  def testKV[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M]](
+  def testKV[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M] with Map[K, V]](
     data: Seq[(K, V)],
-    omap: OrderedMapLike[K, V, IN, M]) {
+    omap: OrderedMapLike[K, V, IN, M] with Map[K, V]) {
 
     // verify the map elements are ordered by key
     omap.keys should beEqSeq(data.map(_._1))
@@ -158,9 +160,9 @@ object OrderedMapProperties extends FlatSpec with Matchers {
   }
 
   // Assumes 'data' is in key order
-  def testDel[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M]](
+  def testDel[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M] with Map[K, V]](
     data: Seq[(K, V)],
-    omap: OrderedMapLike[K, V, IN, M]) {
+    omap: OrderedMapLike[K, V, IN, M] with Map[K, V]) {
 
     data.iterator.map(_._1).foreach { key =>
       val delMap = omap - key
@@ -170,12 +172,14 @@ object OrderedMapProperties extends FlatSpec with Matchers {
     }
   }
 
-  def testEq[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M]](
+  def testEq[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M] with Map[K, V]](
     data: Seq[(K, V)],
-    empty: OrderedMapLike[K, V, IN, M]) {
+    map: OrderedMapLike[K, V, IN, M] with Map[K, V]) {
 
-    val map1 = scala.util.Random.shuffle(data).foldLeft(empty)((m, e) => m + e)
-    val map2 = scala.util.Random.shuffle(data).foldLeft(empty)((m, e) => m + e)
+    val map1 = scala.util.Random.shuffle(data)
+      .foldLeft(map.empty)((m, e) => (m + e).asInstanceOf[M])
+    val map2 = scala.util.Random.shuffle(data)
+      .foldLeft(map.empty)((m, e) => (m + e).asInstanceOf[M])
 
     (map1 == map2) should be (true)
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/ordered.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/ordered.scala
@@ -1,0 +1,295 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.maps.ordered
+
+import org.scalatest._
+
+import com.twitter.algebird.matchers.seq._
+
+object RBProperties extends FlatSpec with Matchers {
+  import com.twitter.algebird.maps.redblack.tree._
+
+  def color[K](node: Node[K]): Color = node match {
+    case n: INode[K] => n.color
+    case _ => B
+  }
+
+  def testBlackHeight[K](node: Node[K]): Int = node match {
+    case n: LNode[K] => 1
+
+    case n: INode[K] if (n.color == R) => {
+      val lh = testBlackHeight(n.lsub)
+      val rh = testBlackHeight(n.rsub)
+      if (!(lh > 0 && lh == rh)) 0 else lh
+    }
+
+    case n: INode[K] if (n.color == B) => {
+      val lh = testBlackHeight(n.lsub)
+      val rh = testBlackHeight(n.rsub)
+      if (!(lh > 0 && lh == rh)) 0 else 1 + lh
+    }
+
+    case _ => throw new Exception("bad node trait")
+  }
+
+  def testRedChildrenBlack[K](node: Node[K]): Boolean = node match {
+    case n: LNode[K] => true
+
+    case n: INode[K] if (n.color == R) =>
+      color(n.lsub) == B && color(n.rsub) == B &&
+        testRedChildrenBlack(n.lsub) && testRedChildrenBlack(n.rsub)
+
+    case n: INode[K] if (n.color == B) =>
+      testRedChildrenBlack(n.lsub) && testRedChildrenBlack(n.rsub)
+
+    case _ => throw new Exception("bad node trait")
+  }
+
+  def testBalance[K](node: Node[K]): (Int, Int) = node match {
+    case n: LNode[K] => (0, 0)
+
+    case n: INode[K] => {
+      val (lmin, lmax) = testBalance(n.lsub)
+      val (rmin, rmax) = testBalance(n.rsub)
+      if ((lmax <= (2 * lmin)) && (rmax <= (2 * rmin)))
+        (1 + math.min(lmin, rmin), 1 + math.max(lmax, rmax))
+      else
+        (-1, 0)
+    }
+
+    case _ => throw new Exception("bad node trait")
+  }
+
+  // test RB tree invariant properties related to RB construction
+  def testRB[K](root: Node[K]) = {
+    // The root node of a RB tree should be black
+    color(root) should be (B)
+
+    // Every path from a node to its descendant leafs should contain the same # of black nodes
+    testBlackHeight(root) should be > 0
+
+    // If a node is red, then both its children should be black
+    testRedChildrenBlack(root) should be (true)
+
+    // Depth of deepest node should be <= twice the depth of shallowest
+    val (bmin, bmax) = testBalance(root)
+    bmin should be >= 0
+  }
+}
+
+object OrderedSetProperties extends FlatSpec with Matchers {
+  import com.twitter.algebird.maps.redblack.tree.INode
+  import tree._
+  import infra._
+  import RBProperties._
+
+  // Assumes 'data' is in key order
+  def testK[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M]](
+    data: Seq[K],
+    omap: OrderedSetLike[K, IN, M]) {
+
+    // verify the map elements are ordered by key
+    omap.keys should beEqSeq(data)
+  }
+
+  // Assumes 'data' is in key order
+  def testDel[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M]](
+    data: Seq[K],
+    omap: OrderedSetLike[K, IN, M]) {
+
+    data.foreach { key =>
+      val delMap = omap - key
+      val delData = data.filter(_ != key)
+      testRB(delMap)
+      testK(delData, delMap)
+    }
+  }
+
+  def testEq[K, IN <: INode[K], M <: OrderedSetLike[K, IN, M]](
+    data: Seq[K],
+    empty: OrderedSetLike[K, IN, M]) {
+
+    val map1 = scala.util.Random.shuffle(data).foldLeft(empty)((m, e) => m + e)
+    val map2 = scala.util.Random.shuffle(data).foldLeft(empty)((m, e) => m + e)
+
+    (map1 == map2) should be (true)
+
+    data.iterator.foreach { key =>
+      val map1d = map1 - key
+      val map2d = map2 - key
+      (map1d == map2) should be (false)
+      (map1 == map2d) should be (false)
+      ((map1d + key) == map2) should be (true)
+      (map1 == (map2d + key)) should be (true)
+    }
+  }
+}
+
+object OrderedMapProperties extends FlatSpec with Matchers {
+  import tree._
+  import infra._
+  import RBProperties._
+
+  // Assumes 'data' is in key order
+  def testKV[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M]](
+    data: Seq[(K, V)],
+    omap: OrderedMapLike[K, V, IN, M]) {
+
+    // verify the map elements are ordered by key
+    omap.keys should beEqSeq(data.map(_._1))
+
+    // verify the map correctly preserves key -> value mappings
+    data.map(x => omap.get(x._1)) should beEqSeq(data.map(x => Option(x._2)))
+    omap.values should beEqSeq(data.map(_._2))
+  }
+
+  // Assumes 'data' is in key order
+  def testDel[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M]](
+    data: Seq[(K, V)],
+    omap: OrderedMapLike[K, V, IN, M]) {
+
+    data.iterator.map(_._1).foreach { key =>
+      val delMap = omap - key
+      val delData = data.filter(_._1 != key)
+      testRB(delMap)
+      testKV(delData, delMap)
+    }
+  }
+
+  def testEq[K, V, IN <: INodeMap[K, V], M <: OrderedMapLike[K, V, IN, M]](
+    data: Seq[(K, V)],
+    empty: OrderedMapLike[K, V, IN, M]) {
+
+    val map1 = scala.util.Random.shuffle(data).foldLeft(empty)((m, e) => m + e)
+    val map2 = scala.util.Random.shuffle(data).foldLeft(empty)((m, e) => m + e)
+
+    (map1 == map2) should be (true)
+
+    data.iterator.foreach { p =>
+      val (key, value) = p
+      val map1d = map1 - key
+      val map2d = map2 - key
+      (map1d == map2) should be (false)
+      (map1 == map2d) should be (false)
+      ((map1d + ((key, value))) == map2) should be (true)
+      (map1 == (map2d + ((key, value)))) should be (true)
+      val v = data.head._2
+      if (value != v) {
+        ((map1 + ((key, v))) == map2) should be (false)
+        (map1 == (map2 + ((key, v)))) should be (false)
+      }
+    }
+  }
+}
+
+class OrderedSetSpec extends FlatSpec with Matchers {
+  import RBProperties._
+  import OrderedSetProperties._
+
+  def mapType1 = OrderedSet.key[Int]
+
+  it should "pass exhaustive tree patterns" in {
+    // N should remain small, because we are about to exhaustively test N! patterns.
+    // Values larger than 8 rapidly start to take a lot of time, for example my runs for
+    // N = 10 complete in about 10-15 minutes.
+    val N = 8
+    (0 to N).foreach { n =>
+      val data = Vector.tabulate(n)(j => j)
+      data.permutations.foreach { shuffle =>
+        val omap = shuffle.foldLeft(mapType1)((m, e) => m + e)
+        testRB(omap)
+        testK(data, omap)
+        testDel(data, omap)
+      }
+    }
+  }
+
+  it should "pass randomized tree patterns" in {
+    val data = Vector.tabulate(50)(j => j)
+    (1 to 1000).foreach { u =>
+      val shuffled = scala.util.Random.shuffle(data)
+      val omap = shuffled.foldLeft(mapType1)((m, e) => m + e)
+
+      testRB(omap)
+      testK(data, omap)
+      testDel(data, omap)
+      testEq(data, mapType1)
+    }
+  }
+
+  it should "serialize and deserialize" in {
+    import com.twitter.algebird.SerDe.roundTripSerDe
+
+    val data = Vector.tabulate(50)(j => j)
+    val omap = data.foldLeft(mapType1)((m, e) => m + e)
+    val imap = roundTripSerDe(omap)
+
+    (imap == omap) should be (true)
+    testRB(imap)
+    testK(data, imap)
+    testDel(data, imap)
+  }
+}
+
+class OrderedMapSpec extends FlatSpec with Matchers {
+  import RBProperties._
+  import OrderedMapProperties._
+
+  def mapType1 = OrderedMap.key[Int].value[Int]
+
+  it should "pass exhaustive tree patterns" in {
+    // N should remain small, because we are about to exhaustively test N! patterns.
+    // Values larger than 8 rapidly start to take a lot of time, for example my runs for
+    // N = 10 complete in about 10-15 minutes.
+    val N = 8
+    (0 to N).foreach { n =>
+      val data = Vector.tabulate(n)(j => (j, j))
+      data.permutations.foreach { shuffle =>
+        val omap = shuffle.foldLeft(mapType1)((m, e) => m + e)
+        testRB(omap)
+        testKV(data, omap)
+        testDel(data, omap)
+      }
+    }
+  }
+
+  it should "pass randomized tree patterns" in {
+    val data = Vector.tabulate(50)(j => (j, j))
+    (1 to 1000).foreach { u =>
+      val shuffled = scala.util.Random.shuffle(data)
+      val omap = shuffled.foldLeft(mapType1)((m, e) => m + e)
+
+      testRB(omap)
+      testKV(data, omap)
+      testDel(data, omap)
+      testEq(data, mapType1)
+    }
+  }
+
+  it should "serialize and deserialize" in {
+    import com.twitter.algebird.SerDe.roundTripSerDe
+
+    val data = Vector.tabulate(50)(j => (j, j))
+    val omap = data.foldLeft(mapType1)((m, e) => m + e)
+    val imap = roundTripSerDe(omap)
+
+    (imap == omap) should be (true)
+    testRB(imap)
+    testKV(data, imap)
+    testDel(data, imap)
+  }
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/ordered.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/ordered.scala
@@ -130,10 +130,8 @@ object OrderedSetProperties extends FlatSpec with Matchers {
     data: Seq[K],
     map: OrderedSetLike[K, IN, M] with SortedSet[K]) {
 
-    val map1 = scala.util.Random.shuffle(data)
-      .foldLeft(map.empty)((m, e) => (m + e).asInstanceOf[M])
-    val map2 = scala.util.Random.shuffle(data)
-      .foldLeft(map.empty)((m, e) => (m + e).asInstanceOf[M])
+    val map1 = scala.util.Random.shuffle(data).foldLeft(map.empty)((m, e) => m + e)
+    val map2 = scala.util.Random.shuffle(data).foldLeft(map.empty)((m, e) => m + e)
 
     (map1 == map2) should be (true)
 
@@ -195,10 +193,8 @@ object OrderedMapProperties extends FlatSpec with Matchers {
     data: Seq[(K, V)],
     map: OrderedMapLike[K, V, IN, M] with SortedMap[K, V]) {
 
-    val map1 = scala.util.Random.shuffle(data)
-      .foldLeft(map.empty)((m, e) => (m + e).asInstanceOf[M])
-    val map2 = scala.util.Random.shuffle(data)
-      .foldLeft(map.empty)((m, e) => (m + e).asInstanceOf[M])
+    val map1 = scala.util.Random.shuffle(data).foldLeft(map.empty)((m, e) => m + e)
+    val map2 = scala.util.Random.shuffle(data).foldLeft(map.empty)((m, e) => m + e)
 
     (map1 == map2) should be (true)
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/prefixsum.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/prefixsum.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird.maps.prefixsum
 
+import scala.collection.SortedMap
+
 import org.scalatest._
 
 import com.twitter.algebird.Monoid
@@ -27,9 +29,9 @@ object PrefixSumMapProperties extends FlatSpec with Matchers {
   import infra._
 
   // Assumes 'data' is in key order
-  def testPrefix[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K, V, P, IN, M] with Map[K, V]](
+  def testPrefix[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K, V, P, IN, M] with SortedMap[K, V]](
     data: Seq[(K, V)],
-    psmap: PrefixSumMapLike[K, V, P, IN, M] with Map[K, V]) {
+    psmap: PrefixSumMapLike[K, V, P, IN, M] with SortedMap[K, V]) {
 
     val mon = psmap.prefixMonoid
     val psTruth = data.map(_._2).scanLeft(mon.zero)((v, e) => mon.inc(v, e))

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/prefixsum.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/prefixsum.scala
@@ -27,9 +27,9 @@ object PrefixSumMapProperties extends FlatSpec with Matchers {
   import infra._
 
   // Assumes 'data' is in key order
-  def testPrefix[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K, V, P, IN, M]](
+  def testPrefix[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K, V, P, IN, M] with Map[K, V]](
     data: Seq[(K, V)],
-    psmap: PrefixSumMapLike[K, V, P, IN, M]) {
+    psmap: PrefixSumMapLike[K, V, P, IN, M] with Map[K, V]) {
 
     val mon = psmap.prefixMonoid
     val psTruth = data.map(_._2).scanLeft(mon.zero)((v, e) => mon.inc(v, e))

--- a/algebird-test/src/test/scala/com/twitter/algebird/maps/prefixsum.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/maps/prefixsum.scala
@@ -1,0 +1,80 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird.maps.prefixsum
+
+import org.scalatest._
+
+import com.twitter.algebird.Monoid
+
+import com.twitter.algebird.matchers.seq._
+
+object PrefixSumMapProperties extends FlatSpec with Matchers {
+  import tree._
+  import infra._
+
+  // Assumes 'data' is in key order
+  def testPrefix[K, V, P, IN <: INodePS[K, V, P], M <: PrefixSumMapLike[K, V, P, IN, M]](
+    data: Seq[(K, V)],
+    psmap: PrefixSumMapLike[K, V, P, IN, M]) {
+
+    val mon = psmap.prefixMonoid
+    val psTruth = data.map(_._2).scanLeft(mon.zero)((v, e) => mon.inc(v, e))
+    psmap.prefixSums() should beEqSeq(psTruth.tail)
+    psmap.prefixSums(open = true) should beEqSeq(psTruth.dropRight(1))
+    psmap.prefixSums() should beEqSeq(psmap.keys.map(k => psmap.prefixSum(k)))
+    psmap.prefixSums(open = true) should beEqSeq(psmap.keys.map(k => psmap.prefixSum(k, open = true)))
+  }
+}
+
+class PrefixSumMapSpec extends FlatSpec with Matchers {
+  import com.twitter.algebird.maps.ordered.RBProperties._
+  import com.twitter.algebird.maps.ordered.OrderedMapProperties._
+
+  import PrefixSumMapProperties._
+
+  def mapType1 =
+    PrefixSumMap.key[Int].value[Int]
+      .prefix(IncrementingMonoid.fromMonoid(implicitly[Monoid[Int]]))
+
+  it should "pass randomized tree patterns" in {
+    val data = Vector.tabulate(50)(j => (j, j))
+    (1 to 1000).foreach { u =>
+      val shuffled = scala.util.Random.shuffle(data)
+      val psmap = shuffled.foldLeft(mapType1)((m, e) => m + e)
+
+      testRB(psmap)
+      testKV(data, psmap)
+      testDel(data, psmap)
+      testEq(data, mapType1)
+      testPrefix(data, psmap)
+    }
+  }
+
+  it should "serialize and deserialize" in {
+    import com.twitter.algebird.SerDe.roundTripSerDe
+
+    val data = Vector.tabulate(50)(j => (j, j))
+    val omap = data.foldLeft(mapType1)((m, e) => m + e)
+    val imap = roundTripSerDe(omap)
+
+    (imap == omap) should be (true)
+    testRB(imap)
+    testKV(data, imap)
+    testDel(data, imap)
+    testPrefix(data, imap)
+  }
+}


### PR DESCRIPTION
This is a PR for tree and map traits supporting some binary tree algorithms, factored out of the PR for implementing t-digest: #495

A Library of Binary Tree Algorithms as Mixable Scala Traits
http://erikerlandson.github.io/blog/2015/09/26/a-library-of-binary-tree-algorithms-as-mixable-scala-traits/
