### PR TITLE
Implement an appendMonoid Aggregator factory which yields aggregators…

### DIFF
--- a/algebird-spark/src/main/scala/com/twitter/algebird/spark/AlgebirdRDD.scala
+++ b/algebird-spark/src/main/scala/com/twitter/algebird/spark/AlgebirdRDD.scala
@@ -21,8 +21,8 @@ class AlgebirdRDD[T](val rdd: RDD[T]) extends AnyVal {
   def aggregateOption[B: ClassTag, C](agg: Aggregator[T, B, C]): Option[C] = {
     val pr = rdd.mapPartitions({ data =>
       if (data.isEmpty) Iterator.empty else {
-        val sg = agg.prepare(data.next)
-        Iterator(agg.appendAll(sg, data))
+        val b = agg.prepare(data.next)
+        Iterator(agg.appendAll(b, data))
       }
     }, preservesPartitioning = true)
     pr.coalesce(1, shuffle = true)

--- a/algebird-spark/src/main/scala/com/twitter/algebird/spark/AlgebirdRDD.scala
+++ b/algebird-spark/src/main/scala/com/twitter/algebird/spark/AlgebirdRDD.scala
@@ -18,10 +18,17 @@ class AlgebirdRDD[T](val rdd: RDD[T]) extends AnyVal {
    * requires a commutative Semigroup. To generalize to non-commutative, we need a sorted partition for
    * T.
    */
-  def aggregateOption[B: ClassTag, C](agg: Aggregator[T, B, C]): Option[C] =
-    (new AlgebirdRDD(rdd.map(agg.prepare)))
-      .sumOption(agg.semigroup, implicitly)
-      .map(agg.present)
+  def aggregateOption[B: ClassTag, C](agg: Aggregator[T, B, C]): Option[C] = {
+    val pr = rdd.mapPartitions({ data =>
+      if (data.isEmpty) Iterator.empty else {
+        val sg = agg.prepare(data.next)
+        Iterator(agg.appendAll(sg, data))
+      }
+    }, preservesPartitioning = true)
+    pr.coalesce(1, shuffle = true)
+      .mapPartitions(pr => Iterator(agg.semigroup.sumOption(pr)))
+      .collect.head.map(agg.present)
+  }
 
   /**
    * This will throw if you use a non-MonoidAggregator with an empty RDD

--- a/algebird-test/src/test/scala/com/twitter/algebird/AppendAggregatorTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AppendAggregatorTest.scala
@@ -6,16 +6,16 @@ class AppendAggregatorTest extends WordSpec with Matchers {
   val data = Vector.fill(100) { scala.util.Random.nextInt(100) }
   val mpty = Vector.empty[Int]
 
-  // test the methods that appendMonoid method defines or overrides
-  def testMethods[E, M, P](
-    agg1: MonoidAggregator[E, M, P],
-    agg2: MonoidAggregator[E, M, P],
+  // test the methods that appendSemigroup method defines or overrides
+  def testMethodsSemigroup[E, M, P](
+    agg1: Aggregator[E, M, P],
+    agg2: Aggregator[E, M, P],
     data: Seq[E],
     empty: Seq[E]) {
 
     val n = data.length
     val (half1, half2) = data.splitAt(n / 2)
-    val lhs = agg1.appendAll(half1)
+    val lhs = agg1.appendAll(agg1.prepare(half1.head), half1.tail)
 
     data.foreach { e =>
       agg1.prepare(e) should be(agg2.prepare(e))
@@ -24,7 +24,6 @@ class AppendAggregatorTest extends WordSpec with Matchers {
     agg1.present(lhs) should be(agg2.present(lhs))
 
     agg1(data) should be (agg2(data))
-    agg1(empty) should be (agg2(empty))
 
     agg1.applyOption(data) should be(agg2.applyOption(data))
     agg1.applyOption(empty) should be(agg2.applyOption(empty))
@@ -34,15 +33,26 @@ class AppendAggregatorTest extends WordSpec with Matchers {
     }
 
     agg1.appendAll(lhs, half2) should be(agg2.appendAll(lhs, half2))
+  }
 
-    agg2.appendAll(data) should be(agg2.appendAll(data))
+  // test the methods that appendMonoid method defines or overrides
+  def testMethodsMonoid[E, M, P](
+    agg1: MonoidAggregator[E, M, P],
+    agg2: MonoidAggregator[E, M, P],
+    data: Seq[E],
+    empty: Seq[E]) {
+
+    testMethodsSemigroup(agg1, agg2, data, empty)
+
+    agg1(empty) should be (agg2(empty))
+    agg1.appendAll(data) should be(agg2.appendAll(data))
   }
 
   "appendMonoid" should {
     "be equivalent to integer monoid aggregator" in {
       val agg1 = Aggregator.fromMonoid[Int]
       val agg2 = Aggregator.appendMonoid((m: Int, e: Int) => m + e)
-      testMethods(agg1, agg2, data, mpty)
+      testMethodsMonoid(agg1, agg2, data, mpty)
     }
 
     "be equivalent to set monoid aggregator" in {
@@ -54,7 +64,26 @@ class AppendAggregatorTest extends WordSpec with Matchers {
       val agg1 = Aggregator.prepareMonoid((e: Int) => Set(e))(setMonoid)
       val agg2 = Aggregator.appendMonoid((m: Set[Int], e: Int) => m + e)(setMonoid)
 
-      testMethods(agg1, agg2, data, mpty)
+      testMethodsMonoid(agg1, agg2, data, mpty)
+    }
+  }
+
+  "appendSemigroup" should {
+    "be equivalent to integer semigroup aggregator" in {
+      val agg1 = Aggregator.fromSemigroup[Int]
+      val agg2 = Aggregator.appendSemigroup(identity[Int]_, (m: Int, e: Int) => m + e)
+      testMethodsSemigroup(agg1, agg2, data, mpty)
+    }
+
+    "be equivalent to set semigroup aggregator" in {
+      object setSemigroup extends Semigroup[Set[Int]] {
+        def plus(m1: Set[Int], m2: Set[Int]) = m1 ++ m2
+      }
+
+      val agg1 = Aggregator.prepareSemigroup((e: Int) => Set(e))(setSemigroup)
+      val agg2 = Aggregator.appendSemigroup((e: Int) => Set(e), (m: Set[Int], e: Int) => m + e)(setSemigroup)
+
+      testMethodsSemigroup(agg1, agg2, data, mpty)
     }
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/AppendAggregatorTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AppendAggregatorTest.scala
@@ -1,0 +1,60 @@
+package com.twitter.algebird
+
+import org.scalatest._
+
+class AppendAggregatorTest extends WordSpec with Matchers {
+  val data = Vector.fill(100) { scala.util.Random.nextInt(100) }
+  val mpty = Vector.empty[Int]
+
+  // test the methods that appendMonoid method defines or overrides
+  def testMethods[E, M, P](
+    agg1: MonoidAggregator[E, M, P],
+    agg2: MonoidAggregator[E, M, P],
+    data: Seq[E],
+    empty: Seq[E]) {
+
+    val n = data.length
+    val (half1, half2) = data.splitAt(n / 2)
+    val lhs = agg1.appendAll(half1)
+
+    data.foreach { e =>
+      agg1.prepare(e) should be(agg2.prepare(e))
+    }
+
+    agg1.present(lhs) should be(agg2.present(lhs))
+
+    agg1(data) should be (agg2(data))
+    agg1(empty) should be (agg2(empty))
+
+    agg1.applyOption(data) should be(agg2.applyOption(data))
+    agg1.applyOption(empty) should be(agg2.applyOption(empty))
+
+    half2.foreach { e =>
+      agg1.append(lhs, e) should be(agg2.append(lhs, e))
+    }
+
+    agg1.appendAll(lhs, half2) should be(agg2.appendAll(lhs, half2))
+
+    agg2.appendAll(data) should be(agg2.appendAll(data))
+  }
+
+  "appendMonoid" should {
+    "be equivalent to integer monoid aggregator" in {
+      val agg1 = Aggregator.fromMonoid[Int]
+      val agg2 = Aggregator.appendMonoid((m: Int, e: Int) => m + e)
+      testMethods(agg1, agg2, data, mpty)
+    }
+
+    "be equivalent to set monoid aggregator" in {
+      object setMonoid extends Monoid[Set[Int]] {
+        val zero = Set.empty[Int]
+        def plus(m1: Set[Int], m2: Set[Int]) = m1 ++ m2
+      }
+
+      val agg1 = Aggregator.prepareMonoid((e: Int) => Set(e))(setMonoid)
+      val agg2 = Aggregator.appendMonoid((m: Set[Int], e: Int) => m + e)(setMonoid)
+
+      testMethods(agg1, agg2, data, mpty)
+    }
+  }
+}


### PR DESCRIPTION
… that can take advantage of an efficient append method for faster aggregations.

This is a PR in response to:
http://erikerlandson.github.io/blog/2015/11/24/the-prepare-operation-considered-harmful-in-algebird/

The rationale for a solution based on a factory function is that the `append` method and `prepare` method need to remain logically consistent with each other.  The factory function enforces that logical constraint, and in addition allows a few other efficient overrides.

Working through this issue has left me still feeling like an Aggregator class explicitly based on a Monoid, augmented with `append`, is desirable.  The main problem is that it would not be backward compatible with the current design that requires a definition of `prepare`.

Related but tangential, I'm still feeling like a `Monoid[T]` subclass `AppendMonoid[T, E]`, having `zero`, `plus` and `append`, is a possibly useful thing.  The type laws for such an object would include all the Monoid type laws, and also probably something like:

```scala
mon.append(t, e) == mon.plus(t, mon.append(mon.zero, e))
```
