### PR TITLE
Using dropRight instead of tail for shortening BytesSpec array

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/BytesSpec.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BytesSpec.scala
@@ -115,11 +115,9 @@ class BytesSpec extends WordSpec with Matchers with GeneratorDrivenPropertyCheck
       suffixed should be > bytes1
 
       // 4. a Bytes instances and a "shorter" Bytes instance.
-      if (bytes1.array.length > 1) {
-        val shortened = Bytes(bytes1.array.tail)
-        bytes1 should be > shortened
-        shortened should be < bytes1
-      }
+      val shortened = Bytes(bytes1.array.dropRight(1))
+      bytes1 should be > shortened
+      shortened should be < bytes1
     }
   }
 


### PR DESCRIPTION
A truncated array is only guaranteed to compare as less if the truncation happens at the end.  Also we should be able to compare an empty Array so I'm not excluding the case where length == 1.

I've verified this by testing with a "\0" prefix on the random string (which makes the original code fail consistently).

Fixes #503 