### PR TITLE
Using dropRight instead of tail for shortening BytesSpec array

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/BytesSpec.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BytesSpec.scala
@@ -115,11 +115,9 @@ class BytesSpec extends WordSpec with Matchers with GeneratorDrivenPropertyCheck
       suffixed should be > bytes1
 
       // 4. a Bytes instances and a "shorter" Bytes instance.
-      if (bytes1.array.length > 1) {
-        val shortened = Bytes(bytes1.array.tail)
-        bytes1 should be > shortened
-        shortened should be < bytes1
-      }
+      val shortened = Bytes(bytes1.array.dropRight(1))
+      bytes1 should be > shortened
+      shortened should be < bytes1
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/BytesSpec.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BytesSpec.scala
@@ -12,7 +12,7 @@ class BytesSpec extends WordSpec with Matchers with GeneratorDrivenPropertyCheck
 
   "has a sane equals function" in {
     val random = new scala.util.Random
-    forAll((Gen.choose(1, 4096), "wordLength")) { (wordLength: Int) =>
+    forAll((Gen.choose(0, 4096), "wordLength")) { (wordLength: Int) =>
       // Given two different array instances that have the same content.
       val word = random.nextString(wordLength)
       val array1 = word.getBytes
@@ -63,7 +63,7 @@ class BytesSpec extends WordSpec with Matchers with GeneratorDrivenPropertyCheck
 
   "has a sane hashCode function" in {
     val random = new scala.util.Random
-    forAll((Gen.choose(1, 4096), "wordLength")) { (wordLength: Int) =>
+    forAll((Gen.choose(0, 4096), "wordLength")) { (wordLength: Int) =>
       // Given two Bytes instances that are equal.
       val word = random.nextString(wordLength)
       val array1 = word.getBytes
@@ -90,7 +90,7 @@ class BytesSpec extends WordSpec with Matchers with GeneratorDrivenPropertyCheck
 
   "provides an Ordering typeclass" in {
     val random = new scala.util.Random
-    forAll((Gen.choose(1, 4096), "wordLength")) { (wordLength: Int) =>
+    forAll((Gen.choose(0, 4096), "wordLength")) { (wordLength: Int) =>
       val word = random.nextString(wordLength)
       val array1 = word.getBytes
       val array2 = word.getBytes
@@ -115,9 +115,11 @@ class BytesSpec extends WordSpec with Matchers with GeneratorDrivenPropertyCheck
       suffixed should be > bytes1
 
       // 4. a Bytes instances and a "shorter" Bytes instance.
-      val shortened = Bytes(bytes1.array.dropRight(1))
-      bytes1 should be > shortened
-      shortened should be < bytes1
+      if (bytes1.array.length > 0) {
+        val shortened = Bytes(bytes1.array.dropRight(1))
+        bytes1 should be > shortened
+        shortened should be < bytes1
+      }
     }
   }
 


### PR DESCRIPTION
A truncated array is only guaranteed to compare as less if the truncation happens at the end. Also we should be able to compare an empty Array so I'm not excluding the case where length == 1.

I've verified this by testing with a "\0" prefix on the random string (which makes the original code fail consistently).

Also testing empty arrays here.

Recreates #504
Fixes #503