### PR TITLE
Fix flaky `MinHasherSpec` test.  Fixes #500

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
@@ -55,7 +55,7 @@ class MinHasherSpec extends WordSpec with Matchers {
     "measure 0.5 similarity in 1024 bytes with < 0.1 error" in {
       test(new MinHasher32(0.5, 1024), 0.5, 0.1)
     }
-    "measure 0.8 similarity in 1024 bytes with < 0.05 error" in {
+    "measure 0.8 similarity in 1024 bytes with < 0.1 error" in {
       test(new MinHasher32(0.8, 1024), 0.8, 0.1)
     }
     "measure 1.0 similarity in 1024 bytes with < 0.01 error" in {

--- a/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
@@ -56,7 +56,7 @@ class MinHasherSpec extends WordSpec with Matchers {
       test(new MinHasher32(0.5, 1024), 0.5, 0.1)
     }
     "measure 0.8 similarity in 1024 bytes with < 0.05 error" in {
-      test(new MinHasher32(0.8, 1024), 0.8, 0.05)
+      test(new MinHasher32(0.8, 1024), 0.8, 0.1)
     }
     "measure 1.0 similarity in 1024 bytes with < 0.01 error" in {
       test(new MinHasher32(1.0, 1024), 1.0, 0.01)


### PR DESCRIPTION
One `MinHasher32` being tested was using 247 hash functions internally, which
means that the expected absolute error bound:

    1 / sqrt {# of hash functions} = 1 / sqrt 247  ~  0.064

The same test required an upper bound on the error of `0.05`, which was below
the expected error bound, meaning that this test would give flaky results due to
occasionally exceeding the required error bound.  This change increases the
upper bound on the error to 0.1 which should give enough headroom over the
expected error bound to reduce the number of random test failures.