### PR TITLE
Fix the input type of Operators.toRichTraversable

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Operators.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Operators.scala
@@ -20,7 +20,7 @@ object Operators {
   implicit def toMinus[T: Group](t: T) = new MinusOp(t)
   implicit def toTimes[T: Ring](t: T) = new TimesOp(t)
   implicit def toDiv[T: Field](t: T) = new DivOp(t)
-  implicit def toRichTraversable[T](t: Traversable[T]) = new RichTraversable(t)
+  implicit def toRichTraversable[T](t: TraversableOnce[T]) = new RichTraversable(t)
 }
 
 class PlusOp[T: Semigroup](t: T) {


### PR DESCRIPTION
I could be missing something obvious, but I think Operators.toRichTraversable should take a TraversableOnce instead of a Traversable. This will allow it to be less restrictive in the input types that it allows.

Currently:
```
scala> import com.twitter.algebird.Operators.toRichTraversable

scala> val x: Traversable[Int] = Traversable(1, 2, 3)
x: Traversable[Int] = List(1, 2, 3)
scala> x.monoidSum
res11: Int = 6

scala> val y: TraversableOnce[Int] = Traversable(1, 2, 3)
y: TraversableOnce[Int] = List(1, 2, 3)
scala> y.monoidSum
<console>:17: error: value monoidSum is not a member of TraversableOnce[Int]
              y.monoidSum
                ^
```

With my fix:
```
scala> val y: TraversableOnce[Int] = Traversable(1, 2, 3)
y: TraversableOnce[Int] = List(1, 2, 3)

scala> y.monoidSum
res0: Int = 6
```