### PR TITLE
make SSOne/SSMany constructors private and add apply method with count

### DIFF
--- a/algebird-test/src/test/scala/com/twitter/algebird/SpaceSaverTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SpaceSaverTest.scala
@@ -51,5 +51,9 @@ class SpaceSaverTest extends WordSpec with Matchers {
             assert(approx ~ exactCounts(item))
         }
     }
+
+    "be consistent in its constructors" in {
+      assert(SpaceSaver(10, "ha") ++ SpaceSaver(10, "ha") ++ SpaceSaver(10, "ha") === SpaceSaver(10, "ha", 3))
+    }
   }
 }


### PR DESCRIPTION
These constructors should have been private from the beginning. The documentation already says other constructors should be used instead.
Also a new constructor/apply is added to set the exact count of an item instead of default value of 1