### PR TITLE
Bump scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ def isScala210x(scalaVersion: String) = scalaBinaryVersion(scalaVersion) == "2.1
 
 val sharedSettings = Project.defaultSettings ++ scalariformSettings ++  Seq(
   organization := "com.twitter",
-  scalaVersion := "2.10.5",
+  scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.10.5", "2.11.7"),
   ScalariformKeys.preferences := formattingPreferences,
 


### PR DESCRIPTION
While investigating some dbuild failures on our OSS projects, noticed that the scalaVersion in algebird was set to 2.10.x (this resulted in some cross-version compatibility issues). Setting it to 2.11.7 (we still create artifacts for 2.10.x). 