### PR TITLE
Add sortedTakeBy and sortedReverseTakeBy to Aggregator.scala

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -183,10 +183,24 @@ object Aggregator extends java.io.Serializable {
   def sortedTake[T: Ordering](count: Int): MonoidAggregator[T, PriorityQueue[T], Seq[T]] =
     new mutable.PriorityQueueToListAggregator[T](count)
   /**
+   * Same as sortedTake, but using a function that returns a value that has an Ordering.
+   *
+   * This function is like writing list.sortBy(fn).take(count).
+   */
+  def sortByTake[T, U: Ordering](count: Int)(fn: T => U): MonoidAggregator[T, PriorityQueue[T], Seq[T]] =
+    Aggregator.sortedTake(count)(Ordering.by(fn))
+  /**
    * Take the largest `count` items using a heap
    */
   def sortedReverseTake[T: Ordering](count: Int): MonoidAggregator[T, PriorityQueue[T], Seq[T]] =
     new mutable.PriorityQueueToListAggregator[T](count)(implicitly[Ordering[T]].reverse)
+  /**
+   * Same as sortedReverseTake, but using a function that returns a value that has an Ordering.
+   *
+   * This function is like writing list.sortBy(fn).reverse.take(count).
+   */
+  def sortByReverseTake[T, U: Ordering](count: Int)(fn: T => U): MonoidAggregator[T, PriorityQueue[T], Seq[T]] =
+    Aggregator.sortedReverseTake(count)(Ordering.by(fn))
   /**
    * Immutable version of sortedTake, for frameworks that check immutability of reduce functions.
    */


### PR DESCRIPTION
You can accomplish the same thing by passing Ordering.by(fn) directly to the sortedTake function, but I think adding these new functions makes the code a bit easier to use and will make downstream code more readable.

I didn’t see any existing unit tests on Aggregator.sortedTake, so I didn’t add any tests to this code. But would be willing to add some additional tests if we feel it is necessary.