### PR TITLE
Add Batched[A] type for efficient lazy addition

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Batched.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Batched.scala
@@ -126,7 +126,7 @@ object Batched {
    * produce different lists (for instance, if one of the batches has
    * more zeros in it than another one).
    */
-  def equiv[A](implicit s: Semigroup[A]): Equiv[Batched[A]] =
+  implicit def equiv[A](implicit s: Semigroup[A]): Equiv[Batched[A]] =
     new Equiv[Batched[A]] {
       def equiv(x: Batched[A], y: Batched[A]): Boolean = x.sum(s) == y.sum(s)
     }
@@ -285,7 +285,7 @@ object Batched {
    */
   private[algebird] class ReverseItemsIterator[A](root: Batched[A]) extends ItemsIterator[A](root) {
     def descend(v: Batched[A]): A = {
-      @tailrec def descend0(v: Batched[A]): A =
+      @inline @tailrec def descend0(v: Batched[A]): A =
         v match {
           case Items(lhs, rhs) =>
             stack = lhs :: stack

--- a/algebird-core/src/main/scala/com/twitter/algebird/Batched.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Batched.scala
@@ -1,0 +1,303 @@
+package com.twitter.algebird
+
+import scala.annotation.tailrec
+
+/**
+ * Batched: the free semigroup.
+ *
+ * For any type `T`, `Batched[T]` represents a way to lazily combine T
+ * values as a semigroup would (i.e. associatively). A `Semigroup[T]`
+ * instance can be used to recover a `T` value from a `Batched[T]`.
+ *
+ * Like other free structures, Batched trades space for time. A sum of
+ * batched values defers the underlying semigroup action, instead
+ * storing all values in memory (in a tree structure). If an
+ * underlying semigroup is available, `Batched.semigroup` and
+ * `Batch.monoid` can be configured to periodically sum the tree to
+ * keep the overall size below `batchSize`.
+ *
+ * `Batched[T]` values are guaranteed not to be empty -- that is, they
+ * will contain at least one `T` value.
+ */
+sealed abstract class Batched[T] {
+
+  /**
+   * Sum all the `T` values in this batch using the given semigroup.
+   */
+  def sum(implicit sg: Semigroup[T]): T
+
+  /**
+   * Combine two batched values.
+   *
+   * As mentioned above, this just creates a new tree structure
+   * containing `this` and `that`.
+   */
+  def combine(that: Batched[T]): Batched[T] =
+    Batched.Items(this, that)
+
+  /**
+   * Add more values to a batched value.
+   *
+   * This method will grow the tree to the left.
+   */
+  def append(that: TraversableOnce[T]): Batched[T] =
+    that.foldLeft(this)((b, t) => b.combine(Batched(t)))
+
+  /**
+   * Provide an iterator over the underlying tree structure.
+   *
+   * This is the order used by `.sum`.
+   *
+   * This iterator traverses the tree from left-to-right. If the
+   * original expression was (w + x + y + z), this iterator returns w,
+   * x, y, and then z.
+   */
+  def iterator: Iterator[T] =
+    this match {
+      case Batched.Item(t) => Iterator.single(t)
+      case b => new Batched.ForwardItemsIterator(b)
+    }
+
+  /**
+   * Convert the batch to a `List[T]`.
+   */
+  def toList: List[T] =
+    reverseIterator.foldLeft(List.empty[T])((ts, t) => t :: ts)
+
+  /**
+   * Provide a reversed iterator over the underlying tree structure.
+   *
+   * This iterator traverses the tree from right-to-left. If the
+   * original expression was (w + x + y + z), this iterator returns z,
+   * y, x, and then w.
+   */
+  def reverseIterator: Iterator[T] =
+    this match {
+      case Batched.Item(t) => Iterator.single(t)
+      case b => new Batched.ReverseItemsIterator(b)
+    }
+
+  /**
+   * Report the size of the underlying tree structure.
+   */
+  def size: Int
+}
+
+object Batched {
+
+  /**
+   * Constructed a batch from a single value.
+   */
+  def apply[T](t: T): Batched[T] =
+    Item(t)
+
+  /**
+   * Constructed an optional batch from a collection of values.
+   *
+   * Since batches cannot be empty, this method returns `None` if `ts`
+   * is empty, and `Some(batch)` otherwise.
+   */
+  def items[T](ts: TraversableOnce[T]): Option[Batched[T]] =
+    if (ts.isEmpty) None else {
+      val it = ts.toIterator
+      val t0 = it.next
+      Some(Item(t0).append(it))
+    }
+
+  /**
+   * The free semigroup for batched values.
+   *
+   * This semigroup just accumulates batches and doesn't ever evaluate
+   * them to flatten the tree.
+   */
+  implicit def semigroup[A]: Semigroup[Batched[A]] =
+    new Semigroup[Batched[A]] {
+      def plus(x: Batched[A], y: Batched[A]): Batched[A] = x combine y
+    }
+
+  /**
+   * Compacting semigroup for batched values.
+   *
+   * This semigroup ensures that the batch's tree structure has fewer
+   * than `batchSize` values in it. When more values are added, the
+   * tree is compacted using `s`.
+   */
+  def semigroup[A](batchSize: Int)(implicit s: Semigroup[A]): Semigroup[Batched[A]] =
+    new BatchedSemigroup[A](batchSize, s)
+
+  /**
+   * Monoid for batched values.
+   *
+   * This monoid just accumulates batches and doesn't ever evaluate
+   * them to flatten the tree.
+   *
+   * It represents the identity using `Batched(m.zero)`, but does not
+   * have a unique representation of zero. For example, `zero combine
+   * zero` has a different tree structure to `zero`, but they both
+   * represent the same value (as seen by `.sum`).
+   */
+  def monoid[A](implicit m: Monoid[A]): Monoid[Batched[A]] =
+    new Monoid[Batched[A]] {
+      val zero: Batched[A] = Batched(m.zero)
+      def plus(x: Batched[A], y: Batched[A]): Batched[A] = x combine y
+    }
+
+  /**
+   * Compacting monoid for batched values.
+   *
+   * This monoid ensures that the batch's tree structure has fewer
+   * than `batchSize` values in it. When more values are added, the
+   * tree is compacted using `m`.
+   */
+  def monoid[A](batchSize: Int)(implicit m: Monoid[A]): Monoid[Batched[A]] =
+    new BatchedMonoid[A](batchSize, m)
+
+  def aggregator[A, B, C](batchSize: Int, agg: Aggregator[A, B, C]): Aggregator[A, Batched[B], C] = new Aggregator[A, Batched[B], C] {
+    def prepare(a: A): Batched[B] = Item(agg.prepare(a))
+    def semigroup: Semigroup[Batched[B]] = new BatchedSemigroup(batchSize, agg.semigroup)
+    def present(b: Batched[B]): C = agg.present(b.sum(agg.semigroup))
+  }
+
+  def monoidAggregator[A, B, C](batchSize: Int, agg: MonoidAggregator[A, B, C]): MonoidAggregator[A, Batched[B], C] =
+    new MonoidAggregator[A, Batched[B], C] {
+      def prepare(a: A): Batched[B] = Item(agg.prepare(a))
+      def monoid: Monoid[Batched[B]] = new BatchedMonoid(batchSize, agg.monoid)
+      def present(b: Batched[B]): C = agg.present(b.sum(agg.semigroup))
+    }
+
+  def foldOption[T: Semigroup](batchSize: Int): Fold[T, Option[T]] =
+    Fold.foldLeft[T, Option[Batched[T]]](None: Option[Batched[T]]) {
+      case (Some(b), t) => Some(b.combine(Item(t)))
+      case (None, t) => Some(Item(t))
+    }
+      .map(_.map(_.sum))
+
+  def fold[T: Monoid](batchSize: Int): Fold[T, T] =
+    Fold.foldLeft[T, Batched[T]](Batched(Monoid.zero[T])) { (b, t) => b.combine(Item(t)) }
+      .map(_.sum)
+
+  /**
+   * This represents a single (unbatched) value.
+   */
+  private[algebird] case class Item[T](t: T) extends Batched[T] {
+    def size: Int = 1
+    def sum(implicit sg: Semigroup[T]): T = t
+  }
+
+  /**
+   * This represents two (or more) batched values being added.
+   *
+   * The actual addition is deferred until the `.sum` method is called.
+   */
+  private[algebird] case class Items[T](left: Batched[T], right: Batched[T]) extends Batched[T] {
+    // Items#size will always be >= 2.
+    val size: Int = left.size + right.size
+
+    def sum(implicit sg: Semigroup[T]): T =
+      sg.sumOption(new ForwardItemsIterator(this)).get
+  }
+
+  /**
+   * Abstract iterator through a batch's tree.
+   *
+   * This class is agnostic about whether the traversal is
+   * left-to-right or right-to-left. The abstract method `descend`
+   * controls which direction the iterator moves.
+   */
+  private[algebird] abstract class ItemsIterator[A](root: Batched[A]) extends Iterator[A] {
+    var stack: List[Batched[A]] = Nil
+    var running: Boolean = true
+    var ready: A = descend(root)
+
+    def ascend(): Unit =
+      stack match {
+        case Nil =>
+          running = false
+        case h :: t =>
+          stack = t
+          ready = descend(h)
+      }
+
+    def descend(v: Batched[A]): A
+
+    def hasNext: Boolean =
+      running
+
+    def next(): A =
+      if (running) {
+        val result = ready
+        ascend()
+        result
+      } else {
+        throw new NoSuchElementException("next on empty iterator")
+      }
+  }
+
+  /**
+   * Left-to-right iterator through a batch's tree.
+   */
+  private[algebird] class ForwardItemsIterator[A](root: Batched[A]) extends ItemsIterator[A](root) {
+    def descend(v: Batched[A]): A = {
+      @inline @tailrec def descend0(v: Batched[A]): A =
+        v match {
+          case Items(lhs, rhs) =>
+            stack = rhs :: stack
+            descend0(lhs)
+          case Item(value) =>
+            value
+        }
+      descend0(v)
+    }
+  }
+
+  /**
+   * Right-to-left iterator through a batch's tree.
+   */
+  private[algebird] class ReverseItemsIterator[A](root: Batched[A]) extends ItemsIterator[A](root) {
+    def descend(v: Batched[A]): A = {
+      @tailrec def descend0(v: Batched[A]): A =
+        v match {
+          case Items(lhs, rhs) =>
+            stack = lhs :: stack
+            descend0(rhs)
+          case Item(value) =>
+            value
+        }
+      descend0(v)
+    }
+  }
+}
+
+/**
+ * Compacting semigroup for batched values.
+ *
+ * This semigroup ensures that the batch's tree structure has fewer
+ * than `batchSize` values in it. When more values are added, the
+ * tree is compacted using `s`.
+ */
+class BatchedSemigroup[T](batchSize: Int, sg: Semigroup[T]) extends Semigroup[Batched[T]] {
+
+  require(batchSize > 0, s"Batch size must be > 0, found: $batchSize")
+
+  def plus(a: Batched[T], b: Batched[T]): Batched[T] = {
+    val next = Batched.Items(a, b)
+    if (next.size < batchSize) next
+    else Batched.Item(next.sum(sg))
+  }
+}
+
+/**
+ * Compacting monoid for batched values.
+ *
+ * This monoid ensures that the batch's tree structure has fewer
+ * than `batchSize` values in it. When more values are added, the
+ * tree is compacted using `m`.
+ */
+class BatchedMonoid[T](batchSize: Int, monoid: Monoid[T]) extends BatchedSemigroup(batchSize, monoid) with Monoid[Batched[T]] {
+  val zero: Batched[T] = Batched(monoid.zero)
+
+  // if we knew that (a+b=0) only for (a=0, b=0), we could instead do:
+  //   new Batched.ItemsIterator(b).exists(monoid.isNonZero)
+  override def isNonZero(b: Batched[T]): Boolean =
+    monoid.isNonZero(b.sum(monoid))
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/BatchedTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BatchedTest.scala
@@ -1,0 +1,71 @@
+package com.twitter.algebird
+
+import org.scalatest._
+
+import org.scalatest.prop.PropertyChecks
+import org.scalacheck.{ Gen, Arbitrary, Prop, Properties }
+import Arbitrary.arbitrary
+
+import scala.collection.BitSet
+
+import java.lang.AssertionError
+import java.util.Arrays
+
+object Helpers {
+  implicit def arbitraryBatched[A: Arbitrary]: Arbitrary[Batched[A]] = {
+    val item = arbitrary[A].map(Batched(_))
+    val items = arbitrary[(A, List[A])].map {
+      case (a, as) =>
+        Batched(a).append(as)
+    }
+    Arbitrary(Gen.oneOf(item, items))
+  }
+}
+
+import Helpers.arbitraryBatched
+
+class BatchedLaws extends CheckProperties with Matchers with PropertyChecks {
+
+  import BaseProperties._
+
+  def testBatchedMonoid[A: Arbitrary: Monoid](name: String, size: Int): Unit = {
+    implicit val m: Monoid[Batched[A]] = Batched.monoid[A](size)
+    property(s"CountMinSketch[$name] batched at $size is a Monoid") {
+      monoidLawsEq[Batched[A]](_.sum == _.sum)
+    }
+  }
+
+  testBatchedMonoid[Int]("Int", 1)
+  testBatchedMonoid[Int]("Int", 10)
+  testBatchedMonoid[Int]("Int", 100)
+  testBatchedMonoid[Int]("Int", 1000000)
+  testBatchedMonoid[BigInt]("BigInt", 1)
+  testBatchedMonoid[BigInt]("BigInt", 10)
+  testBatchedMonoid[BigInt]("BigInt", 100)
+  testBatchedMonoid[BigInt]("BigInt", 1000000)
+  testBatchedMonoid[String]("String", 1)
+  testBatchedMonoid[String]("String", 10)
+  testBatchedMonoid[String]("String", 100)
+  testBatchedMonoid[String]("String", 1000000)
+}
+
+class BatchedTests extends PropSpec with Matchers with PropertyChecks {
+  property(".iterator works") {
+    forAll { (x: Int, xs: List[Int]) =>
+      Batched(x).append(xs).iterator.toList shouldBe (x :: xs)
+    }
+  }
+
+  property(".iterator and .reverseIterator agree") {
+    forAll { (b: Batched[Int]) =>
+      b.iterator.toList.reverse shouldBe b.reverseIterator.toList
+      b.iterator.sum shouldBe b.reverseIterator.sum
+    }
+  }
+
+  property(".toList works") {
+    forAll { (b: Batched[Int]) =>
+      b.toList shouldBe b.iterator.toList
+    }
+  }
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/BatchedTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BatchedTest.scala
@@ -29,7 +29,7 @@ class BatchedLaws extends CheckProperties with Matchers with PropertyChecks {
   import BaseProperties._
 
   def testBatchedMonoid[A: Arbitrary: Monoid](name: String, size: Int): Unit = {
-    implicit val m: Monoid[Batched[A]] = Batched.monoid[A](size)
+    implicit val m: Monoid[Batched[A]] = Batched.compactingMonoid[A](size)
     property(s"CountMinSketch[$name] batched at $size is a Monoid") {
       monoidLawsEq[Batched[A]](_.sum == _.sum)
     }


### PR DESCRIPTION
This is the free semigroup -- it represents combining one or more
elements using an associative operation. The values are stored in a
tree structure, which can be traversed. If a semigroup for the
underlying values becomes available, the structure can be summed to a
single value.

Batching represents a space/time trade-off (we use more space to use
less time). In some cases these structures may become too big. To
address this, there are constructors for `Monoid[Batched[A]]` and
`Semigroup[Batched[A]]` instances that will periodically compact
themselves (summing the tree to a single value) to keep the overall
size below a specific parameter.

Batching is appropriate anytime an eager concatenation or combination
will produce expensive intermediate values that will be thrown away, and a more
efficient aggregate summation is possible. In those cases, building up
a batch and then summing it should result in much more efficient
operations.

This commit adds the type, with documentation. It also adds some basic
law-checks and tests.