### PR TITLE
Add a default k value for Aggregator.approximatePercentile

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -275,14 +275,14 @@ object Aggregator extends java.io.Serializable {
    * Returns the lower bound of a given percentile where the percentile is between (0,1]
    * The items that are iterated over cannot be negative.
    */
-  def approximatePercentile[T](percentile: Double, k: Int)(implicit num: Numeric[T]): QTreeAggregatorLowerBound[T] =
+  def approximatePercentile[T](percentile: Double, k: Int = QTreeAggregator.DefaultK)(implicit num: Numeric[T]): QTreeAggregatorLowerBound[T] =
     QTreeAggregatorLowerBound[T](percentile, k)
 
   /**
    * Returns the intersection of a bounded percentile where the percentile is between (0,1]
    * The items that are iterated over cannot be negative.
    */
-  def approximatePercentileBounds[T](percentile: Double, k: Int)(implicit num: Numeric[T]): QTreeAggregator[T] =
+  def approximatePercentileBounds[T](percentile: Double, k: Int = QTreeAggregator.DefaultK)(implicit num: Numeric[T]): QTreeAggregator[T] =
     QTreeAggregator[T](percentile, k)
 }
 


### PR DESCRIPTION
This is pretty minor, but QTreeAggregator and QTreeAggregatorLowerBound have default k values, so I think approximatePercentile and approximatePercentileBounds should also get the default k value. This might help out users who are new to QTrees :)

A small bit of testing:

```scala
scala> import com.twitter.algebird.Aggregator
import com.twitter.algebird.Aggregator

scala> val agg = Aggregator.approximatePercentile[Int](0.5)
agg: com.twitter.algebird.QTreeAggregatorLowerBound[Int] = QTreeAggregatorLowerBound(0.5,9)

scala> agg(Seq(1,2,3,4,5))
res4: Double = 3.0
```