### PR TITLE
Add a MapAlgebra.group function

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/MapAlgebra.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/MapAlgebra.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package com.twitter.algebird
 
 import scala.collection.{ Map => ScMap }
-import scala.collection.mutable.{ Map => MMap }
+import scala.collection.mutable.{ Builder, Map => MMap }
 
 import com.twitter.algebird.macros.{ Cuber, Roller }
 
@@ -187,9 +187,42 @@ object MapAlgebra {
   def removeZeros[K, V: Monoid](m: Map[K, V]): Map[K, V] =
     m filter { case (_, v) => Monoid.isNonZero(v) }
 
-  // groupBy ks, sum all the vs
+  /**
+   * For each key, sum all the values. Note that if V is a Monoid, the current
+   * implementation will drop from the output any key where the values are all
+   * Monoid.zero. If the Semigroup is a Monoid, This function is equivalent to:
+   *
+   *   pairs.filter(_._2 != Monoid.zero).groupBy(_._1).mapValues(_.map(_._2).sum)
+   *
+   * Otherwise, the function is equivalent to:
+   *
+   *   pairs.groupBy(_._1).mapValues(_.map(_._2).sum)
+   */
   def sumByKey[K, V: Semigroup](pairs: TraversableOnce[(K, V)]): Map[K, V] =
     Monoid.sum(pairs map { Map(_) })
+
+  /**
+   * For each key, creates a list of all values. This function is equivalent to:
+   *
+   *   pairs.groupBy(_._1).mapValues(_.map(_._2))
+   */
+  def group[K, V](pairs: TraversableOnce[(K, V)]): Map[K, List[V]] =
+    if (pairs.isEmpty) Map.empty
+    else {
+      val mutable = MMap[K, Builder[V, List[V]]]()
+      pairs.foreach {
+        case (k, v) =>
+          val oldVOpt = mutable.get(k)
+          // sorry for the micro optimization here: avoiding a closure
+          val bldr = if (oldVOpt.isEmpty) {
+            val b = List.newBuilder[V]
+            mutable.update(k, b)
+            b
+          } else oldVOpt.get
+          bldr += v
+      }
+      mutable.iterator.map { case (k, bldr) => (k, bldr.result) }.toMap
+    }
 
   // Consider this as edges from k -> v, produce a Map[K,Set[V]]
   def toGraph[K, V](pairs: TraversableOnce[(K, V)]): Map[K, Set[V]] =

--- a/algebird-core/src/main/scala/com/twitter/algebird/Operators.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Operators.scala
@@ -41,7 +41,10 @@ class DivOp[T: Field](t: T) {
 
 class RichTraversable[T](t: TraversableOnce[T]) {
   def sumByKey[K, V](implicit ev: <:<[T, (K, V)], sg: Semigroup[V]): Map[K, V] =
-    MapAlgebra.sumByKey(t.map { _.asInstanceOf[(K, V)] })
+    MapAlgebra.sumByKey(t.asInstanceOf[TraversableOnce[(K, V)]])
+
+  def group[K, V](implicit ev: <:<[T, (K, V)]): Map[K, List[V]] =
+    MapAlgebra.group(t.asInstanceOf[TraversableOnce[(K, V)]])
 
   def monoidSum(implicit monoid: Monoid[T]) = Monoid.sum(t)
   def ringProduct(implicit ring: Ring[T]) = Ring.product(t)

--- a/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
@@ -230,14 +230,23 @@ class CollectionSpecification extends CheckProperties {
     }
   }
 
-  property("sumByKey works") {
+  property("MapAlgebra.sumByKey works") {
     forAll { (keys: List[Int], values: List[Int]) =>
       import com.twitter.algebird.Operators._
       val tupList = keys.zip(values)
-      (tupList.sumByKey.filter { _._2 != 0 } ==
-        tupList.groupBy { _._1 }
+      val expected = tupList.groupBy { _._1 }
         .mapValues { v => v.map { _._2 }.sum }
-        .filter { _._2 != 0 })
+        .filter { _._2 != 0 }
+      MapAlgebra.sumByKey(tupList) == expected && tupList.sumByKey == expected
+    }
+  }
+
+  property("MapAlgebra.group works") {
+    forAll { (keys: List[Int], values: List[Int]) =>
+      import com.twitter.algebird.Operators._
+      val tupList = keys.zip(values)
+      val expected = tupList.groupBy(_._1).mapValues(_.map(_._2).toList)
+      MapAlgebra.group(tupList) == expected && tupList.group == expected
     }
   }
 


### PR DESCRIPTION
In some personal code I wanted a 'MapAlgebra.group' analog to the 'TypedPipe.group' function:

```scala
def group[K, V](pairs: TraversableOnce[(K, V)]): Map[K, List[V]]
```
I think my implementation seems reasonably efficient, but I would be open to feedback if there was a better solution.

While I was at it, I added some additional documentation to MapAlgebra.sumByKey to mention that it filters out any keys where the values are 0. 

I also slightly updated the MapAlgebra.sumByKey unit test to (a) explicitly test that sumByKey drops values that are 0 and (b) test both the implicit and explicit version of the function.

I hope these changes all seem reasonable!