### PR TITLE
Optimize count-min sketch

### DIFF
--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/CMSBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/CMSBenchmark.scala
@@ -6,7 +6,6 @@ import org.openjdk.jmh.annotations._
 import com.twitter.algebird.{ TopPctCMS, CMSHasherImplicits, TopPctCMSMonoid }
 import scala.util.Random.nextString
 
-import CMSHasherImplicits._
 import CMSFunctions.generateHashes
 
 /**

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/CMSBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/CMSBenchmark.scala
@@ -1,88 +1,83 @@
-package com.twitter.algebird.benchmark
+package com.twitter.algebird
+package benchmark
 
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import com.twitter.algebird.{ TopPctCMS, CMSHasherImplicits, TopPctCMSMonoid }
+import scala.util.Random.nextString
+
+import CMSHasherImplicits._
+import CMSFunctions.generateHashes
 
 /**
- * Benchmarks the Count-Min sketch implementation in Algebird.
+ * Benchmarks the Count-Min sketch (CMS) implementation in Algebird.
  *
  * We benchmark different `K` types as well as different input data streams.
  */
-
 object CMSBenchmark {
 
   @State(Scope.Benchmark)
   class CMSState {
 
-    val Seed = 1
-    val JavaCharSizeInBits = 2 * 8
+    val Seed: Int = 1
+    val MaxBits: Int = 2048
 
     @Param(Array("0.1", "0.005"))
     var eps: Double = 0.0
 
-    @Param(Array("0.0000001" /* 1E-8 */ ))
+    @Param(Array("0.0000001")) // 1e-8
     var delta: Double = 0.0
 
-    @Param(Array("0.2"))
-    var heavyHittersPct: Double = 0.0
+    // number of data values to combine into a CMS
+    @Param(Array("1000"))
+    var size: Int = 0
 
-    @Param(Array("100"))
-    var operations: Int = 0 // Number of operations per benchmark repetition (cf. `reps`)
+    // need to initialize later because we don't have `size` yet.
+    var smallLongs: Vector[Long] = _
+    var smallBigInts: Vector[BigInt] = _
+    var largeBigInts: Vector[BigInt] = _
+    var largeStrings: Vector[String] = _
 
-    @Param(Array("2048"))
-    var maxBits: Int = 0
-
-    var random: scala.util.Random = _
-    var cmsLongMonoid: TopPctCMSMonoid[Long] = _
-    var cmsBigIntMonoid: TopPctCMSMonoid[BigInt] = _
-    var cmsStringMonoid: TopPctCMSMonoid[String] = _
-    var inputsBigInt: Seq[BigInt] = _
-    var inputsString: Seq[String] = _
+    // need to initialize later because we don't have `eps` and `delta` yet.
+    var longMonoid: CMSMonoid[Long] = _
+    var bigIntMonoid: CMSMonoid[BigInt] = _
+    var stringMonoid: CMSMonoid[String] = _
 
     @Setup(Level.Trial)
     def setup(): Unit = {
-      // Required import of implicit values (e.g. for BigInt- or Long-backed CMS instances)
-      import CMSHasherImplicits._
+      longMonoid = CMS.monoid[Long](eps, delta, Seed)
+      bigIntMonoid = CMS.monoid[BigInt](eps, delta, Seed)
+      stringMonoid = CMS.monoid[String](eps, delta, Seed)
 
-      cmsLongMonoid = TopPctCMS.monoid[Long](eps, delta, Seed, heavyHittersPct)
-      cmsBigIntMonoid = TopPctCMS.monoid[BigInt](eps, delta, Seed, heavyHittersPct)
-      cmsStringMonoid = TopPctCMS.monoid[String](eps, delta, Seed, heavyHittersPct)
-
-      random = new scala.util.Random
-
-      inputsString = (0 to operations).map { i => random.nextString(maxBits / JavaCharSizeInBits) }.toSeq
-      Console.out.println(s"Created ${inputsString.size} input records for String")
-      inputsBigInt = inputsString.map { s => BigInt(s.getBytes) }
-      Console.out.println(s"Created ${inputsBigInt.size} input records for BigInt")
+      val bitsPerChar = 16
+      largeStrings = (1 to size).map(i => nextString(MaxBits / bitsPerChar)).toVector
+      largeBigInts = largeStrings.map(s => BigInt(s.getBytes)).toVector
+      smallLongs = (1 to size).map(_.toLong).toVector
+      smallBigInts = (1 to size).map(BigInt(_)).toVector
     }
+
   }
+
+  def sumCmsVector[A](as: Vector[A], m: CMSMonoid[A]): CMS[A] =
+    m.sum(as.iterator.map(CMSItem(_, 1L, m.params)))
 }
 
 class CMSBenchmark {
   import CMSBenchmark._
-  // Case A (K=Long): We count the first hundred integers, i.e. [1, 100]
-  @Benchmark
-  def timePlusOfFirstHundredIntegersWithLongCms(state: CMSState) = {
-    (1 to state.operations).view.foldLeft(state.cmsLongMonoid.zero)((l, r) => { l ++ state.cmsLongMonoid.create(r) })
-  }
 
-  // Case B.1 (K=BigInt): We count the first hundred integers, i.e. [1, 100]
   @Benchmark
-  def timePlusOfFirstHundredIntegersWithBigIntCms(state: CMSState) = {
-    (1 to state.operations).view.foldLeft(state.cmsBigIntMonoid.zero)((l, r) => { l ++ state.cmsBigIntMonoid.create(r) })
-  }
+  def sumSmallLongCms(st: CMSState): CMS[Long] =
+    sumCmsVector(st.smallLongs, st.longMonoid)
 
-  // Case B.2 (K=BigInt): We count numbers drawn randomly from a 2^maxBits address space
   @Benchmark
-  def timePlusOfRandom2048BitNumbersWithBigIntCms(state: CMSState) = {
-    state.inputsBigInt.view.foldLeft(state.cmsBigIntMonoid.zero)((l, r) => l ++ state.cmsBigIntMonoid.create(r))
-  }
+  def sumSmallBigIntCms(st: CMSState): CMS[BigInt] =
+    sumCmsVector(st.smallBigInts, st.bigIntMonoid)
 
-  // Case C (K=String): We count strings drawn randomly from a 2^maxBits address space
   @Benchmark
-  def timePlusOfRandom2048BitNumbersWithStringCms(state: CMSState) = {
-    state.inputsString.view.foldLeft(state.cmsStringMonoid.zero)((l, r) => l ++ state.cmsStringMonoid.create(r))
-  }
+  def sumLargeBigIntCms(st: CMSState): CMS[BigInt] =
+    sumCmsVector(st.largeBigInts, st.bigIntMonoid)
 
+  @Benchmark
+  def sumLargeStringCms(st: CMSState): CMS[String] =
+    sumCmsVector(st.largeStrings, st.stringMonoid)
 }

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/CMSBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/CMSBenchmark.scala
@@ -3,7 +3,6 @@ package benchmark
 
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
-import com.twitter.algebird.{ TopPctCMS, CMSHasherImplicits, TopPctCMSMonoid }
 import scala.util.Random.nextString
 
 import CMSFunctions.generateHashes

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/TopCMSBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/TopCMSBenchmark.scala
@@ -1,0 +1,91 @@
+package com.twitter.algebird.benchmark
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import com.twitter.algebird.{ TopPctCMS, CMSHasherImplicits, TopPctCMSMonoid }
+
+/**
+ * Benchmarks the Count-Min sketch implementation in Algebird.
+ *
+ * We benchmark different `K` types as well as different input data streams.
+ */
+
+object TopCMSBenchmark {
+
+  @State(Scope.Benchmark)
+  class CMSState {
+
+    val Seed = 1
+    val JavaCharSizeInBits = 2 * 8
+
+    @Param(Array("0.1", "0.005"))
+    var eps: Double = 0.0
+
+    @Param(Array("0.0000001" /* 1E-8 */ ))
+    var delta: Double = 0.0
+
+    @Param(Array("0.2"))
+    var heavyHittersPct: Double = 0.0
+
+    @Param(Array("1000"))
+    var ops: Int = 0 // Number of operations per benchmark repetition (cf. `reps`)
+
+    @Param(Array("2048"))
+    var maxBits: Int = 0
+
+    var random: scala.util.Random = _
+    var cmsLongMonoid: TopPctCMSMonoid[Long] = _
+    var cmsBigIntMonoid: TopPctCMSMonoid[BigInt] = _
+    var cmsStringMonoid: TopPctCMSMonoid[String] = _
+    var inputsBigInt: Vector[BigInt] = _
+    var inputsString: Vector[String] = _
+
+    @Setup(Level.Trial)
+    def setup(): Unit = {
+      // Required import of implicit values (e.g. for BigInt- or Long-backed CMS instances)
+      import CMSHasherImplicits._
+
+      cmsLongMonoid = TopPctCMS.monoid[Long](eps, delta, Seed, heavyHittersPct)
+      cmsBigIntMonoid = TopPctCMS.monoid[BigInt](eps, delta, Seed, heavyHittersPct)
+      cmsStringMonoid = TopPctCMS.monoid[String](eps, delta, Seed, heavyHittersPct)
+
+      random = new scala.util.Random
+
+      inputsString = (0 to ops).map { i => random.nextString(maxBits / JavaCharSizeInBits) }.toVector
+      Console.out.println(s"Created ${inputsString.size} input records for String")
+      inputsBigInt = inputsString.map { s => BigInt(s.getBytes) }.toVector
+      Console.out.println(s"Created ${inputsBigInt.size} input records for BigInt")
+    }
+  }
+}
+
+class TopCMSBenchmark {
+  import TopCMSBenchmark._
+  // Case A (K=Long): We count the first hundred integers, i.e. [1, 100]
+  @Benchmark
+  def timePlusOfFirstHundredIntegersWithLongCms(st: CMSState) = {
+    val m = st.cmsLongMonoid
+    m.sumOption((1 to st.ops).iterator.map(n => m.create(n)))
+  }
+
+  // Case B.1 (K=BigInt): We count the first hundred integers, i.e. [1, 100]
+  @Benchmark
+  def timePlusOfFirstHundredIntegersWithBigIntCms(st: CMSState) = {
+    val m = st.cmsBigIntMonoid
+    m.sumOption((1 to st.ops).iterator.map(n => m.create(BigInt(n))))
+  }
+
+  // Case B.2 (K=BigInt): We count numbers drawn randomly from a 2^maxBits address space
+  @Benchmark
+  def timePlusOfRandom2048BitNumbersWithBigIntCms(st: CMSState) = {
+    val m = st.cmsBigIntMonoid
+    m.sumOption(st.inputsBigInt.iterator.map(m.create(_)))
+  }
+
+  // Case C (K=String): We count strings drawn randomly from a 2^maxBits address space
+  @Benchmark
+  def timePlusOfRandom2048BitNumbersWithStringCms(st: CMSState) = {
+    val m = st.cmsStringMonoid
+    m.sumOption(st.inputsString.iterator.map(m.create(_)))
+  }
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/CMSHasher.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CMSHasher.scala
@@ -1,0 +1,150 @@
+package com.twitter.algebird
+
+/**
+ * The Count-Min sketch uses `d` (aka `depth`) pair-wise independent hash functions drawn from a universal hashing
+ * family of the form:
+ *
+ * `h(x) = [a * x + b (mod p)] (mod m)`
+ *
+ * As a requirement for using CMS you must provide an implicit `CMSHasher[K]` for the type `K` of the items you want to
+ * count.  Algebird ships with several such implicits for commonly used types `K` such as [[Long]] and [[BigInt]].
+ *
+ * If your type `K` is not supported out of the box, you have two options: 1) You provide a "translation" function to
+ * convert items of your (unsupported) type `K` to a supported type such as [[Double]], and then use the `contramap`
+ * function of [[CMSHasher]] to create the required `CMSHasher[K]` for your type (see the documentation of `contramap`
+ * for an example); 2) You implement a `CMSHasher[K]` from scratch, using the existing CMSHasher implementations as a
+ * starting point.
+ */
+trait CMSHasher[K] extends java.io.Serializable {
+
+  self =>
+
+  /**
+   * Returns `a * x + b (mod p) (mod width)`.
+   */
+  def hash(a: Int, b: Int, width: Int)(x: K): Int
+
+  /**
+   * Given `f`, a function from `L` into `K`, creates a `CMSHasher[L]` whose hash function is equivalent to:
+   *
+   * {{{
+   * def hash(a: Int, b: Int, width: Int)(x: L): CMSHasher[L] = CMSHasher[K].hash(a, b, width)(f(x))
+   * }}}
+   */
+  def on[L](f: L => K) = new CMSHasher[L] {
+    override def hash(a: Int, b: Int, width: Int)(x: L): Int = self.hash(a, b, width)(f(x))
+  }
+
+  /**
+   * Given `f`, a function from `L` into `K`, creates a `CMSHasher[L]` whose hash function is equivalent to:
+   *
+   * {{{
+   * def hash(a: Int, b: Int, width: Int)(x: L): CMSHasher[L] = CMSHasher[K].hash(a, b, width)(f(x))
+   * }}}
+   *
+   * Be aware that the use of contramap may come at a cost (e.g. increased time) due to the translation calls between
+   * `K` and `L`.
+   *
+   * =Usage=
+   *
+   * The following example creates a CMSHasher for the unsupported type `K=Double`:
+   *
+   * {{{
+   * def f(d: Double): Array[Byte] = {
+   *   val l: Long = java.lang.Double.doubleToLongBits(d)
+   *   java.nio.ByteBuffer.allocate(8).putLong(l).array()
+   * }
+   *
+   * implicit val cmsHasherDouble: CMSHasher[Double] = CMSHasherArrayByte.contramap((d: Double) => f(d))
+   * }}}
+   */
+  def contramap[L](f: L => K) = on(f)
+
+}
+
+object CMSHasher {
+  implicit object CMSHasherLong extends CMSHasher[Long] {
+
+    override def hash(a: Int, b: Int, width: Int)(x: Long): Int = {
+      val unModded: Long = (x * a) + b
+      // Apparently a super fast way of computing x mod 2^p-1
+      // See page 149 of http://www.cs.princeton.edu/courses/archive/fall09/cos521/Handouts/universalclasses.pdf
+      // after Proposition 7.
+      val modded: Long = (unModded + (unModded >> 32)) & Int.MaxValue
+      // Modulo-ing integers is apparently twice as fast as modulo-ing Longs.
+      modded.toInt % width
+    }
+
+  }
+
+  implicit val cmsHasherShort: CMSHasher[Short] = CMSHasherInt.contramap(x => x.toInt)
+
+  implicit object CMSHasherInt extends CMSHasher[Int] {
+
+    override def hash(a: Int, b: Int, width: Int)(x: Int): Int = {
+      val unModded: Int = (x * a) + b
+      val modded: Long = (unModded + (unModded >> 32)) & Int.MaxValue
+      modded.toInt % width
+    }
+  }
+
+  /**
+   * =Implementation details=
+   *
+   * This hash function is based upon Murmur3.  Note that the original CMS paper requires
+   * `d` (depth) pair-wise independent hash functions;  in the specific case of Murmur3 we argue that it is sufficient
+   * to pass `d` different seed values to Murmur3 to achieve a similar effect.
+   *
+   * To seed Murmur3 we use only `a`, which is a randomly drawn `Int` via [[scala.util.Random]] in the CMS code.
+   * What is important to note is that we intentionally ignore `b`.  Why?  We need to ensure that we seed Murmur3 with
+   * a random value, notably one that is uniformly distributed.  Somewhat surprisingly, combining two random values
+   * (such as `a` and `b` in our case) typically worsens the "randomness" of the combination, i.e. the combination is
+   * less uniformly distributed as either of its original inputs.  Hence the combination of two random values is
+   * discouraged in this context, notably if the two random inputs were generated from the same source anyways, which
+   * is the case for us because we use Scala's PRNG only.
+   *
+   * For further details please refer to the discussion
+   * [[http://stackoverflow.com/questions/3956478/understanding-randomness Understanding Randomness]] on
+   * StackOverflow.
+   *
+   * @param a Must be a random value, typically created via [[scala.util.Random]].
+   * @param b Ignored by this particular hash function, see the reasoning above for the justification.
+   * @param width Width of the CMS counting table, i.e. the width/size of each row in the counting table.
+   * @param x Item to be hashed.
+   * @return Slot assigned to item `x` in the vector of size `width`, where `x in [0, width)`.
+   */
+  private[algebird] def hashBytes(a: Int, b: Int, width: Int)(x: Array[Byte]): Int = {
+    val hash: Int = scala.util.hashing.MurmurHash3.arrayHash(x, a)
+    // We only want positive integers for the subsequent modulo.  This method mimics Java's Hashtable
+    // implementation.  The Java code uses `0x7FFFFFFF` for the bit-wise AND, which is equal to Int.MaxValue.
+    val positiveHash = hash & Int.MaxValue
+    positiveHash % width
+  }
+
+  // This CMSHasher[BigInt] is newer, and faster, than the old version
+  // found in CMSHasherImplicits. Unless you have serialized data that
+  // requires the old implementation for correctness, you should be
+  // using this instance.
+  implicit object CMSHasherBigInt extends CMSHasher[BigInt] {
+    override def hash(a: Int, b: Int, width: Int)(x: BigInt): Int =
+      ((a * x.hashCode + b) & Int.MaxValue) % width
+  }
+
+  // This CMSHasher[String] is newer, and faster, than the old version
+  // found in CMSHasherImplicits. Unless you have serialized data that
+  // requires the old implementation for correctness, you should be
+  // using this instance.
+  implicit object CMSHasherString extends CMSHasher[String] {
+    override def hash(a: Int, b: Int, width: Int)(x: String): Int =
+      (scala.util.hashing.MurmurHash3.stringHash(x, a) & Int.MaxValue) % width
+  }
+
+  implicit object CMSHasherBytes extends CMSHasher[Bytes] {
+    override def hash(a: Int, b: Int, width: Int)(x: Bytes): Int = hashBytes(a, b, width)(x.array)
+  }
+
+  implicit object CMSHasherByteArray extends CMSHasher[Array[Byte]] {
+    override def hash(a: Int, b: Int, width: Int)(x: Array[Byte]): Int = hashBytes(a, b, width)(x)
+  }
+
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/CMSHasher.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CMSHasher.scala
@@ -121,13 +121,9 @@ object CMSHasher {
     positiveHash % width
   }
 
-  // This CMSHasher[BigInt] is newer, and faster, than the old version
-  // found in CMSHasherImplicits. Unless you have serialized data that
-  // requires the old implementation for correctness, you should be
-  // using this instance.
   implicit object CMSHasherBigInt extends CMSHasher[BigInt] {
     override def hash(a: Int, b: Int, width: Int)(x: BigInt): Int =
-      ((a * x.hashCode + b) & Int.MaxValue) % width
+      CMSHasher.hashBytes(a, b, width)(x.toByteArray)
   }
 
   // This CMSHasher[String] is newer, and faster, than the old version

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -1312,10 +1312,7 @@ case class CMSHash[K: CMSHasher](a: Int, b: Int, width: Int) extends java.io.Ser
  */
 object CMSHasherImplicits {
 
-  implicit object CMSHasherBigInt extends CMSHasher[BigInt] {
-    override def hash(a: Int, b: Int, width: Int)(x: BigInt): Int =
-      CMSHasher.hashBytes(a, b, width)(x.toByteArray)
-  }
+  implicit val CMSHasherBigInt: CMSHasher[BigInt] = CMSHasher.CMSHasherBigInt
 
   implicit object CMSHasherString extends CMSHasher[String] {
     override def hash(a: Int, b: Int, width: Int)(x: String): Int =

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -468,7 +468,7 @@ object CMS {
       val hashes: Seq[CMSHash[K]] = CMSFunctions.generateHashes(eps, delta, seed)
       CMSParams(hashes, eps, delta, maxExactCountOpt)
     }
-    CMSInstance[K](params)
+    CMSZero[K](params)
   }
 
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -67,11 +67,7 @@ package com.twitter.algebird
  * some factor depending on eps."
  *
  * The type `K` is the type of items you want to count.  You must provide an implicit `CMSHasher[K]` for `K`,  and
- * Algebird ships with several such implicits for commonly used types such as [[Long]] and [[BigInt]]:
- *
- * {{{
- * import com.twitter.algebird.CMSHasherImplicits._
- * }}}
+ * Algebird ships with several such implicits for commonly used types such as [[Long]] and [[BigInt]].
  *
  * If your type `K` is not supported out of the box, you have two options: 1) You provide a "translation" function to
  * convert items of your (unsupported) type `K` to a supported type such as [[Double]], and then use the `contramap`
@@ -130,6 +126,85 @@ class CMSMonoid[K: CMSHasher](eps: Double, delta: Double, seed: Int, maxExactCou
    */
   def create(data: Seq[K]): CMS[K] = data.foldLeft(zero) { case (acc, x) => plus(acc, create(x)) }
 
+  override def sumOption(sketches: TraversableOnce[CMS[K]]): Option[CMS[K]] =
+    if (sketches.isEmpty) None else Some(sum(sketches))
+
+  override def sum(sketches: TraversableOnce[CMS[K]]): CMS[K] = {
+    val summation = new CMSSummation(params)
+    summation.updateAll(sketches)
+    summation.result
+  }
+}
+
+class CMSSummation[K](params: CMSParams[K]) {
+  private[this] val hashes = params.hashes.toArray
+  private[this] val height = CMSFunctions.depth(params.delta)
+  private[this] val width = CMSFunctions.width(params.eps)
+  private[this] val cells = new Array[Long](height * width)
+  private[this] var totalCount = 0L
+
+  final def insert(k: K, count: Long): Unit = {
+    var row = 0
+    var offset = 0
+    val hs = hashes
+    while (row < hs.length) {
+      cells(offset + hs(row)(k)) += count
+      offset += width
+      row += 1
+    }
+  }
+
+  def updateAll(sketches: TraversableOnce[CMS[K]]): Unit =
+    sketches.foreach(updateInto)
+
+  def updateInto(cms: CMS[K]): Unit =
+    cms match {
+      case CMSZero(_) =>
+        ()
+      case CMSItem(item, count, _) =>
+        insert(item, count)
+        totalCount += count
+      case SparseCMS(table, count, _) =>
+        table.foreach {
+          case (item, c) =>
+            insert(item, c)
+        }
+        totalCount += count
+      case CMSInstance(CMSInstance.CountsTable(matrix), count, _) =>
+        var offset = 0
+        val rit = matrix.iterator
+        while (rit.hasNext) {
+          var col = 0
+          val cit = rit.next.iterator
+          while (cit.hasNext) {
+            cells(offset + col) += cit.next
+            col += 1
+          }
+          offset += width
+        }
+        totalCount += count
+    }
+
+  def result: CMS[K] = {
+    def vectorize(row: Int): Vector[Long] = {
+      val offset = row * width
+      val b = Vector.newBuilder[Long]
+      var col = 0
+      while (col < width) {
+        b += cells(offset + col)
+        col += 1
+      }
+      b.result
+    }
+
+    val b = Vector.newBuilder[Vector[Long]]
+    var row = 0
+    while (row < height) {
+      b += vectorize(row)
+      row += 1
+    }
+    CMSInstance(CMSInstance.CountsTable(b.result), totalCount, params)
+  }
 }
 
 /**
@@ -412,8 +487,6 @@ object CMS {
  * the returned frequency estimates are always instances of `Approximate[Long]`.
  *
  * @example {{{
- * // Implicits that enabling CMS-hashing of `Long` values.
- * import com.twitter.algebird.CMSHasherImplicits._
  *
  * // Creates a monoid for a CMS that can count `Long` elements.
  * val cmsMonoid: CMSMonoid[Long] = {
@@ -565,8 +638,9 @@ case class CMSInstance[K](countsTable: CMSInstance.CountsTable[K],
             cms + (x, count)
         }
       case other: CMSInstance[K] =>
+        val newTable = countsTable ++ other.countsTable
         val newTotalCount = totalCount + other.totalCount
-        CMSInstance[K](countsTable ++ other.countsTable, newTotalCount, params)
+        CMSInstance[K](newTable, newTotalCount, params)
     }
   }
 
@@ -578,8 +652,19 @@ case class CMSInstance[K](countsTable: CMSInstance.CountsTable[K],
     }
   }
 
-  def frequency(item: K): Approximate[Long] =
-    makeApprox(countsTable.counts.iterator.zip(params.hashes.iterator).map { case (row, hash) => row(hash(item)) }.min)
+  def frequency(item: K): Approximate[Long] = {
+    var freq = Long.MaxValue
+    val hs = params.hashes
+    val it = countsTable.counts.iterator
+    var i = 0
+    while (it.hasNext) {
+      val row = it.next
+      val count = row(hs(i)(item))
+      if (count < freq) freq = count
+      i += 1
+    }
+    makeApprox(freq)
+  }
 
   /**
    * Let X be a CMS, and let count_X[j, k] denote the value in X's 2-dimensional count table at row j and column k.
@@ -590,10 +675,10 @@ case class CMSInstance[K](countsTable: CMSInstance.CountsTable[K],
   def innerProduct(other: CMS[K]): Approximate[Long] = {
     other match {
       case other: CMSInstance[_] =>
-        require((other.depth, other.width) == (depth, width), "Tables must have the same dimensions.")
+        require(other.depth == depth && other.width == width, "Tables must have the same dimensions.")
 
         def innerProductAtDepth(d: Int) = (0 to (width - 1)).iterator.map { w =>
-          countsTable.getCount(d, w) * other.countsTable.getCount(d, w)
+          countsTable.getCount((d, w)) * other.countsTable.getCount((d, w))
         }.sum
 
         val est = (0 to (depth - 1)).iterator.map { innerProductAtDepth }.min
@@ -661,13 +746,18 @@ object CMSInstance {
      * Adds another counts table to this one, through element-wise addition.
      */
     def ++(other: CountsTable[K]): CountsTable[K] = {
-      require((depth, width) == (other.depth, other.width), "Tables must have the same dimensions.")
-      val iil: IndexedSeq[IndexedSeq[Long]] = Monoid.plus[IndexedSeq[IndexedSeq[Long]]](counts, other.counts)
-      def toVector[V](is: IndexedSeq[V]): Vector[V] = is match {
-        case v: Vector[_] => v.asInstanceOf[Vector[V]]
-        case _ => Vector(is: _*)
+      require(depth == other.depth && width == other.width, "Tables must have the same dimensions.")
+      val xss = this.counts.iterator
+      val yss = other.counts.iterator
+      val rows = Vector.newBuilder[Vector[Long]]
+      while (xss.hasNext) {
+        val xs = xss.next.iterator
+        val ys = yss.next.iterator
+        val row = Vector.newBuilder[Long]
+        while (xs.hasNext) row += (xs.next + ys.next)
+        rows += row.result
       }
-      CountsTable[K](toVector(iil.map { toVector }))
+      CountsTable[K](rows.result)
     }
   }
 
@@ -702,9 +792,6 @@ case class TopCMSParams[K](logic: HeavyHittersLogic[K])
  * the returned frequency estimates are always instances of `Approximate[Long]`.
  *
  * @example {{{
- * // Implicits that enabling CMS-hashing of `Long` values.
- * import com.twitter.algebird.CMSHasherImplicits._
- *
  * // Creates a monoid for a CMS that can count `Long` elements.
  * val topPctCMSMonoid: TopPctCMSMonoid[Long] = {
  *   val eps = 0.001
@@ -818,11 +905,11 @@ case class TopCMSInstance[K](override val cms: CMS[K], hhs: HeavyHitters[K], par
 
 }
 
-class TopCMSMonoid[K](cms: CMS[K], logic: HeavyHittersLogic[K]) extends Monoid[TopCMS[K]] {
+class TopCMSMonoid[K](emptyCms: CMS[K], logic: HeavyHittersLogic[K]) extends Monoid[TopCMS[K]] {
 
   val params: TopCMSParams[K] = TopCMSParams(logic)
 
-  val zero: TopCMS[K] = TopCMSZero[K](cms, params)
+  val zero: TopCMS[K] = TopCMSZero[K](emptyCms, params)
 
   /**
    * Combines the two sketches.
@@ -837,7 +924,8 @@ class TopCMSMonoid[K](cms: CMS[K], logic: HeavyHittersLogic[K]) extends Monoid[T
   /**
    * Creates a sketch out of a single item.
    */
-  def create(item: K): TopCMS[K] = TopCMSItem[K](item, cms + item, params)
+  def create(item: K): TopCMS[K] =
+    TopCMSItem[K](item, emptyCms + item, params)
 
   /**
    * Creates a sketch out of multiple items.
@@ -846,6 +934,21 @@ class TopCMSMonoid[K](cms: CMS[K], logic: HeavyHittersLogic[K]) extends Monoid[T
     data.foldLeft(zero) { case (acc, x) => plus(acc, create(x)) }
   }
 
+  override def sum(sketches: TraversableOnce[TopCMS[K]]): TopCMS[K] = {
+    val topCandidates = scala.collection.mutable.Set.empty[K]
+    val summation = new CMSSummation(emptyCms.params)
+    sketches.foreach { sketch =>
+      summation.updateInto(sketch.cms)
+      topCandidates ++= sketch.heavyHitters
+    }
+    val cms = summation.result
+    val ests = topCandidates.map(k => HeavyHitter(k, cms.frequency(k).estimate)).toSet
+    val hhs = logic.purgeHeavyHitters(cms)(HeavyHitters(ests))
+    TopCMSInstance(cms, hhs, params)
+  }
+
+  override def sumOption(sketches: TraversableOnce[TopCMS[K]]): Option[TopCMS[K]] =
+    if (sketches.isEmpty) None else Some(sum(sketches))
 }
 
 class TopCMSAggregator[K](cmsMonoid: TopCMSMonoid[K])
@@ -961,11 +1064,7 @@ case class HeavyHitter[K](item: K, count: Long) extends java.io.Serializable
  * =Usage=
  *
  * The type `K` is the type of items you want to count.  You must provide an implicit `CMSHasher[K]` for `K`,  and
- * Algebird ships with several such implicits for commonly used types such as [[Long]] and [[BigInt]]:
- *
- * {{{
- * import com.twitter.algebird.CMSHasherImplicits._
- * }}}
+ * Algebird ships with several such implicits for commonly used types such as [[Long]] and [[BigInt]].
  *
  * If your type `K` is not supported out of the box, you have two options: 1) You provide a "translation" function to
  * convert items of your (unsupported) type `K` to a supported type such as [[Double]], and then use the `contramap`
@@ -985,7 +1084,7 @@ case class HeavyHitter[K](item: K, count: Long) extends java.io.Serializable
  *           user names, you could map each username to a unique numeric ID expressed as a `Long`, and then count the
  *           occurrences of those `Long`s with a CMS of type `K=Long`.  Note that this mapping between the elements of
  *           your problem domain and their identifiers used for counting via CMS should be bijective.
- *           We require a [[CMSHasher]] context bound for `K`, see [[CMSHasherImplicits]] for available implicits that
+ *           We require a [[CMSHasher]] context bound for `K`, see [[CMSHasher]] for available implicits that
  *           can be imported.
  *           Which type K should you pick in practice?  For domains that have less than `2^64` unique elements, you'd
  *           typically use [[Long]].  For larger domains you can try [[BigInt]], for example.
@@ -1054,11 +1153,7 @@ case class TopPctCMSAggregator[K](cmsMonoid: TopPctCMSMonoid[K]) extends TopCMSA
  * =Usage=
  *
  * The type `K` is the type of items you want to count.  You must provide an implicit `CMSHasher[K]` for `K`,  and
- * Algebird ships with several such implicits for commonly used types such as [[Long]] and [[BigInt]]:
- *
- * {{{
- * import com.twitter.algebird.CMSHasherImplicits._
- * }}}
+ * Algebird ships with several such implicits for commonly used types such as [[Long]] and [[BigInt]].
  *
  * If your type `K` is not supported out of the box, you have two options: 1) You provide a "translation" function to
  * convert items of your (unsupported) type `K` to a supported type such as [[Double]], and then use the `contramap`
@@ -1077,7 +1172,7 @@ case class TopPctCMSAggregator[K](cmsMonoid: TopPctCMSMonoid[K]) extends TopCMSA
  *           user names, you could map each username to a unique numeric ID expressed as a `Long`, and then count the
  *           occurrences of those `Long`s with a CMS of type `K=Long`.  Note that this mapping between the elements of
  *           your problem domain and their identifiers used for counting via CMS should be bijective.
- *           We require a [[CMSHasher]] context bound for `K`, see [[CMSHasherImplicits]] for available implicits that
+ *           We require a [[CMSHasher]] context bound for `K`, see [[CMSHasher]] for available implicits that
  *           can be imported.
  *           Which type K should you pick in practice?  For domains that have less than `2^64` unique elements, you'd
  *           typically use [[Long]].  For larger domains you can try [[BigInt]], for example.
@@ -1199,72 +1294,6 @@ object ScopedTopNCMS {
 
 }
 
-/**
- * The Count-Min sketch uses `d` (aka `depth`) pair-wise independent hash functions drawn from a universal hashing
- * family of the form:
- *
- * `h(x) = [a * x + b (mod p)] (mod m)`
- *
- * As a requirement for using CMS you must provide an implicit `CMSHasher[K]` for the type `K` of the items you want to
- * count.  Algebird ships with several such implicits for commonly used types `K` such as [[Long]] and [[BigInt]]:
- *
- * {{{
- * import com.twitter.algebird.CMSHasherImplicits._
- * }}}
- *
- * If your type `K` is not supported out of the box, you have two options: 1) You provide a "translation" function to
- * convert items of your (unsupported) type `K` to a supported type such as [[Double]], and then use the `contramap`
- * function of [[CMSHasher]] to create the required `CMSHasher[K]` for your type (see the documentation of `contramap`
- * for an example); 2) You implement a `CMSHasher[K]` from scratch, using the existing CMSHasher implementations as a
- * starting point.
- */
-trait CMSHasher[K] extends java.io.Serializable {
-
-  self =>
-
-  /**
-   * Returns `a * x + b (mod p) (mod width)`.
-   */
-  def hash(a: Int, b: Int, width: Int)(x: K): Int
-
-  /**
-   * Given `f`, a function from `L` into `K`, creates a `CMSHasher[L]` whose hash function is equivalent to:
-   *
-   * {{{
-   * def hash(a: Int, b: Int, width: Int)(x: L): CMSHasher[L] = CMSHasher[K].hash(a, b, width)(f(x))
-   * }}}
-   */
-  def on[L](f: L => K) = new CMSHasher[L] {
-    override def hash(a: Int, b: Int, width: Int)(x: L): Int = self.hash(a, b, width)(f(x))
-  }
-
-  /**
-   * Given `f`, a function from `L` into `K`, creates a `CMSHasher[L]` whose hash function is equivalent to:
-   *
-   * {{{
-   * def hash(a: Int, b: Int, width: Int)(x: L): CMSHasher[L] = CMSHasher[K].hash(a, b, width)(f(x))
-   * }}}
-   *
-   * Be aware that the use of contramap may come at a cost (e.g. increased time) due to the translation calls between
-   * `K` and `L`.
-   *
-   * =Usage=
-   *
-   * The following example creates a CMSHasher for the unsupported type `K=Double`:
-   *
-   * {{{
-   * def f(d: Double): Array[Byte] = {
-   *   val l: Long = java.lang.Double.doubleToLongBits(d)
-   *   java.nio.ByteBuffer.allocate(8).putLong(l).array()
-   * }
-   *
-   * implicit val cmsHasherDouble: CMSHasher[Double] = CMSHasherArrayByte.contramap((d: Double) => f(d))
-   * }}}
-   */
-  def contramap[L](f: L => K) = on(f)
-
-}
-
 case class CMSHash[K: CMSHasher](a: Int, b: Int, width: Int) extends java.io.Serializable {
 
   /**
@@ -1275,83 +1304,21 @@ case class CMSHash[K: CMSHasher](a: Int, b: Int, width: Int) extends java.io.Ser
 }
 
 /**
- * Implicits that enable CMS-hashing for common data types such as [[Long]] and [[BigInt]].
+ * This formerly held the instances that moved to object CMSHasher
+ *
+ * These instances are slow, but here for compatibility with old
+ * serialized data. For new code, avoid these and instead use the
+ * implicits found in the CMSHasher companion object.
  */
 object CMSHasherImplicits {
 
-  implicit object CMSHasherLong extends CMSHasher[Long] {
-
-    override def hash(a: Int, b: Int, width: Int)(x: Long): Int = {
-      val unModded: Long = (x * a) + b
-      // Apparently a super fast way of computing x mod 2^p-1
-      // See page 149 of http://www.cs.princeton.edu/courses/archive/fall09/cos521/Handouts/universalclasses.pdf
-      // after Proposition 7.
-      val modded: Long = (unModded + (unModded >> 32)) & Int.MaxValue
-      // Modulo-ing integers is apparently twice as fast as modulo-ing Longs.
-      modded.toInt % width
-    }
-
-  }
-
-  implicit val cmsHasherShort: CMSHasher[Short] = CMSHasherInt.contramap(x => x.toInt)
-
-  implicit object CMSHasherInt extends CMSHasher[Int] {
-
-    override def hash(a: Int, b: Int, width: Int)(x: Int): Int = {
-      val unModded: Int = (x * a) + b
-      val modded: Long = (unModded + (unModded >> 32)) & Int.MaxValue
-      modded.toInt % width
-    }
-
-  }
-
-  /**
-   * =Implementation details=
-   *
-   * This hash function is based upon Murmur3.  Note that the original CMS paper requires
-   * `d` (depth) pair-wise independent hash functions;  in the specific case of Murmur3 we argue that it is sufficient
-   * to pass `d` different seed values to Murmur3 to achieve a similar effect.
-   *
-   * To seed Murmur3 we use only `a`, which is a randomly drawn `Int` via [[scala.util.Random]] in the CMS code.
-   * What is important to note is that we intentionally ignore `b`.  Why?  We need to ensure that we seed Murmur3 with
-   * a random value, notably one that is uniformly distributed.  Somewhat surprisingly, combining two random values
-   * (such as `a` and `b` in our case) typically worsens the "randomness" of the combination, i.e. the combination is
-   * less uniformly distributed as either of its original inputs.  Hence the combination of two random values is
-   * discouraged in this context, notably if the two random inputs were generated from the same source anyways, which
-   * is the case for us because we use Scala's PRNG only.
-   *
-   * For further details please refer to the discussion
-   * [[http://stackoverflow.com/questions/3956478/understanding-randomness Understanding Randomness]] on
-   * StackOverflow.
-   *
-   * @param a Must be a random value, typically created via [[scala.util.Random]].
-   * @param b Ignored by this particular hash function, see the reasoning above for the justification.
-   * @param width Width of the CMS counting table, i.e. the width/size of each row in the counting table.
-   * @param x Item to be hashed.
-   * @return Slot assigned to item `x` in the vector of size `width`, where `x in [0, width)`.
-   */
-  private def hashBytes(a: Int, b: Int, width: Int)(x: Array[Byte]): Int = {
-    val hash: Int = scala.util.hashing.MurmurHash3.arrayHash(x, a)
-    // We only want positive integers for the subsequent modulo.  This method mimics Java's Hashtable
-    // implementation.  The Java code uses `0x7FFFFFFF` for the bit-wise AND, which is equal to Int.MaxValue.
-    val positiveHash = hash & Int.MaxValue
-    positiveHash % width
-  }
-
   implicit object CMSHasherBigInt extends CMSHasher[BigInt] {
-    override def hash(a: Int, b: Int, width: Int)(x: BigInt): Int = hashBytes(a, b, width)(x.toByteArray)
+    override def hash(a: Int, b: Int, width: Int)(x: BigInt): Int =
+      CMSHasher.hashBytes(a, b, width)(x.toByteArray)
   }
 
   implicit object CMSHasherString extends CMSHasher[String] {
-    override def hash(a: Int, b: Int, width: Int)(x: String): Int = hashBytes(a, b, width)(x.getBytes("UTF-8"))
+    override def hash(a: Int, b: Int, width: Int)(x: String): Int =
+      CMSHasher.hashBytes(a, b, width)(x.getBytes("UTF-8"))
   }
-
-  implicit object CMSHasherBytes extends CMSHasher[Bytes] {
-    override def hash(a: Int, b: Int, width: Int)(x: Bytes): Int = hashBytes(a, b, width)(x.array)
-  }
-
-  implicit object CMSHasherByteArray extends CMSHasher[Array[Byte]] {
-    override def hash(a: Int, b: Int, width: Int)(x: Array[Byte]): Int = hashBytes(a, b, width)(x)
-  }
-
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/legacy/CountMinSketchMonoid.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/legacy/CountMinSketchMonoid.scala
@@ -11,16 +11,13 @@ import com.twitter.algebird.TopPctCMS
  * Only use this object when transitioning legacy code.  Newer code should use [[TopPctCMS.monoid()]]:
  *
  * {{{
- * import com.twitter.algebird.CMSHasherImplicits._
  * val cmsMonoid = TopPctCMS.monoid[Long](...)
  * }}}
  */
 object CountMinSketchMonoid {
 
-  import com.twitter.algebird.CMSHasherImplicits._
-
   @deprecated(
-    "You should use TopPctCMS.monoid[Long]() instead of legacy.CountMinSketchMonoid, and import CMSHasherImplicits._",
+    "You should use TopPctCMS.monoid[Long]() instead of legacy.CountMinSketchMonoid",
     since = "0.8.1")
   def apply(eps: Double, delta: Double, seed: Int, heavyHittersPct: Double = 0.01): CountMinSketchMonoid =
     TopPctCMS.monoid[Long](eps, delta, seed, heavyHittersPct)

--- a/algebird-test/src/main/scala/com/twitter/algebird/ApproximateProperty.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/ApproximateProperty.scala
@@ -25,10 +25,10 @@ object ApproximateProperty {
    *  Useful because `Gen.listOfN(n, gen).sample` gives us Option[List[T]],
    *  while we often want List[T].
    */
-  private def genListOf[T](n: Int, gen: Gen[T]): List[T] = {
+  @annotation.tailrec private def genListOf[T](n: Int, gen: Gen[T], trial: Int = 100): List[T] = {
     Gen.listOfN(n, gen).sample match {
       case Some(xs) => xs
-      case _ => genListOf(n, gen)
+      case _ => if (trial <= 0) Nil else genListOf(n, gen, trial - 1)
     }
   }
 

--- a/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
@@ -44,7 +44,7 @@ object BaseProperties {
   def isAssociativeEq[T: Semigroup, U <: T: Arbitrary](eqfn: (T, T) => Boolean) = {
     'isAssociativeEq |: forAll { (a: U, b: U, c: U) =>
       val semi = implicitly[Semigroup[T]]
-      eqfn(semi.plus(a, semi.plus(b, c)), semi.plus(semi.plus(a, b), c))
+      eqfn(semi.plus(a, semi.plus(b, c)), semi.plus(semi.plus(a, b), c)) //&& false
     }
   }
 
@@ -53,10 +53,8 @@ object BaseProperties {
 
   def isAssociative[T: Semigroup: Arbitrary] = isAssociativeDifferentTypes[T, T]
 
-  def semigroupSumWorks[T: Semigroup: Arbitrary: Equiv] = 'semigroupSumWorks |: forAll { (in: List[T]) =>
-    in.isEmpty || {
-      Equiv[T].equiv(Semigroup.sumOption(in.iterator).get, in.reduceLeft(Semigroup.plus(_, _)))
-    }
+  def semigroupSumWorks[T: Semigroup: Arbitrary: Equiv] = 'semigroupSumWorks |: forAll { (head: T, tail: List[T]) =>
+    Equiv[T].equiv(Semigroup.sumOption(head :: tail).get, tail.foldLeft(head)(Semigroup.plus(_, _)))
   }
 
   def isCommutativeEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean) = 'isCommutativeEq |: forAll { (a: T, b: T) =>
@@ -113,6 +111,9 @@ object BaseProperties {
 
   def monoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean): Prop =
     validZeroEq[T](eqfn) && semigroupLawsEq[T](eqfn)
+
+  def monoidLawsEquiv[T: Monoid: Arbitrary: Equiv]: Prop =
+    monoidLawsEq[T](Equiv[T].equiv)
 
   def commutativeMonoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean) =
     monoidLawsEq[T](eqfn) && isCommutativeEq[T](eqfn)

--- a/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
@@ -44,7 +44,7 @@ object BaseProperties {
   def isAssociativeEq[T: Semigroup, U <: T: Arbitrary](eqfn: (T, T) => Boolean) = {
     'isAssociativeEq |: forAll { (a: U, b: U, c: U) =>
       val semi = implicitly[Semigroup[T]]
-      eqfn(semi.plus(a, semi.plus(b, c)), semi.plus(semi.plus(a, b), c)) //&& false
+      eqfn(semi.plus(a, semi.plus(b, c)), semi.plus(semi.plus(a, b), c))
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -180,7 +180,7 @@ class CMSContraMapSpec extends WordSpec with Matchers with GeneratorDrivenProper
     val a = 4
     val b = 0
     val width = 1234
-    val x = Array(113.toByte).toSeq // same as Seq(1.toByte)
+    val x = Array(113.toByte).toSeq // same as Seq(133.toByte)
     val result = targetHasher.hash(a, b, width)(x)
     val expected = sourceHasher.hash(a, b, width)("q")
     result should be(expected)
@@ -358,7 +358,7 @@ class CmsTotalCountProperty[K: CMSHasher: Gen] extends CmsProperty[K] {
 class CmsProperties extends ApproximateProperties("CountMinSketch") {
   import ApproximateProperty.toProp
 
-  implicit val intGen = Gen.choose(Int.MinValue, Int.MaxValue)
+  implicit val intGen = Gen.choose(1, 100)
 
   property("CMS works for small lists") = toProp(new CmsSmallFrequencyProperty[Int](), 10, 10, 0.01)
   property("CMS works for large lists") = toProp(new CmsLargeFrequencyProperty[Int](), 10, 10, 0.01)


### PR DESCRIPTION
This PR updates the existing `CMS[A]` type to be more efficient, especially when summing many `CMS[A]` structures. The changes are expected to be binary-compatible. The only difference is that more efficient `CMSHasher` instances are available without an import (the import is still available for the legacy instances, which may be needed for old serialized data).

I've also updated the benchmarks to help demonstrate the changes. Here are the benchmarks from before any of the changes:

```
Benchmark                         (eps)  (size)    Cnt    Score     Error  Units
CMSBenchmark.sumLargeBigIntCms      0.1    1000     5   49.939 ±   1.152  ops/s
CMSBenchmark.sumLargeBigIntCms    0.005    1000     5   48.309 ±   2.453  ops/s
CMSBenchmark.sumLargeStringCms      0.1    1000     5   50.682 ±  14.959  ops/s
CMSBenchmark.sumLargeStringCms    0.005    1000     5   51.256 ±   3.108  ops/s
CMSBenchmark.sumSmallBigIntCms      0.1    1000     5  556.247 ±  34.430  ops/s
CMSBenchmark.sumSmallBigIntCms    0.005    1000     5  377.775 ±  34.519  ops/s
CMSBenchmark.sumSmallLongCms        0.1    1000     5  594.712 ±  26.725  ops/s
CMSBenchmark.sumSmallLongCms      0.005    1000     5  449.726 ± 110.672  ops/s
```

and here are the benchmarks after:

```
Benchmark                         (eps)  (size)    Cnt     Score      Error  Units
CMSBenchmark.sumLargeBigIntCms      0.1    1000     5   626.961 ±   32.379  ops/s
CMSBenchmark.sumLargeBigIntCms    0.005    1000     5   573.082 ±  186.829  ops/s
CMSBenchmark.sumLargeStringCms      0.1    1000     5   173.149 ±   64.034  ops/s
CMSBenchmark.sumLargeStringCms    0.005    1000     5   146.868 ±  136.613  ops/s
CMSBenchmark.sumSmallBigIntCms      0.1    1000     5  1369.887 ±  188.736  ops/s
CMSBenchmark.sumSmallBigIntCms    0.005    1000     5  1144.827 ±  238.539  ops/s
CMSBenchmark.sumSmallLongCms        0.1    1000     5  7998.298 ± 6520.702  ops/s
CMSBenchmark.sumSmallLongCms      0.005    1000     5  4708.305 ± 1749.729  ops/s
```

There should also be much less garbage generated in most cases.