### PR TITLE
Add sumOption to Short,Int,Long,Float,Double

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Field.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Field.scala
@@ -54,6 +54,14 @@ object FloatField extends Field[Float] {
     assertNotZero(r)
     l / r
   }
+  override def sum(t: TraversableOnce[Float]): Float = {
+    var sum = 0.0f
+    t.foreach(sum += _)
+    sum
+  }
+  override def sumOption(t: TraversableOnce[Float]): Option[Float] =
+    if (t.isEmpty) None
+    else Some(sum(t))
 }
 
 object DoubleField extends Field[Double] {
@@ -67,6 +75,14 @@ object DoubleField extends Field[Double] {
     assertNotZero(r)
     l / r
   }
+  override def sum(t: TraversableOnce[Double]): Double = {
+    var sum = 0.0
+    t.foreach(sum += _)
+    sum
+  }
+  override def sumOption(t: TraversableOnce[Double]): Option[Double] =
+    if (t.isEmpty) None
+    else Some(sum(t))
 }
 
 object BooleanField extends Field[Boolean] {

--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -86,9 +86,9 @@ object ShortRing extends Ring[Short] {
   override def minus(l: Short, r: Short) = (l - r).toShort
   override def times(l: Short, r: Short) = (l * r).toShort
   override def sum(t: TraversableOnce[Short]): Short = {
-    var sum: Short = 0
-    t.foreach { s => sum = (sum + s).toShort }
-    sum
+    var sum = 0
+    t.foreach(sum += _)
+    sum.toShort
   }
   override def sumOption(t: TraversableOnce[Short]): Option[Short] =
     if (t.isEmpty) None

--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -68,6 +68,14 @@ object IntRing extends Ring[Int] {
   override def plus(l: Int, r: Int) = l + r
   override def minus(l: Int, r: Int) = l - r
   override def times(l: Int, r: Int) = l * r
+  override def sum(t: TraversableOnce[Int]): Int = {
+    var sum = 0
+    t.foreach(sum += _)
+    sum
+  }
+  override def sumOption(t: TraversableOnce[Int]): Option[Int] =
+    if (t.isEmpty) None
+    else Some(sum(t))
 }
 
 object ShortRing extends Ring[Short] {
@@ -77,6 +85,14 @@ object ShortRing extends Ring[Short] {
   override def plus(l: Short, r: Short) = (l + r).toShort
   override def minus(l: Short, r: Short) = (l - r).toShort
   override def times(l: Short, r: Short) = (l * r).toShort
+  override def sum(t: TraversableOnce[Short]): Short = {
+    var sum: Short = 0
+    t.foreach { s => sum = (sum + s).toShort }
+    sum
+  }
+  override def sumOption(t: TraversableOnce[Short]): Option[Short] =
+    if (t.isEmpty) None
+    else Some(sum(t))
 }
 
 object LongRing extends Ring[Long] {
@@ -86,6 +102,14 @@ object LongRing extends Ring[Long] {
   override def plus(l: Long, r: Long) = l + r
   override def minus(l: Long, r: Long) = l - r
   override def times(l: Long, r: Long) = l * r
+  override def sum(t: TraversableOnce[Long]): Long = {
+    var sum = 0L
+    t.foreach(sum += _)
+    sum
+  }
+  override def sumOption(t: TraversableOnce[Long]): Option[Long] =
+    if (t.isEmpty) None
+    else Some(sum(t))
 }
 
 object BigIntRing extends NumericRing[BigInt]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers ++= Seq(
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.9")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")


### PR DESCRIPTION
This can avoid some cases of double boxing. When we use for instance, `Semigroup[T]` and `T` happens to be `Long`, then we can still box despite the specialized call because `T` was generic where the `Semigroup` was used (I believe that is true).

Doing `sum` with plus means, unboxing the accumulator and the next item, adding them, boxing the result and starting again. This gives about `N` boxing operations and `2N` unboxing operations for `N` items to sum. If we do sum internally, we know the type, so we only have to unbox from the `TraverableOnce`, which gives `N` unboxing operations.