### PR TITLE
Add a new Aggregator.numericSum function (second try)

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -284,6 +284,20 @@ object Aggregator extends java.io.Serializable {
    */
   def approximatePercentileBounds[T](percentile: Double, k: Int = QTreeAggregator.DefaultK)(implicit num: Numeric[T]): QTreeAggregator[T] =
     QTreeAggregator[T](percentile, k)
+
+  /**
+   * An aggregator that sums Numeric values into Doubles.
+   *
+   * Note that if you instead wanted to aggregate Numeric values of a type T into the same type T
+   * (e.g. if you want MonoidAggregator[T, T, T] for some Numeric type T), you can directly use
+   * Aggregator.fromMonoid[T] after importing the numericRing implicit:
+   *
+   *   > import com.twitter.algebird.Ring.numericRing
+   *   > def numericAggregator[T: Numeric]: MonoidAggregator[T, T, T] = Aggregator.fromMonoid[T]
+   */
+  def numericSum[T](implicit num: Numeric[T]): MonoidAggregator[T, Double, Double] =
+    Preparer[T].map(num.toDouble).monoidAggregate(Aggregator.fromMonoid)
+
 }
 
 /**

--- a/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
@@ -76,6 +76,16 @@ class AggregatorLaws extends CheckProperties {
     }
   }
 
+  def checkNumericSum[T: Arbitrary](implicit num: Numeric[T]) =
+    forAll { in: List[T] =>
+      val aggregator = Aggregator.numericSum[T]
+      aggregator(in) == in.map(num.toDouble).sum
+    }
+  property("Aggregator.numericSum is correct for Ints") { checkNumericSum[Int] }
+  property("Aggregator.numericSum is correct for Longs") { checkNumericSum[Long] }
+  property("Aggregator.numericSum is correct for Doubles") { checkNumericSum[Double] }
+  property("Aggregator.numericSum is correct for Floats") { checkNumericSum[Float] }
+
   implicit def monoidAggregator[A, B, C](implicit prepare: Arbitrary[A => B], m: Monoid[B], present: Arbitrary[B => C]): Arbitrary[MonoidAggregator[A, B, C]] = Arbitrary {
     for {
       pp <- prepare.arbitrary


### PR DESCRIPTION
I had to create a new PR with the suggested changes (due to the issue discussed [[here](https://github.com/isaacs/github/issues/361)](https://github.com/isaacs/github/issues/361)). Here was the previous [PR](https://github.com/twitter/algebird/pull/534).

This PR creates a numericSum aggregator which aggregates numeric values into Doubles.

Note that @johnynek suggested making this function specialized, but I tried that and the scala compiler complained.

The code was:
```scala
def numericSum[@specialized(Int, Long, Float, Double) T](implicit num: Numeric[T]): MonoidAggregator[T, Double, Double] =
  Preparer[T].map(num.toDouble).monoidAggregate(Aggregator.fromMonoid)
```
And the error was:
```
[warn] /Users/jlande/work/github/algebird/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala:298: type T is unused or used in non-specializable positions.
[warn]   def numericSum[@specialized(Int, Long, Float, Double) T](implicit num: Numeric[T]): MonoidAggregator[T, Double, Double] =

I suspect the issue is that the num.toDouble function is not specialized so the compiler cannot achieve the specialization optimization.
