### PR TITLE
upgrade to new scalatest and scalacheck

### DIFF
--- a/algebird-test/src/main/scala/com/twitter/algebird/ApproximateProperty.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/ApproximateProperty.scala
@@ -52,49 +52,47 @@ object ApproximateProperty {
       }
 
   def toProp(a: ApproximateProperty, objectReps: Int, inputReps: Int, falsePositiveRate: Double): Prop =
-    new Prop {
-      def apply(params: Gen.Parameters) = {
-        require(0 <= falsePositiveRate && falsePositiveRate <= 1)
+    Prop { params: Gen.Parameters =>
+      require(0 <= falsePositiveRate && falsePositiveRate <= 1)
 
-        val list = successesAndProbabilities(a, objectReps, inputReps)
-        val n = list.length
+      val list = successesAndProbabilities(a, objectReps, inputReps)
+      val n = list.length
 
-        val monoid = implicitly[Monoid[(Int, Double, List[String])]]
-        val (successes, sumOfProbabilities, exacts) = monoid.sum(list)
+      val monoid = implicitly[Monoid[(Int, Double, List[String])]]
+      val (successes, sumOfProbabilities, exacts) = monoid.sum(list)
 
-        // Computed from Hoeffding's inequality, might be inaccurate
-        // TODO Make sure this is correct
-        val diff = scala.math.sqrt(-n * scala.math.log(falsePositiveRate) / 2.0)
+      // Computed from Hoeffding's inequality, might be inaccurate
+      // TODO Make sure this is correct
+      val diff = scala.math.sqrt(-n * scala.math.log(falsePositiveRate) / 2.0)
 
-        val success = if (successes >= (sumOfProbabilities - diff)) Prop.Proof else Prop.False
+      val success = if (successes >= (sumOfProbabilities - diff)) Prop.Proof else Prop.False
 
-        // Args that get printed when Scalacheck runs the test
-        val argsList: List[(String, String)] = {
-          val results = List(("Successes", s"$successes (out of $n)"),
-            ("Expected successes", "%.2f".format(sumOfProbabilities)),
-            ("Required successes", "%.2f".format(sumOfProbabilities - diff)))
+      // Args that get printed when Scalacheck runs the test
+      val argsList: List[(String, String)] = {
+        val results = List(("Successes", s"$successes (out of $n)"),
+          ("Expected successes", "%.2f".format(sumOfProbabilities)),
+          ("Required successes", "%.2f".format(sumOfProbabilities - diff)))
 
-          val exampleFailures =
-            if (success == Prop.False)
-              List(("Example failures:\n  >", exacts.take(5).mkString("\n  >")))
-            else List()
+        val exampleFailures =
+          if (success == Prop.False)
+            List(("Example failures:\n  >", exacts.take(5).mkString("\n  >")))
+          else List()
 
-          val zeroProbTests = objectReps * inputReps - n
-          val testsReturnedZeroProb =
-            if (zeroProbTests > 0) {
-              List(("Omitted results", s"${zeroProbTests}/${objectReps * inputReps} tests returned an Approximate with probability 0. These tests have been omitted from the calculation."))
-            } else List()
+        val zeroProbTests = objectReps * inputReps - n
+        val testsReturnedZeroProb =
+          if (zeroProbTests > 0) {
+            List(("Omitted results", s"${zeroProbTests}/${objectReps * inputReps} tests returned an Approximate with probability 0. These tests have been omitted from the calculation."))
+          } else List()
 
-          results ++ exampleFailures ++ testsReturnedZeroProb
-        }
-
-        val args = argsList.map {
-          case (name, value) =>
-            Prop.Arg(name, value, 0, value, Pretty.prettyAny(value), Pretty.prettyAny(value))
-        }
-
-        Prop.Result(success, args = args)
+        results ++ exampleFailures ++ testsReturnedZeroProb
       }
+
+      val args = argsList.map {
+        case (name, value) =>
+          Prop.Arg(name, value, 0, value, Pretty.prettyAny(value), Pretty.prettyAny(value))
+      }
+
+      Prop.Result(success, args = args)
     }
 
   /**
@@ -122,6 +120,6 @@ object ApproximateProperty {
  * the scalacheck property is run exactly once.
  */
 abstract class ApproximateProperties(name: String) extends Properties(name) {
-  def overrideParameters(p: Test.Parameters): Test.Parameters =
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
     p.withMinSuccessfulTests(1)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -181,8 +181,8 @@ lazy val algebirdCore = module("core").settings(
 lazy val algebirdTest = module("test").settings(
   testOptions in Test ++= Seq(Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "4")),
   libraryDependencies <++= (scalaVersion) { scalaVersion =>
-    Seq("org.scalacheck" %% "scalacheck" % "1.12.5",
-        "org.scalatest" %% "scalatest" % "2.2.4") ++ {
+    Seq("org.scalacheck" %% "scalacheck" % "1.13.1",
+        "org.scalatest" %% "scalatest" % "3.0.0") ++ {
       if (isScala210x(scalaVersion))
         Seq("org.scalamacros" %% "quasiquotes" % quasiquotesVersion)
       else


### PR DESCRIPTION
## Problem
I'm trying to upgrade a monorepo to scalatest 3.x and scalacheck 1.13.1.  Because our repo depends on algebird-test, we now need a version of algebird that supports scalacheck 1.13.1.  This will also allow algebird to begin supporting 2.12, which should be released in the next few weeks.

## Solution
I'm cutting you over to scalatest 3.0.0 and scalacheck 1.13.1.  I tried only moving over scalacheck, but scalatest is compiled against a single version of scalacheck, and will break if you switch.

Some of the Prop api has changed–NB that Prop is now sealed, so we need to use the Prop object to create a new Prop.

## Other notable issues
I've run into a problem with the Eventually tests that I'm not really equipped to solve.  It looks like algebird was using the Gen[A => B] implicit from scalacheck, but it used to be really dumb, and only supported constant functions.  It's [less dumb][0] now, which breaks this test.  I don't know how Eventually is actually supposed to behave, so I'd love some help from y'all.  I've enabled edits from maintainers, so please feel free to just fix it.

## Protip
This change has a lot of whitespace changes–append ?w=1 to the url to ignore the whitespace changes.  Thanks!!!

[0]: https://github.com/rickynils/scalacheck/pull/171