### PR TITLE
Improve HLLSeries performance.

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -93,7 +93,7 @@ object HyperLogLog {
     var need = bits
     while (i < bytes.length && need >= 0) {
       val byte = bytes(i) & 0xff
-      val limit = Integer.min(8, need)
+      val limit = java.lang.Math.min(8, need)
       var j = 0
       while (j < limit) {
         sum += ((byte >>> (7 - j)) & 1) << (i * 8 + j)

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer
 import java.lang.Math
 
 /** A super lightweight (hopefully) version of BitSet */
-@deprecated("This is no longer used.", since = "1.12.3")
+@deprecated("This is no longer used.", since = "0.12.3")
 case class BitSetLite(in: Array[Byte]) {
   def contains(x: Int): Boolean = {
     // Pretend 'in' is little endian so that the bitstring b0b1b2b3 is
@@ -81,7 +81,7 @@ object HyperLogLog {
   @inline
   def twopow(i: Int): Double = Math.pow(2.0, i)
 
-  @deprecated("This is no longer used. Use j(Array[Byte], Int) instead.", since = "1.12.3")
+  @deprecated("This is no longer used. Use j(Array[Byte], Int) instead.", since = "0.12.3")
   def j(bsl: BitSetLite, bits: Int): Int =
     j(bsl.in, bits)
 
@@ -106,7 +106,7 @@ object HyperLogLog {
     sum
   }
 
-  @deprecated("This is no longer used. Use rhoW(Array[Byte], Int) instead.", since = "1.12.3")
+  @deprecated("This is no longer used. Use rhoW(Array[Byte], Int) instead.", since = "0.12.3")
   def rhoW(bsl: BitSetLite, bits: Int): Byte =
     rhoW(bsl.in, bits)
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -19,6 +19,7 @@ package com.twitter.algebird
 import java.nio.ByteBuffer
 
 /** A super lightweight (hopefully) version of BitSet */
+@deprecated("this is no longer used", since = "1.12.3")
 case class BitSetLite(in: Array[Byte]) {
   def contains(x: Int): Boolean = {
     // Pretend 'in' is little endian so that the bitstring b0b1b2b3 is
@@ -26,7 +27,7 @@ case class BitSetLite(in: Array[Byte]) {
     // 1 is in the bitset.
     val arrayIdx = x / 8
     val remainder = x % 8
-    ((in(arrayIdx) >> (7 - remainder)) & 1) == 1
+    ((in(arrayIdx) >>> (7 - remainder)) & 1) == 1
   }
 }
 
@@ -79,34 +80,65 @@ object HyperLogLog {
   @inline
   def twopow(i: Int): Double = java.lang.Math.pow(2.0, i)
 
-  /**
-   * the value 'j' is equal to <w_0, w_1 ... w_(bits-1)>
-   *  TODO: We could read in a byte at a time.
-   */
-  def j(bsl: BitSetLite, bits: Int): Int = {
-    @annotation.tailrec
-    def loop(pos: Int, accum: Int): Int = {
-      if (pos >= bits) {
-        accum
-      } else if (bsl.contains(pos)) {
-        loop(pos + 1, accum + (1 << pos))
-      } else {
-        loop(pos + 1, accum)
-      }
-    }
-    loop(0, 0)
-  }
+  @deprecated("this is no longer used", since = "1.12.3")
+  def j(bsl: BitSetLite, bits: Int): Int =
+    j(bsl.in, bits)
 
   /**
-   * The value 'w' is equal to <w_bits ... w_n>. The function rho counts the number of leading
-   *  zeroes in 'w'. We can calculate rho(w) at once with the method rhoW.
+   *
    */
-  def rhoW(bsl: BitSetLite, bits: Int): Byte = {
-    @annotation.tailrec
-    def loop(pos: Int, zeros: Int): Int =
-      if (bsl.contains(pos)) zeros
-      else loop(pos + 1, zeros + 1)
-    loop(bits, 1).toByte
+  def j(bytes: Array[Byte], bits: Int): Int = {
+    var i = 0
+    var sum = 0
+    var need = bits
+    while (i < bytes.length && need >= 0) {
+      val byte = bytes(i) & 0xff
+      val limit = Integer.min(8, need)
+      var j = 0
+      while (j < limit) {
+        sum += ((byte >>> (7 - j)) & 1) << (i * 8 + j)
+        j += 1
+      }
+      need -= 8
+      i += 1
+    }
+    sum
+  }
+
+  @deprecated("this is no longer used", since = "1.12.3")
+  def rhoW(bsl: BitSetLite, bits: Int): Byte =
+    rhoW(bsl.in, bits)
+
+  /**
+   * The value 'w' is represented as a bitset (encoding in
+   * `bytes`). This function counds the number of leading zeros in 'w'.
+   *
+   * Each byte is treated as a set of bits (little-endian). That is,
+   * the one bit represents the first value, then the two bit, then
+   * four, and so on.
+   *
+   * We treat the leading `bits` bits as if they were instead a single
+   * zero bit.
+   */
+  def rhoW(bytes: Array[Byte], bits: Int): Byte = {
+    var i = bits / 8 // tracks the position in bytes
+    var j = 7 - (bits % 8) // tracks the bit position in bytes(i)
+    var zeros = 1 // start with a single zero
+    while (i < bytes.length) {
+      while (j >= 0) {
+        if (((bytes(i) >>> j) & 1) == 1) return zeros.toByte
+        zeros += 1
+        j -= 1
+      }
+      i += 1
+      j = 7
+    }
+
+    // If the array has only zeros we say there are no leading
+    // zeros. Since different length byte arrays of all zeros should
+    // return the same value here, it's not clear what other answer is
+    // appropriate. We will almost never reach this code in practice.
+    0.toByte
   }
 
   /**
@@ -117,10 +149,8 @@ object HyperLogLog {
    *  the value 'w' is equal to <w_bits ... w_n>. The function rho counts the number of leading
    *  zeroes in 'w'. We can calculate rho(w) at once with the method rhoW.
    */
-  def jRhoW(in: Array[Byte], bits: Int): (Int, Byte) = {
-    val onBits = BitSetLite(in)
-    (j(onBits, bits), rhoW(onBits, bits))
-  }
+  def jRhoW(in: Array[Byte], bits: Int): (Int, Byte) =
+    (j(in, bits), rhoW(in, bits))
 
   def toBytes(h: HLL): Array[Byte] = {
     h match {
@@ -231,6 +261,34 @@ object HyperLogLog {
     require(err >= 0.00003 && err < 1.0, s"Error must be in (0.00003, 1.0): $err")
     math.ceil(2.0 * math.log(1.04 / err) / math.log(2.0)).toInt
   }
+
+  def initialEstimate(bits: Int, size: Int, zeroCnt: Int, z: Double): Double = {
+    val sizeDouble: Double = size.toDouble
+    val smallE = 5 * sizeDouble / 2.0
+    val factor = alpha(bits) * sizeDouble * sizeDouble
+
+    val e: Double = factor * z
+
+    // There are large and small value corrections from the paper We
+    // stopped using the large value corrections since when using
+    // Long there were pathologically bad results.
+    //
+    // See https://github.com/twitter/algebird/issues/284
+    if (e > smallE || zeroCnt == 0) e
+    else size * scala.math.log(size.toDouble / zeroCnt)
+  }
+
+  def asApprox(bits: Int, v: Double): Approximate[Long] = {
+    val stdev = 1.04 / scala.math.sqrt(twopow(bits))
+    val lowerBound = math.floor(math.max(v * (1.0 - 3 * stdev), 0.0)).toLong
+    val upperBound = math.ceil(v * (1.0 + 3 * stdev)).toLong
+    // Lower bound. see: http://en.wikipedia.org/wiki/68-95-99.7_rule
+    val prob3StdDev = 0.9972
+    Approximate(lowerBound, v.toLong, upperBound, prob3StdDev)
+  }
+
+  def approximateSize(bits: Int, size: Int, zeroCnt: Int, z: Double): Approximate[Long] =
+    asApprox(bits, initialEstimate(bits, size, zeroCnt, z))
 }
 
 sealed abstract class HLL extends java.io.Serializable {
@@ -243,43 +301,17 @@ sealed abstract class HLL extends java.io.Serializable {
   def +(other: HLL): HLL
   def toDenseHLL: DenseHLL
 
-  def approximateSize = asApprox(initialEstimate)
+  def approximateSize: Approximate[Long] =
+    asApprox(initialEstimate)
 
   def estimatedSize: Double = initialEstimate
 
-  private lazy val initialEstimate: Double = {
+  private lazy val initialEstimate: Double =
+    HyperLogLog.initialEstimate(bits, size, zeroCnt, z)
 
-    val sizeDouble: Double = size.toDouble
-    val smallE = 5 * sizeDouble / 2.0
-    val factor = alpha(bits) * sizeDouble * sizeDouble
+  private def asApprox(v: Double): Approximate[Long] =
+    HyperLogLog.asApprox(bits, v)
 
-    val e: Double = factor * z
-    // There are large and small value corrections from the paper
-    // We stopped using the large value corrections since when using Long's
-    // there was pathologically bad results. See https://github.com/twitter/algebird/issues/284
-    if (e <= smallE) {
-      smallEstimate(e)
-    } else {
-      e
-    }
-  }
-
-  private def asApprox(v: Double): Approximate[Long] = {
-    val stdev = error(bits)
-    val lowerBound = math.floor(math.max(v * (1.0 - 3 * stdev), 0.0)).toLong
-    val upperBound = math.ceil(v * (1.0 + 3 * stdev)).toLong
-    // Lower bound. see: http://en.wikipedia.org/wiki/68-95-99.7_rule
-    val prob3StdDev = 0.9972
-    Approximate(lowerBound, v.toLong, upperBound, prob3StdDev)
-  }
-
-  private def smallEstimate(e: Double): Double = {
-    if (zeroCnt == 0) {
-      e
-    } else {
-      size * scala.math.log(size.toDouble / zeroCnt)
-    }
-  }
   /**
    * Set each item in the given buffer to the max of this and the buffer
    */
@@ -311,7 +343,7 @@ sealed abstract class HLL extends java.io.Serializable {
       // find the number of leading zeros
       // we use bitMask to force rhoW to stop after going through (bits - reducedBits) bits
       ByteBuffer.wrap(buf).putInt(Integer.reverse(currentJ | bitMask))
-      HyperLogLog.rhoW(BitSetLite(buf), reducedBits)
+      HyperLogLog.rhoW(buf, reducedBits)
     }
   }
 
@@ -563,10 +595,8 @@ class HyperLogLogMonoid(val bits: Int) extends Monoid[HLL] {
     createFromHashBytes(hashBytes)
   }
 
-  def createFromHashBytes(hashed: Array[Byte]): HLL = {
-    val (j, rhow) = jRhoW(hashed, bits)
-    SparseHLL(bits, Map(j -> Max(rhow)))
-  }
+  def createFromHashBytes(hashed: Array[Byte]): HLL =
+    SparseHLL(bits, Map(j(hashed, bits) -> Max(rhoW(hashed, bits))))
 
   @deprecated("Use toHLL", since = "0.10.0 / 2015-05")
   def batchCreate[T <% Array[Byte]](instances: Iterable[T]): HLL = {

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -19,7 +19,7 @@ package com.twitter.algebird
 import java.nio.ByteBuffer
 
 /** A super lightweight (hopefully) version of BitSet */
-@deprecated("this is no longer used", since = "1.12.3")
+@deprecated("This is no longer used.", since = "1.12.3")
 case class BitSetLite(in: Array[Byte]) {
   def contains(x: Int): Boolean = {
     // Pretend 'in' is little endian so that the bitstring b0b1b2b3 is
@@ -80,7 +80,7 @@ object HyperLogLog {
   @inline
   def twopow(i: Int): Double = java.lang.Math.pow(2.0, i)
 
-  @deprecated("this is no longer used", since = "1.12.3")
+  @deprecated("This is no longer used. Use j(Array[Byte], Int) instead.", since = "1.12.3")
   def j(bsl: BitSetLite, bits: Int): Int =
     j(bsl.in, bits)
 
@@ -91,7 +91,7 @@ object HyperLogLog {
     var i = 0
     var sum = 0
     var need = bits
-    while (i < bytes.length && need >= 0) {
+    while (i < bytes.length && need > 0) {
       val byte = bytes(i) & 0xff
       val limit = java.lang.Math.min(8, need)
       var j = 0
@@ -105,7 +105,7 @@ object HyperLogLog {
     sum
   }
 
-  @deprecated("this is no longer used", since = "1.12.3")
+  @deprecated("This is no longer used. Use rhoW(Array[Byte], Int) instead.", since = "1.12.3")
   def rhoW(bsl: BitSetLite, bits: Int): Byte =
     rhoW(bsl.in, bits)
 
@@ -126,7 +126,9 @@ object HyperLogLog {
     var zeros = 1 // start with a single zero
     while (i < bytes.length) {
       while (j >= 0) {
-        if (((bytes(i) >>> j) & 1) == 1) return zeros.toByte
+        if (((bytes(i) >>> j) & 1) == 1) {
+          return zeros.toByte
+        }
         zeros += 1
         j -= 1
       }

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -17,6 +17,7 @@ limitations under the License.
 package com.twitter.algebird
 
 import java.nio.ByteBuffer
+import java.lang.Math
 
 /** A super lightweight (hopefully) version of BitSet */
 @deprecated("This is no longer used.", since = "1.12.3")
@@ -78,7 +79,7 @@ object HyperLogLog {
   }
 
   @inline
-  def twopow(i: Int): Double = java.lang.Math.pow(2.0, i)
+  def twopow(i: Int): Double = Math.pow(2.0, i)
 
   @deprecated("This is no longer used. Use j(Array[Byte], Int) instead.", since = "1.12.3")
   def j(bsl: BitSetLite, bits: Int): Int =
@@ -93,7 +94,7 @@ object HyperLogLog {
     var need = bits
     while (i < bytes.length && need > 0) {
       val byte = bytes(i) & 0xff
-      val limit = java.lang.Math.min(8, need)
+      val limit = Math.min(8, need)
       var j = 0
       while (j < limit) {
         sum += ((byte >>> (7 - j)) & 1) << (i * 8 + j)
@@ -282,8 +283,8 @@ object HyperLogLog {
 
   def asApprox(bits: Int, v: Double): Approximate[Long] = {
     val stdev = 1.04 / scala.math.sqrt(twopow(bits))
-    val lowerBound = math.floor(math.max(v * (1.0 - 3 * stdev), 0.0)).toLong
-    val upperBound = math.ceil(v * (1.0 + 3 * stdev)).toLong
+    val lowerBound = Math.floor(math.max(v * (1.0 - 3 * stdev), 0.0)).toLong
+    val upperBound = Math.ceil(v * (1.0 + 3 * stdev)).toLong
     // Lower bound. see: http://en.wikipedia.org/wiki/68-95-99.7_rule
     val prob3StdDev = 0.9972
     Approximate(lowerBound, v.toLong, upperBound, prob3StdDev)

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLogSeries.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLogSeries.scala
@@ -60,9 +60,8 @@ case class HLLSeries(bits: Int, rows: Vector[Map[Int, Long]]) {
       val it = rows(i).iterator
       while (it.hasNext) {
         val (k, t) = it.next
-        if (t >= threshold && !seen(k)) {
+        if (t >= threshold && seen.add(k)) {
           sum += HyperLogLog.negativePowersOfTwo(i + 1)
-          seen += k
         }
       }
       i -= 1

--- a/algebird-test/src/main/scala/com/twitter/algebird/ApproximateProperty.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/ApproximateProperty.scala
@@ -120,6 +120,6 @@ object ApproximateProperty {
  * the scalacheck property is run exactly once.
  */
 abstract class ApproximateProperties(name: String) extends Properties(name) {
-  def overrideParameters(p: Test.Parameters): Test.Parameters =
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
     p.withMinSuccessfulTests(1)
 }

--- a/algebird-test/src/main/scala/com/twitter/algebird/ApproximateProperty.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/ApproximateProperty.scala
@@ -120,6 +120,6 @@ object ApproximateProperty {
  * the scalacheck property is run exactly once.
  */
 abstract class ApproximateProperties(name: String) extends Properties(name) {
-  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+  def overrideParameters(p: Test.Parameters): Test.Parameters =
     p.withMinSuccessfulTests(1)
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -29,8 +29,9 @@ object ReferenceHyperLogLog {
 
   def jRhoW(in: Array[Byte], bits: Int): (Int, Byte) = {
     val onBits = bytesToBitSet(in)
-    (onBits.filter { _ < bits }.map { 1 << _ }.sum,
-      (onBits.filter { _ >= bits }.min - bits + 1).toByte)
+    val j = onBits.filter { _ < bits }.map { 1 << _ }.sum
+    val rhow = onBits.find { _ >= bits }.map { _ - bits + 1 }.getOrElse(0)
+    (j, rhow.toByte)
   }
 
   def hash(input: Array[Byte]): Array[Byte] = {
@@ -49,13 +50,11 @@ class HyperLogLogLaws extends CheckProperties {
   import BaseProperties._
   import HyperLogLog._
 
-  implicit val hllMonoid = new HyperLogLogMonoid(5) //5 bits
+  val bits = 8
+  implicit val hllMonoid = new HyperLogLogMonoid(bits)
 
-  implicit val hllGen = Arbitrary {
-    for (
-      v <- Gen.choose(0, 10000)
-    ) yield (hllMonoid.create(v))
-  }
+  implicit val hllGen: Arbitrary[HLL] =
+    Arbitrary(Gen.choose(0L, 1000000L).map(v => hllMonoid.create(long2Bytes(v))))
 
   property("HyperLogLog is a Monoid") {
     monoidLawsEq[HLL]{ _.toDenseHLL == _.toDenseHLL }
@@ -75,6 +74,15 @@ class HyperLogLogLaws extends CheckProperties {
   property("HyperLogLog.hash matches reference") {
     Prop.forAll { a: Array[Byte] =>
       HyperLogLog.hash(a).toSeq == ReferenceHyperLogLog.hash(a).toSeq
+    }
+  }
+
+  property("HyperLogLog.j and rhow match reference") {
+    Prop.forAll { (bytes: Array[Byte]) =>
+      val (j0, rhow0) = ReferenceHyperLogLog.jRhoW(bytes, bits)
+      val j1 = HyperLogLog.j(bytes, bits)
+      val rhow1 = HyperLogLog.rhoW(bytes, bits)
+      j0 == j1 && rhow0 == rhow1
     }
   }
 }
@@ -217,7 +225,7 @@ class HLLProperties extends ApproximateProperties("HyperLogLog") {
   implicit val intGen = Gen.chooseNum(Int.MinValue, Int.MaxValue)
   implicit val longGen = Gen.chooseNum(Long.MinValue, Long.MaxValue)
 
-  for (bits <- List(5, 6, 7, 10)) {
+  for (bits <- List(5, 6, 7, 8, 10)) {
     property(s"Count ints with $bits bits") =
       toProp(new HLLCountProperty[Int](bits), 100, 1, 0.01)
 
@@ -249,14 +257,14 @@ class SetSizeAggregatorProperties extends ApproximateProperties("SetSizeAggregat
   implicit val intGen = Gen.chooseNum(Int.MinValue, Int.MaxValue)
   implicit val longGen = Gen.chooseNum(Long.MinValue, Long.MaxValue)
 
-  for (bits <- List(5, 7, 10)) {
+  for (bits <- List(5, 7, 8, 10)) {
     property(s"work as an Aggregator and return exact size when <= maxSetSize for $bits bits, using conversion to Array[Byte]") =
       toProp(new SmallBytesSetSizeAggregatorProperty[Int](bits), 100, 1, 0.01)
     property(s"work as an Aggregator and return exact size when <= maxSetSize for $bits bits, using Hash128") =
       toProp(new SmallSetSizeHashAggregatorProperty[Int](bits), 100, 1, 0.01)
   }
 
-  for (bits <- List(5, 7, 10)) {
+  for (bits <- List(5, 7, 8, 10)) {
     property(s"work as an Aggregator and return approximate size when > maxSetSize for $bits bits, using conversion to Array[Byte]") =
       toProp(new LargeBytesSetSizeAggregatorProperty[Int](bits), 100, 1, 0.01)
     property(s"work as an Aggregator and return approximate size when > maxSetSize for $bits bits, using Hash128") =
@@ -349,7 +357,7 @@ class HyperLogLogTest extends WordSpec with Matchers {
     }
 
     "work as an Aggregator and return a HLL" in {
-      List(5, 7, 10).foreach(bits => {
+      List(5, 7, 8, 10).foreach(bits => {
         val aggregator = HyperLogLogAggregator(bits)
         val data = (0 to 10000).map { i => r.nextInt(1000) }
         val exact = exactCount(data).toDouble
@@ -360,7 +368,7 @@ class HyperLogLogTest extends WordSpec with Matchers {
     }
 
     "work as an Aggregator and return size" in {
-      List(5, 7, 10).foreach(bits => {
+      List(5, 7, 8, 10).foreach(bits => {
         val aggregator = HyperLogLogAggregator.sizeAggregator(bits)
         val data = (0 to 10000).map { i => r.nextInt(1000) }
         val exact = exactCount(data).toDouble


### PR DESCRIPTION
This commit improves the performance of the HLLSeries data
structure. In particular, it introduces two new methods:

    series.insert(bytes, timestamp)
    series.approximateSizeSince(threshold)

Previously to add data to an HLLSeries required allocating another
series and then combining them with the monoid, potentially creating a
lot of garbage. The `insert` method does the same thing but without an
intermediate series.

Similarly, getting an approximate size used to require calling
`.toHLL` to build an HLL structure, and then asking that. By
abstracting out the machinery to actually do the HLL calculation,
we're able to do this directly from HLLSeries with
`approximateSizeSince`.

There are several other internal efficiency improvements. Some
independent benchmarks I've run show a 4-5x speed up in building
series' from many individual events, and a 3-4x speed up in
calculating the approximate sizes.

The data in the series and the serialization format are unchanged.