### PR TITLE
Create Equiv versions of all laws, fix broken tests

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -209,14 +209,6 @@ object SketchMap {
 
   def aggregator[K, V](params: SketchMapParams[K])(implicit valueOrdering: Ordering[V], monoid: Monoid[V]): SketchMapAggregator[K, V] =
     SketchMapAggregator(params, SketchMap.monoid(params))
-
-  // TODO: SketchMap's heavy hitters are not strictly associative
-  // (approximately they are)
-  implicit def equiv[K, V]: Equiv[SketchMap[K, V]] =
-    Equiv.fromFunction { (left, right) =>
-      (left.valuesTable == right.valuesTable) &&
-        (left.totalValue == right.totalValue)
-    }
 }
 
 case class SketchMap[K, V](

--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -209,6 +209,14 @@ object SketchMap {
 
   def aggregator[K, V](params: SketchMapParams[K])(implicit valueOrdering: Ordering[V], monoid: Monoid[V]): SketchMapAggregator[K, V] =
     SketchMapAggregator(params, SketchMap.monoid(params))
+
+  // TODO: SketchMap's heavy hitters are not strictly associative
+  // (approximately they are)
+  implicit def equiv[K, V]: Equiv[SketchMap[K, V]] =
+    Equiv.fromFunction { (left, right) =>
+      (left.valuesTable == right.valuesTable) &&
+        (left.totalValue == right.totalValue)
+    }
 }
 
 case class SketchMap[K, V](

--- a/algebird-core/src/main/scala/com/twitter/algebird/SpaceSaver.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SpaceSaver.scala
@@ -17,11 +17,6 @@ object SpaceSaver {
 
   private[algebird] val ordering = Ordering.by[(_, (Long, Long)), (Long, Long)]{ case (item, (count, err)) => (-count, err) }
 
-  implicit def equiv[T]: Equiv[SpaceSaver[T]] =
-    Equiv.fromFunction { (left, right) =>
-      (left consistentWith right) && (right consistentWith left)
-    }
-
   implicit def spaceSaverSemiGroup[T]: Semigroup[SpaceSaver[T]] = new SpaceSaverSemigroup[T]
 }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/SpaceSaver.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SpaceSaver.scala
@@ -17,6 +17,11 @@ object SpaceSaver {
 
   private[algebird] val ordering = Ordering.by[(_, (Long, Long)), (Long, Long)]{ case (item, (count, err)) => (-count, err) }
 
+  implicit def equiv[T]: Equiv[SpaceSaver[T]] =
+    Equiv.fromFunction { (left, right) =>
+      (left consistentWith right) && (right consistentWith left)
+    }
+
   implicit def spaceSaverSemiGroup[T]: Semigroup[SpaceSaver[T]] = new SpaceSaverSemigroup[T]
 }
 

--- a/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
@@ -24,8 +24,7 @@ import scala.math.Equiv
 /**
  * Base properties useful for all tests using Algebird's typeclasses.
  */
-
-object BaseProperties {
+object BaseProperties extends MetricProperties {
   val arbReasonableBigDecimals: Arbitrary[BigDecimal] = Arbitrary(
     for {
       scale <- Gen.choose(-128, +128)

--- a/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/BaseProperties.scala
@@ -62,6 +62,7 @@ object BaseProperties {
   def isAssociativeDifferentTypes[T: Semigroup, U <: T: Arbitrary]: Prop =
     isAssociativeEquiv[T, U]
 
+  @deprecated("use isAssociativeEquiv[T, U] with implicit Equiv[T] instance", since = "0.12.3")
   def isAssociativeEq[T: Semigroup, U <: T: Arbitrary](eqfn: (T, T) => Boolean): Prop = {
     implicit val eq: Equiv[T] = Equiv.fromFunction(eqfn)
     isAssociativeEquiv[T, U]
@@ -79,6 +80,7 @@ object BaseProperties {
     isCommutativeEquiv[T]
   }
 
+  @deprecated("use isCommutativeEquiv[T] with implicit Equiv[T] instance", since = "0.12.3")
   def isCommutativeEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean): Prop = {
     implicit val eq: Equiv[T] = Equiv.fromFunction(eqfn)
     isCommutativeEquiv[T]
@@ -104,6 +106,7 @@ object BaseProperties {
     semigroupLawsEquiv[T]
   }
 
+  @deprecated("use semigroupLawsEquiv[T] with implicit Equiv[T] instance", since = "0.12.3")
   def semigroupLawsEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean): Prop = {
     implicit val eq: Equiv[T] = Equiv.fromFunction(eqfn)
     semigroupLawsEquiv[T]
@@ -118,6 +121,7 @@ object BaseProperties {
     commutativeSemigroupLawsEquiv[T]
   }
 
+  @deprecated("use commutativeSemigroupLawsEquiv[T] with implicit Equiv[T] instance", since = "0.12.3")
   def commutativeSemigroupLawsEq[T: Semigroup: Arbitrary](eqfn: (T, T) => Boolean): Prop = {
     implicit val eq: Equiv[T] = Equiv.fromFunction(eqfn)
     commutativeSemigroupLawsEquiv[T]
@@ -139,21 +143,34 @@ object BaseProperties {
       (Monoid.isNonZero(a) && Monoid.isNonZero(b)) || prodZero
     }
 
-  def weakZeroDifferentTypes[T: Monoid, U <: T: Arbitrary]: Prop =
+  def weakZeroDifferentTypes[T: Monoid, U <: T: Arbitrary]: Prop = {
+    implicit val eq: Equiv[T] = Equiv.universal
+    weakZeroDifferentTypesEquiv[T, U]
+  }
+
+  def weakZeroDifferentTypesEquiv[T: Monoid: Equiv, U <: T: Arbitrary]: Prop =
     'weakZeroDifferentTypes |: forAll { (a: U) =>
       val mon = implicitly[Monoid[T]]
       val zero = mon.zero
-      // Some types, e.g. Maps, are not totally equal for all inputs (i.e. zero values removed)
-      (mon.plus(a, zero) == mon.plus(zero, a))
+      // Some types, e.g. Maps, are not totally equal for all inputs
+      // (i.e. zero values removed)
+      Equiv[T].equiv(mon.plus(a, zero), mon.plus(zero, a))
     }
 
-  def weakZero[T: Monoid: Arbitrary]: Prop = weakZeroDifferentTypes[T, T]
+  def weakZero[T: Monoid: Arbitrary]: Prop = {
+    implicit val eq: Equiv[T] = Equiv.universal
+    weakZeroEquiv[T]
+  }
+
+  def weakZeroEquiv[T: Monoid: Arbitrary: Equiv]: Prop =
+    weakZeroDifferentTypesEquiv[T, T]
 
   def validZero[T: Monoid: Arbitrary]: Prop = {
     implicit val eq: Equiv[T] = Equiv.universal
     validZeroEquiv[T]
   }
 
+  @deprecated("use validZeroEquiv[T] with implicit Equiv[T] instance", since = "0.12.3")
   def validZeroEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean): Prop = {
     implicit val eq: Equiv[T] = Equiv.fromFunction(eqfn)
     validZeroEquiv[T]
@@ -173,6 +190,7 @@ object BaseProperties {
     monoidLawsEquiv[T]
   }
 
+  @deprecated("use monoidLawsEquiv[T] with implicit Equiv[T] instance", since = "0.12.3")
   def monoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean): Prop = {
     implicit val eq: Equiv[T] = Equiv.fromFunction(eqfn)
     monoidLawsEquiv[T]
@@ -186,6 +204,7 @@ object BaseProperties {
     commutativeMonoidLawsEquiv[T]
   }
 
+  @deprecated("use commutativeMonoidLawsEquiv[T] with implicit Equiv[T] instance", since = "0.12.3")
   def commutativeMonoidLawsEq[T: Monoid: Arbitrary](eqfn: (T, T) => Boolean): Prop = {
     implicit val eq: Equiv[T] = Equiv.fromFunction(eqfn)
     commutativeMonoidLawsEquiv[T]
@@ -210,6 +229,7 @@ object BaseProperties {
     groupLawsEquiv[T]
   }
 
+  @deprecated("use groupLawsEquiv[T] with implicit Equiv[T] instance", since = "0.12.3")
   def groupLawsEq[T: Group: Arbitrary](eqfn: (T, T) => Boolean): Prop = {
     implicit val eq: Equiv[T] = Equiv.fromFunction(eqfn)
     groupLawsEquiv[T]
@@ -219,10 +239,16 @@ object BaseProperties {
     monoidLawsEquiv[T] && hasAdditiveInverses[T]
 
   // Here are multiplicative properties:
-  def validOne[T: Ring: Arbitrary]: Prop =
+  def validOne[T: Ring: Arbitrary]: Prop = {
+    implicit val eq: Equiv[T] = Equiv.universal
+    validOneEquiv[T]
+  }
+
+  def validOneEquiv[T: Ring: Arbitrary: Equiv]: Prop =
     'validOne |: forAll { (a: T) =>
       val rng = implicitly[Ring[T]]
-        (rng.times(rng.one, a) == rng.times(a, rng.one)) && (a == rng.times(a, rng.one))
+      Equiv[T].equiv(rng.times(rng.one, a), rng.times(a, rng.one)) &&
+      Equiv[T].equiv(a, rng.times(a, rng.one))
     }
 
   def zeroAnnihilates[T: Ring: Arbitrary]: Prop =
@@ -232,33 +258,65 @@ object BaseProperties {
       (!ring.isNonZero(ring.times(ring.zero, a)))
     }
 
-  def isDistributiveDifferentTypes[T: Ring, U <: T: Arbitrary]: Prop =
+  def isDistributiveDifferentTypes[T: Ring, U <: T: Arbitrary]: Prop = {
+    implicit val eq: Equiv[T] = Equiv.universal
+    isDistributiveDifferentTypesEquiv[T, U]
+  }
+
+  def isDistributiveDifferentTypesEquiv[T: Ring: Equiv, U <: T: Arbitrary]: Prop =
     'isDistributiveDifferentTypes |:
   forAll { (a: U, b: U, c: U) =>
-      val rng = implicitly[Ring[T]]
-      (rng.times(a, rng.plus(b, c)) == rng.plus(rng.times(a, b), rng.times(a, c))) &&
-        (rng.times(rng.plus(b, c), a) == rng.plus(rng.times(b, a), rng.times(c, a)))
-    }
+    val rng = implicitly[Ring[T]]
+    Equiv[T].equiv(rng.times(a, rng.plus(b, c)), rng.plus(rng.times(a, b), rng.times(a, c))) &&
+    Equiv[T].equiv(rng.times(rng.plus(b, c), a), rng.plus(rng.times(b, a), rng.times(c, a)))
+  }
 
-  def isDistributive[T: Ring: Arbitrary]: Prop = isDistributiveDifferentTypes[T, T]
+  def isDistributive[T: Ring: Arbitrary]: Prop = {
+    implicit val eq: Equiv[T] = Equiv.universal
+    isDistributiveEquiv[T]
+  }
 
-  def timesIsAssociative[T: Ring: Arbitrary]: Prop =
+  def isDistributiveEquiv[T: Ring: Arbitrary: Equiv]: Prop =
+    isDistributiveDifferentTypesEquiv[T, T]
+
+  def timesIsAssociative[T: Ring: Arbitrary]: Prop = {
+    implicit val eq: Equiv[T] = Equiv.universal
+    timesIsAssociativeEquiv[T]
+  }
+
+  def timesIsAssociativeEquiv[T: Ring: Arbitrary: Equiv]: Prop =
     'timesIsAssociative |: forAll { (a: T, b: T, c: T) =>
       val rng = implicitly[Ring[T]]
-      rng.times(a, rng.times(b, c)) == rng.times(rng.times(a, b), c)
+      Equiv[T].equiv(rng.times(a, rng.times(b, c)), rng.times(rng.times(a, b), c))
     }
 
-  def pseudoRingLaws[T: Ring: Arbitrary]: Prop =
-    isDistributive[T] && timesIsAssociative[T] && groupLaws[T] && isCommutative[T] &&
-      isNonZeroWorksRing[T]
+  def pseudoRingLaws[T: Ring: Arbitrary]: Prop = {
+    implicit val eq: Equiv[T] = Equiv.universal
+    pseudoRingLawsEquiv[T]
+  }
 
-  def semiringLaws[T: Ring: Arbitrary]: Prop =
-    isDistributive[T] && timesIsAssociative[T] &&
-      validOne[T] && commutativeMonoidLaws[T] &&
+  def pseudoRingLawsEquiv[T: Ring: Arbitrary: Equiv]: Prop =
+    isDistributiveEquiv[T] && timesIsAssociativeEquiv[T] && groupLawsEquiv[T] &&
+  isCommutativeEquiv[T] && isNonZeroWorksRing[T]
+
+  def semiringLaws[T: Ring: Arbitrary]: Prop = {
+    implicit val eq: Equiv[T] = Equiv.universal
+    semiringLawsEquiv[T]
+  }
+
+  def semiringLawsEquiv[T: Ring: Arbitrary: Equiv]: Prop =
+    isDistributiveEquiv[T] && timesIsAssociativeEquiv[T] &&
+      validOneEquiv[T] && commutativeMonoidLawsEquiv[T] &&
       zeroAnnihilates[T] &&
       isNonZeroWorksRing[T]
 
-  def ringLaws[T: Ring: Arbitrary]: Prop = validOne[T] && pseudoRingLaws[T]
+  def ringLaws[T: Ring: Arbitrary]: Prop = {
+    implicit val eq: Equiv[T] = Equiv.universal
+    ringLawsEquiv[T]
+  }
+
+  def ringLawsEquiv[T: Ring: Arbitrary: Equiv]: Prop =
+    validOneEquiv[T] && pseudoRingLawsEquiv[T]
 
   def hasMultiplicativeInverse[T: Field: Arbitrary]: Prop =
     'hasMultiplicativeInverse |: forAll { (a: T) =>

--- a/algebird-test/src/main/scala/com/twitter/algebird/MetricProperties.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/MetricProperties.scala
@@ -1,0 +1,61 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird
+
+import org.scalacheck.{ Arbitrary, Prop }
+import org.scalacheck.Prop.forAll
+
+import scala.math.Equiv
+
+/**
+ * Properties useful for testing instances of Metric[T].
+ */
+trait MetricProperties {
+  private def beCloseTo(a: Double, b: Double, eps: Double = 1e-10): Boolean =
+    a == b || (math.abs(a - b) / math.abs(a)) < eps || (a.isInfinite && b.isInfinite)
+
+  private def beGreaterThan(a: Double, b: Double, eps: Double = 1e-10): Boolean =
+    a > b - eps || (a.isInfinite && b.isInfinite)
+
+  def isNonNegative[T: Metric: Arbitrary]: Prop =
+    forAll { (a: T, b: T) =>
+      val m = Metric(a, b)
+      beGreaterThan(m, 0.0) || beCloseTo(m, 0.0)
+    }
+
+  def isEqualIffZero[T: Metric: Arbitrary: Equiv]: Prop =
+    forAll { (a: T, b: T) =>
+      if (Equiv[T].equiv(a, b)) beCloseTo(Metric(a, b), 0.0)
+      else !beCloseTo(Metric(a, b), 0.0)
+    }
+
+  def isSymmetric[T: Metric: Arbitrary]: Prop =
+    forAll { (a: T, b: T) =>
+      beCloseTo(Metric(a, b), Metric(b, a))
+    }
+
+  def satisfiesTriangleInequality[T: Metric: Arbitrary]: Prop =
+    forAll { (a: T, b: T, c: T) =>
+      val m1 = Metric(a, b) + Metric(b, c)
+      val m2 = Metric(a, c)
+      beGreaterThan(m1, m2) || beCloseTo(m1, m2)
+    }
+
+  def metricLaws[T: Metric: Arbitrary: Equiv]: Prop =
+    isNonNegative[T] && isEqualIffZero[T] &&
+      isSymmetric[T] && satisfiesTriangleInequality[T]
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/AdJoinedUnitRingLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AdJoinedUnitRingLaws.scala
@@ -20,7 +20,7 @@ import com.twitter.algebird.BaseProperties._
 import com.twitter.algebird.scalacheck.arbitrary._
 import org.scalacheck.Prop.forAll
 
-class AdjoinedUnitRingSpec extends CheckProperties {
+class AdjoinedUnitRingLaws extends CheckProperties {
   // AdjoinedUnit requires this method to be correct, so it is tested here:
   property("intTimes works correctly") {
     forAll { (bi0: BigInt, bi1: BigInt) =>

--- a/algebird-test/src/test/scala/com/twitter/algebird/AveragedValueLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AveragedValueLaws.scala
@@ -5,11 +5,12 @@ import com.twitter.algebird.scalacheck.arbitrary._
 
 class AveragedValueLaws extends CheckProperties {
   property("AveragedValue Group laws") {
-    groupLawsEq[AveragedValue] { (avl, avr) =>
-      ((avl.count == 0L) && (avr.count == 0L)) || {
-        approxEq(1e-10)(avl.value, avr.value) && (avl.count == avr.count)
+    implicit val equiv: Equiv[AveragedValue] =
+      Equiv.fromFunction { (avl, avr) =>
+        ((avl.count == 0L) && (avr.count == 0L)) || {
+          approxEq(1e-10)(avl.value, avr.value) && (avl.count == avr.count)
+        }
       }
-    }
+    groupLawsEquiv[AveragedValue]
   }
-
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/BatchedTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BatchedTest.scala
@@ -24,7 +24,7 @@ object Helpers {
 
 import Helpers.arbitraryBatched
 
-class BatchedLaws extends CheckProperties with Matchers with PropertyChecks {
+class BatchedLaws extends CheckProperties {
 
   import BaseProperties._
   implicit val arbitraryBigDecimalsHere = BaseProperties.arbReasonableBigDecimals
@@ -32,7 +32,7 @@ class BatchedLaws extends CheckProperties with Matchers with PropertyChecks {
   def testBatchedMonoid[A: Arbitrary: Monoid](name: String, size: Int): Unit = {
     implicit val m: Monoid[Batched[A]] = Batched.compactingMonoid[A](size)
     property(s"CountMinSketch[$name] batched at $size is a Monoid") {
-      monoidLawsEq[Batched[A]](_.sum == _.sum)
+      monoidLawsEquiv[Batched[A]]
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
@@ -31,15 +31,16 @@ class CollectionSpecification extends CheckProperties {
   }
 
   property("Option Group laws") {
-    groupLaws[Option[Int]] && groupLawsEq[Map[String, Option[Int]]]{
-      (a: Map[String, Option[Int]], b: Map[String, Option[Int]]) =>
-        val keys: Set[String] = a.keySet | b.keySet
-        keys.forall { key: String =>
-          val v1: Int = a.getOrElse(key, None).getOrElse(0)
-          val v2: Int = b.getOrElse(key, None).getOrElse(0)
-          v1 == v2
+    implicit val equiv: Equiv[Map[String, Option[Int]]] =
+        Equiv.fromFunction { (a, b) =>
+          val keys: Set[String] = a.keySet | b.keySet
+          keys.forall { key: String =>
+            val v1: Int = a.getOrElse(key, None).getOrElse(0)
+            val v2: Int = b.getOrElse(key, None).getOrElse(0)
+            v1 == v2
+          }
         }
-    }
+    groupLaws[Option[Int]] && groupLawsEquiv[Map[String, Option[Int]]]
   }
 
   property("List plus") {
@@ -68,9 +69,8 @@ class CollectionSpecification extends CheckProperties {
   }
 
   property("Array Monoid laws") {
-    monoidLawsEq[Array[Int]]{
-      case (a, b) => a.deep == b.deep
-    }
+    implicit val equiv: Equiv[Array[Int]] = Equiv.by(_.deep)
+    monoidLawsEquiv[Array[Int]]
   }
 
   property("Set plus") {
@@ -181,9 +181,9 @@ class CollectionSpecification extends CheckProperties {
   }
 
   // TODO: this test fails sometimes due to the equiv not doing the right thing.
-  // Fix by defining and Equiv and having all the properties use an implicit Equiv
+  // Fix by defining an Equiv.
   property("IndexedSeq is a pseudoRing") {
-    pseudoRingLaws[IndexedSeq[Int]]
+    pseudoRingLawsEquiv[IndexedSeq[Int]]
   }
 
   property("Either is a Monoid") {

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -10,7 +10,7 @@ import CmsTestImplicits._
 import scala.util.Random
 import CMSHasherImplicits.CMSHasherBigInt
 
-class CmsLaws extends PropSpec with PropertyChecks with Matchers {
+class CmsLaws extends CheckProperties {
 
   import BaseProperties._
 
@@ -36,48 +36,47 @@ class CmsLaws extends PropSpec with PropertyChecks with Matchers {
   property("CountMinSketch[Short] is a Monoid") {
     implicit val cmsMonoid = CMS.monoid[Short](EPS, DELTA, SEED)
     implicit val cmsGen = createArbitrary[Short](cmsMonoid)
-    check(monoidLawsEquiv[CMS[Short]])
+    commutativeMonoidLawsEquiv[CMS[Short]]
   }
 
   property("CountMinSketch[Int] is a Monoid") {
     implicit val cmsMonoid = CMS.monoid[Int](EPS, DELTA, SEED)
     implicit val cmsGen = createArbitrary[Int](cmsMonoid)
-    check(monoidLawsEquiv[CMS[Int]])
+    commutativeMonoidLawsEquiv[CMS[Int]]
   }
 
   property("CountMinSketch[Long] is a Monoid") {
     implicit val cmsMonoid = CMS.monoid[Long](EPS, DELTA, SEED)
     implicit val cmsGen = createArbitrary[Long](cmsMonoid)
-    check(monoidLawsEquiv[CMS[Long]])
+    commutativeMonoidLawsEquiv[CMS[Long]]
   }
 
   property("CountMinSketch[BigInt] is a Monoid") {
     implicit val cmsMonoid = CMS.monoid[BigInt](EPS, DELTA, SEED)
     implicit val cmsGen = createArbitrary[BigInt](cmsMonoid)
-    check(monoidLawsEquiv[CMS[BigInt]])
+    commutativeMonoidLawsEquiv[CMS[BigInt]]
   }
 
   property("CountMinSketch[BigDecimal] is a Monoid") {
     implicit val cmsMonoid = CMS.monoid[BigDecimal](EPS, DELTA, SEED)
     implicit val cmsGen = createArbitrary[BigDecimal](cmsMonoid)
-    check(monoidLawsEquiv[CMS[BigDecimal]])
+    commutativeMonoidLawsEquiv[CMS[BigDecimal]]
   }
 
   property("CountMinSketch[String] is a Monoid") {
     implicit val cmsMonoid = CMS.monoid[String](EPS, DELTA, SEED)
     implicit val cmsGen = createArbitrary[String](cmsMonoid)
-    check(monoidLawsEquiv[CMS[String]])
+    commutativeMonoidLawsEquiv[CMS[String]]
   }
 
-  property("CountMinSketch[Bytes] is a Monoid") {
+  property("CountMinSketch[Bytes] is a commutative monoid") {
     implicit val cmsMonoid = CMS.monoid[Bytes](EPS, DELTA, SEED)
     implicit val cmsGen = createArbitrary[Bytes](cmsMonoid)
-    check(monoidLawsEquiv[CMS[Bytes]])
+    commutativeMonoidLawsEquiv[CMS[Bytes]]
   }
-
 }
 
-class TopPctCmsLaws extends PropSpec with PropertyChecks with Matchers {
+class TopPctCmsLaws extends CheckProperties {
 
   import BaseProperties._
 
@@ -85,6 +84,11 @@ class TopPctCmsLaws extends PropSpec with PropertyChecks with Matchers {
   val EPS = 0.005
   val SEED = 1
   val HEAVY_HITTERS_PCT = 0.1
+
+  implicit def topCmsEquiv[K]: Equiv[TopCMS[K]] =
+    new Equiv[TopCMS[K]] {
+      def equiv(x: TopCMS[K], y: TopCMS[K]): Boolean = (x ++ x) == (x ++ y)
+    }
 
   private def createArbitrary[K: FromIntLike](cmsMonoid: TopPctCMSMonoid[K]): Arbitrary[TopCMS[K]] = {
     val k = implicitly[FromIntLike[K]]
@@ -96,45 +100,44 @@ class TopPctCmsLaws extends PropSpec with PropertyChecks with Matchers {
   property("TopPctCms[Short] is a Monoid") {
     implicit val cmsMonoid = TopPctCMS.monoid[Short](EPS, DELTA, SEED, HEAVY_HITTERS_PCT)
     implicit val cmsGen = createArbitrary[Short](cmsMonoid)
-    monoidLaws[TopCMS[Short]]
+    commutativeMonoidLawsEquiv[TopCMS[Short]]
   }
 
   property("TopPctCms[Int] is a Monoid") {
     implicit val cmsMonoid = TopPctCMS.monoid[Int](EPS, DELTA, SEED, HEAVY_HITTERS_PCT)
     implicit val cmsGen = createArbitrary[Int](cmsMonoid)
-    monoidLaws[TopCMS[Int]]
+    commutativeMonoidLawsEquiv[TopCMS[Int]]
   }
 
   property("TopPctCms[Long] is a Monoid") {
     implicit val cmsMonoid = TopPctCMS.monoid[Long](EPS, DELTA, SEED, HEAVY_HITTERS_PCT)
     implicit val cmsGen = createArbitrary[Long](cmsMonoid)
-    monoidLaws[TopCMS[Long]]
+    commutativeMonoidLawsEquiv[TopCMS[Long]]
   }
 
   property("TopPctCms[BigInt] is a Monoid") {
     implicit val cmsMonoid = TopPctCMS.monoid[BigInt](EPS, DELTA, SEED, HEAVY_HITTERS_PCT)
     implicit val cmsGen = createArbitrary[BigInt](cmsMonoid)
-    monoidLaws[TopCMS[BigInt]]
+    commutativeMonoidLawsEquiv[TopCMS[BigInt]]
   }
 
   property("TopPctCms[BigDecimal] is a Monoid") {
     implicit val cmsMonoid = TopPctCMS.monoid[BigDecimal](EPS, DELTA, SEED, HEAVY_HITTERS_PCT)
     implicit val cmsGen = createArbitrary[BigDecimal](cmsMonoid)
-    monoidLaws[TopCMS[BigDecimal]]
+    commutativeMonoidLawsEquiv[TopCMS[BigDecimal]]
   }
 
   property("TopPctCms[String] is a Monoid") {
     implicit val cmsMonoid = TopPctCMS.monoid[String](EPS, DELTA, SEED, HEAVY_HITTERS_PCT)
     implicit val cmsGen = createArbitrary[String](cmsMonoid)
-    monoidLaws[TopCMS[String]]
+    commutativeMonoidLawsEquiv[TopCMS[String]]
   }
 
   property("TopPctCms[Bytes] is a Monoid") {
     implicit val cmsMonoid = TopPctCMS.monoid[Bytes](EPS, DELTA, SEED, HEAVY_HITTERS_PCT)
     implicit val cmsGen = createArbitrary[Bytes](cmsMonoid)
-    monoidLaws[TopCMS[Bytes]]
+    commutativeMonoidLawsEquiv[TopCMS[Bytes]]
   }
-
 }
 
 class SparseCMSTest extends WordSpec with Matchers with GeneratorDrivenPropertyChecks {

--- a/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CountMinSketchTest.scala
@@ -87,7 +87,8 @@ class TopPctCmsLaws extends CheckProperties {
 
   implicit def topCmsEquiv[K]: Equiv[TopCMS[K]] =
     new Equiv[TopCMS[K]] {
-      def equiv(x: TopCMS[K], y: TopCMS[K]): Boolean = (x ++ x) == (x ++ y)
+      def equiv(x: TopCMS[K], y: TopCMS[K]): Boolean =
+        (x ++ x) == (x ++ y)
     }
 
   private def createArbitrary[K: FromIntLike](cmsMonoid: TopPctCMSMonoid[K]): Arbitrary[TopCMS[K]] = {

--- a/algebird-test/src/test/scala/com/twitter/algebird/DecayedValueLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/DecayedValueLaws.scala
@@ -16,9 +16,11 @@ class DecayedValueLaws extends CheckProperties {
   }
 
   property("DecayedValue Monoid laws") {
-    commutativeMonoidLawsEq[DecayedValue] { (dvl, dvr) =>
-      approxEq(dvl.value, dvr.value) && (dvl.scaledTime == dvr.scaledTime)
-    }
+    implicit val equiv: Equiv[DecayedValue] =
+      Equiv.fromFunction { (dvl, dvr) =>
+        approxEq(dvl.value, dvr.value) && (dvl.scaledTime == dvr.scaledTime)
+      }
+    commutativeMonoidLawsEquiv[DecayedValue]
   }
 
   def averageApproxEq(fn: (DecayedValue, Params) => Double)(implicit p: Arbitrary[Params]) = {

--- a/algebird-test/src/test/scala/com/twitter/algebird/DecayedVectorProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/DecayedVectorProperties.scala
@@ -45,6 +45,7 @@ class DecayedVectorProperties extends CheckProperties {
   }
 
   property("DecayedVector[Map[Int, _]] is a monoid") {
-    monoidLawsEq[DecayedVector[({ type x[a] = Map[Int, a] })#x]](decayedMapEqFn)
+    implicit val equiv = Equiv.fromFunction(decayedMapEqFn)
+    monoidLawsEquiv[DecayedVector[({ type x[a] = Map[Int, a] })#x]]
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/FunctionMonoidTests.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/FunctionMonoidTests.scala
@@ -1,36 +1,27 @@
 package com.twitter.algebird
 
+import com.twitter.algebird.BaseProperties._
 import org.scalacheck.{ Arbitrary, Prop }
 
 class FunctionMonoidTests extends CheckProperties {
-  import com.twitter.algebird.BaseProperties._
-
-  // Generates an arbitrary linear function of the form f(x) = a * x + b,
-  // where a and b are arbitrary integers.
-  // TODO: add more types of functions (e.g., polynomials of degree two).
-  implicit def arbLinearFunc1: Arbitrary[Function1[Int, Int]] = Arbitrary[Function[Int, Int]] {
-    for {
-      a <- Arbitrary.arbInt.arbitrary
-      b <- Arbitrary.arbInt.arbitrary
-    } yield ((x: Int) => a * x + b)
-  }
-
   property("Linear functions over the integers form a monoid under function composition") {
     // TODO: switch the scope of the quantification?
     Prop.forAll { (n: Int) =>
-      monoidLawsEq[Function1[Int, Int]] { (f1, f2) => f1(n) == f2(n) }
+      implicit val eq: Equiv[Function1[Int, Int]] =
+        Equiv.fromFunction { (f1, f2) => f1(n) == f2(n) }
+
+      monoidLawsEquiv[Function1[Int, Int]]
     }
   }
 
   implicit def arbAffine: Arbitrary[AffineFunction[Int]] = Arbitrary[AffineFunction[Int]] {
-    for (
-      a <- Arbitrary.arbInt.arbitrary;
+    for {
+      a <- Arbitrary.arbInt.arbitrary
       b <- Arbitrary.arbInt.arbitrary
-    ) yield AffineFunction(a, b)
+    } yield AffineFunction(a, b)
   }
 
   property("AffineFunctions are monoids") {
     monoidLaws[AffineFunction[Int]]
   }
-
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogSeriesTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogSeriesTest.scala
@@ -29,7 +29,7 @@ class HyperLogLogSeriesLaws extends CheckProperties {
     Arbitrary(arbitrary[List[Timestamp]].map(ts => absorb(monoid.zero, ts)))
 
   property("HyperLogLogSeries is a Monoid") {
-    monoidLawsEq[HLLSeries]{ _.toHLL == _.toHLL }
+    commutativeMonoidLawsEquiv[HLLSeries]
   }
 
   property("HyperLogLogSeries is commutative") {

--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -57,7 +57,7 @@ class HyperLogLogLaws extends CheckProperties {
     Arbitrary(Gen.choose(0L, 1000000L).map(v => hllMonoid.create(long2Bytes(v))))
 
   property("HyperLogLog is a Monoid") {
-    monoidLawsEq[HLL]{ _.toDenseHLL == _.toDenseHLL }
+    commutativeMonoidLawsEquiv[HLL]
   }
 
   property("bitsForError and error match") {

--- a/algebird-test/src/test/scala/com/twitter/algebird/MetricProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MetricProperties.scala
@@ -16,10 +16,11 @@ limitations under the License.
 
 package com.twitter.algebird
 
+import com.twitter.algebird.BaseProperties._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 
-class BaseMetricProperties extends CheckProperties with MetricProperties {
+class MetricLaws extends CheckProperties {
   property("double metric") {
     metricLaws[Double]
   }
@@ -75,31 +76,4 @@ class BaseMetricProperties extends CheckProperties with MetricProperties {
     implicit val eq: Equiv[Map[Int, Double]] = Equiv.fromFunction(mapEqFn)
     metricLaws[Map[Int, Double]]
   }
-}
-
-trait MetricProperties {
-  def isNonNegative[T: Metric: Arbitrary] = forAll { (a: T, b: T) =>
-    val m = Metric(a, b)
-    beGreaterThan(m, 0.0) || beCloseTo(m, 0.0)
-  }
-  def isEqualIffZero[T: Metric: Arbitrary: Equiv] =
-    forAll { (a: T, b: T) =>
-      if (Equiv[T].equiv(a, b)) beCloseTo(Metric(a, b), 0.0)
-      else !beCloseTo(Metric(a, b), 0.0)
-    }
-  def isSymmetric[T: Metric: Arbitrary] = forAll { (a: T, b: T) =>
-    beCloseTo(Metric(a, b), Metric(b, a))
-  }
-  def satisfiesTriangleInequality[T: Metric: Arbitrary] = forAll { (a: T, b: T, c: T) =>
-    val m1 = Metric(a, b) + Metric(b, c)
-    val m2 = Metric(a, c)
-    beGreaterThan(m1, m2) || beCloseTo(m1, m2)
-  }
-
-  def metricLaws[T: Metric: Arbitrary: Equiv] =
-    isNonNegative[T] && isEqualIffZero[T] && isSymmetric[T] && satisfiesTriangleInequality[T]
-
-  // TODO: these are copied elsewhere in the tests. Move them to a common place
-  def beCloseTo(a: Double, b: Double, eps: Double = 1e-10) = a == b || (math.abs(a - b) / math.abs(a)) < eps || (a.isInfinite && b.isInfinite)
-  def beGreaterThan(a: Double, b: Double, eps: Double = 1e-10) = a > b - eps || (a.isInfinite && b.isInfinite)
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/MetricProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MetricProperties.scala
@@ -21,29 +21,29 @@ import org.scalacheck.Prop._
 
 class BaseMetricProperties extends CheckProperties with MetricProperties {
   property("double metric") {
-    metricLaws[Double](defaultEqFn)
+    metricLaws[Double]
   }
 
   property("int metric") {
-    metricLaws[Int](defaultEqFn)
+    metricLaws[Int]
   }
 
   property("float metric") {
-    metricLaws[Float](defaultEqFn)
+    metricLaws[Float]
   }
 
   property("long metric") {
-    metricLaws[Long](defaultEqFn)
+    metricLaws[Long]
   }
 
   property("short metric") {
-    metricLaws[Short](defaultEqFn)
+    metricLaws[Short]
   }
 
   implicit val iterMetric = Metric.L1Iterable[Double]
 
   // TODO: we won't need this when we have an Equatable trait
-  def listEqfn(a: List[Double], b: List[Double]) = {
+  def listEqFn(a: List[Double], b: List[Double]) = {
     val maxSize = scala.math.max(a.size, b.size)
     val diffA = maxSize - a.size
     val diffB = maxSize - b.size
@@ -53,7 +53,8 @@ class BaseMetricProperties extends CheckProperties with MetricProperties {
   }
 
   property("double iterable metric") {
-    metricLaws[List[Double]](listEqfn)
+    implicit val eq: Equiv[List[Double]] = Equiv.fromFunction(listEqFn)
+    metricLaws[List[Double]]
   }
 
   implicit val mapMetric = Metric.L1Map[Int, Double]
@@ -71,9 +72,9 @@ class BaseMetricProperties extends CheckProperties with MetricProperties {
   }
 
   property("int double map metric") {
-    metricLaws[Map[Int, Double]](mapEqFn)
+    implicit val eq: Equiv[Map[Int, Double]] = Equiv.fromFunction(mapEqFn)
+    metricLaws[Map[Int, Double]]
   }
-
 }
 
 trait MetricProperties {
@@ -81,9 +82,11 @@ trait MetricProperties {
     val m = Metric(a, b)
     beGreaterThan(m, 0.0) || beCloseTo(m, 0.0)
   }
-  def isEqualIffZero[T: Metric: Arbitrary](eqfn: (T, T) => Boolean) = forAll { (a: T, b: T) =>
-    if (eqfn(a, b)) beCloseTo(Metric(a, b), 0.0) else !beCloseTo(Metric(a, b), 0.0)
-  }
+  def isEqualIffZero[T: Metric: Arbitrary: Equiv] =
+    forAll { (a: T, b: T) =>
+      if (Equiv[T].equiv(a, b)) beCloseTo(Metric(a, b), 0.0)
+      else !beCloseTo(Metric(a, b), 0.0)
+    }
   def isSymmetric[T: Metric: Arbitrary] = forAll { (a: T, b: T) =>
     beCloseTo(Metric(a, b), Metric(b, a))
   }
@@ -93,11 +96,10 @@ trait MetricProperties {
     beGreaterThan(m1, m2) || beCloseTo(m1, m2)
   }
 
-  def metricLaws[T: Metric: Arbitrary](eqfn: (T, T) => Boolean) =
-    isNonNegative[T] && isEqualIffZero[T](eqfn) && isSymmetric[T] && satisfiesTriangleInequality[T]
+  def metricLaws[T: Metric: Arbitrary: Equiv] =
+    isNonNegative[T] && isEqualIffZero[T] && isSymmetric[T] && satisfiesTriangleInequality[T]
 
   // TODO: these are copied elsewhere in the tests. Move them to a common place
   def beCloseTo(a: Double, b: Double, eps: Double = 1e-10) = a == b || (math.abs(a - b) / math.abs(a)) < eps || (a.isInfinite && b.isInfinite)
   def beGreaterThan(a: Double, b: Double, eps: Double = 1e-10) = a > b - eps || (a.isInfinite && b.isInfinite)
-  def defaultEqFn[T](a: T, b: T): Boolean = a == b
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
@@ -1,11 +1,11 @@
 package com.twitter.algebird
 
+import com.twitter.algebird.BaseProperties._
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalatest.{ Matchers, _ }
+import scala.math.Equiv
 
 class MinHasherTest extends CheckProperties {
-  import com.twitter.algebird.BaseProperties._
-
   implicit val mhMonoid = new MinHasher32(0.5, 512)
   implicit val mhGen = Arbitrary {
     for (
@@ -13,8 +13,9 @@ class MinHasherTest extends CheckProperties {
     ) yield (mhMonoid.init(v))
   }
 
-  property("MinHasher is a Monoid") {
-    monoidLawsEq[MinHashSignature]{ (a, b) => a.bytes.toList == b.bytes.toList }
+  property("MinHasher is a commutative monoid") {
+    implicit val equiv: Equiv[MinHashSignature] = Equiv.by(_.bytes.toList)
+    commutativeMonoidLawsEquiv[MinHashSignature]
   }
 }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/MomentsLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MomentsLaws.scala
@@ -8,13 +8,15 @@ class MomentsLaws extends CheckProperties {
   val EPS = 1e-10
 
   property("Moments Group laws") {
-    groupLawsEq[Moments] { (ml, mr) =>
-      (ml.m0 == mr.m0) &&
-        approxEq(EPS)(ml.m1, mr.m1) &&
-        approxEq(EPS)(ml.m2, mr.m2) &&
-        approxEq(EPS)(ml.m3, mr.m3) &&
-        approxEq(EPS)(ml.m4, mr.m4)
-    }
+    implicit val equiv: Equiv[Moments] =
+      Equiv.fromFunction { (ml, mr) =>
+        (ml.m0 == mr.m0) &&
+          approxEq(EPS)(ml.m1, mr.m1) &&
+          approxEq(EPS)(ml.m2, mr.m2) &&
+          approxEq(EPS)(ml.m3, mr.m3) &&
+          approxEq(EPS)(ml.m4, mr.m4)
+      }
+    groupLawsEquiv[Moments]
   }
 }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/SketchMapTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SketchMapTest.scala
@@ -22,6 +22,14 @@ class SketchMapLaws extends CheckProperties {
     for (key: Int <- Gen.choose(0, 10000)) yield (smMonoid.create((key, 1L)))
   }
 
+  // TODO: SketchMap's heavy hitters are not strictly associative
+  // (approximately they are)
+  implicit def equiv[K, V]: Equiv[SketchMap[K, V]] =
+    Equiv.fromFunction { (left, right) =>
+      (left.valuesTable == right.valuesTable) &&
+        (left.totalValue == right.totalValue)
+    }
+
   property("SketchMap is a commutative monoid") {
     commutativeMonoidLawsEquiv[SketchMap[Int, Long]]
   }

--- a/algebird-test/src/test/scala/com/twitter/algebird/SketchMapTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SketchMapTest.scala
@@ -22,12 +22,8 @@ class SketchMapLaws extends CheckProperties {
     for (key: Int <- Gen.choose(0, 10000)) yield (smMonoid.create((key, 1L)))
   }
 
-  // TODO: SketchMap's heavy hitters are not strictly associative (approximately they are)
-  property("SketchMap is a Monoid") {
-    commutativeMonoidLawsEq[SketchMap[Int, Long]] { (left, right) =>
-      (left.valuesTable == right.valuesTable) &&
-        (left.totalValue == right.totalValue)
-    }
+  property("SketchMap is a commutative monoid") {
+    commutativeMonoidLawsEquiv[SketchMap[Int, Long]]
   }
 }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/SpaceSaverTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SpaceSaverTest.scala
@@ -22,7 +22,7 @@ class SpaceSaverLaws extends CheckProperties {
             Gen.nonEmptyContainerOf[List, SSOne[Int]](Arbitrary.arbitrary[SSOne[Int]]).map(_.reduce(sg.plus)))
         }
 
-        commutativeSemigroupLawsEq[SpaceSaver[Int]] { (left, right) => (left consistentWith right) && (right consistentWith left) }
+        commutativeSemigroupLawsEquiv[SpaceSaver[Int]]
       }
     }
   }

--- a/algebird-test/src/test/scala/com/twitter/algebird/SpaceSaverTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SpaceSaverTest.scala
@@ -22,6 +22,10 @@ class SpaceSaverLaws extends CheckProperties {
             Gen.nonEmptyContainerOf[List, SSOne[Int]](Arbitrary.arbitrary[SSOne[Int]]).map(_.reduce(sg.plus)))
         }
 
+        implicit def equiv[T]: Equiv[SpaceSaver[T]] =
+          Equiv.fromFunction { (left, right) =>
+            (left consistentWith right) && (right consistentWith left)
+          }
         commutativeSemigroupLawsEquiv[SpaceSaver[Int]]
       }
     }

--- a/algebird-test/src/test/scala/com/twitter/algebird/TopKTests.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/TopKTests.scala
@@ -33,11 +33,9 @@ class TopKTests extends CheckProperties {
     implicitly[Arbitrary[List[Int]]].arbitrary.map { qmonoid.build(_) }
   }
 
-  def q2l(q1: PriorityQueue[Int]): List[Int] = q1.iterator.asScala.toList.sorted
+  def q2l(q: PriorityQueue[Int]): List[Int] = q.iterator.asScala.toList.sorted
 
-  def eqFn(q1: PriorityQueue[Int], q2: PriorityQueue[Int]): Boolean = {
-    q2l(q1) == q2l(q2)
-  }
+  implicit val eq: Equiv[PriorityQueue[Int]] = Equiv.by(q2l)
 
   def pqIsCorrect(items: List[List[Int]]): Boolean = {
     val correct = items.flatten.sorted.take(SIZE)
@@ -60,7 +58,7 @@ class TopKTests extends CheckProperties {
   }
 
   property("PriorityQueueMonoid is a Monoid") {
-    monoidLawsEq[PriorityQueue[Int]](eqFn)
+    monoidLawsEquiv[PriorityQueue[Int]]
   }
 
   implicit def tkmonoid = new TopKMonoid[Int](SIZE)
@@ -77,7 +75,7 @@ class TopKTests extends CheckProperties {
   }
 
   property("TopKMonoid is a Monoid") {
-    monoidLawsEq[PriorityQueue[Int]](eqFn)
+    monoidLawsEquiv[PriorityQueue[Int]]
   }
 
 }

--- a/algebird-util/src/main/scala/com/twitter/algebird/util/UtilAlgebras.scala
+++ b/algebird-util/src/main/scala/com/twitter/algebird/util/UtilAlgebras.scala
@@ -50,13 +50,25 @@ object UtilAlgebras {
 
   implicit def futureSemigroup[T: Semigroup]: Semigroup[Future[T]] = new ApplicativeSemigroup[T, Future]
   implicit def futureMonoid[T: Monoid]: Monoid[Future[T]] = new ApplicativeMonoid[T, Future]
-  implicit def futureGroup[T: Group]: Group[Future[T]] = new ApplicativeGroup[T, Future]
-  implicit def futureRing[T: Ring]: Ring[Future[T]] = new ApplicativeRing[T, Future]
-  implicit def futureField[T: Field]: Field[Future[T]] = new ApplicativeField[T, Future]
 
   implicit def trySemigroup[T: Semigroup]: Semigroup[Try[T]] = new ApplicativeSemigroup[T, Try]
   implicit def tryMonoid[T: Monoid]: Monoid[Try[T]] = new ApplicativeMonoid[T, Try]
+
+  @deprecated("futureGroup is broken and will be removed at the next minor version bump", since = "0.12.3")
+  implicit def futureGroup[T: Group]: Group[Future[T]] = new ApplicativeGroup[T, Future]
+
+  @deprecated("futureRing is broken and will be removed at the next minor version bump", since = "0.12.3")
+  implicit def futureRing[T: Ring]: Ring[Future[T]] = new ApplicativeRing[T, Future]
+
+  @deprecated("futureField is broken and will be removed at the next minor version bump", since = "0.12.3")
+  implicit def futureField[T: Field]: Field[Future[T]] = new ApplicativeField[T, Future]
+
+  @deprecated("tryGroup is broken and will be removed at the next minor version bump", since = "0.12.3")
   implicit def tryGroup[T: Group]: Group[Try[T]] = new ApplicativeGroup[T, Try]
+
+  @deprecated("tryRing is broken and will be removed at the next minor version bump", since = "0.12.3")
   implicit def tryRing[T: Ring]: Ring[Try[T]] = new ApplicativeRing[T, Try]
+
+  @deprecated("tryField is broken and will be removed at the next minor version bump", since = "0.12.3")
   implicit def tryField[T: Field]: Field[Try[T]] = new ApplicativeField[T, Try]
 }


### PR DESCRIPTION
This PR comes after #579. Closes #528. 

### Description
- Addresses #548 by deprecating the group/ring instances for future/try
- Adds actual tests for the monoid and semigroup instances for `Future` and `Try`
- updates the generators for `Future` and `Try` to include exceptional cases
- Adds an `Equiv` version to all remaining laws
- activates tests for `Batched` and `TopCMS`, which weren't running
- adds implicit `Equiv` instances for SpaceSaver and SketchMap
- tightens some tests to commutative
- moves `MetricProperties` into `src` so users can make use of `metricsLaws[T]`