### PR TITLE
Coverage and documentation for AveragedValue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 * Add `metricsLaws[T]` to `BaseProperties` in `algebird-test`: https://github.com/twitter/algebird/pull/584
 * Modify generated `Tuple2Monoid`, etc to extend `TupleNSemigroup`, giving subclasses access to efficient `sumOption`: https://github.com/twitter/algebird/pull/585
 * optimize `Generated{Abstract,Product}Algebra.sumOption` with benchmarking https://github.com/twitter/algebird/pull/591
+* Add an efficient `sumOption`, `+`, `-` and docs to `AveragedValue`: https://github.com/twitter/algebird/pull/589
 
 ### Version 0.12.2 ###
 

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/AveragedValueBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/AveragedValueBenchmark.scala
@@ -1,0 +1,36 @@
+package com.twitter.algebird
+package benchmark
+
+import scala.util.Random
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.math._
+
+object AveragedValueBenchmark {
+  @State(Scope.Benchmark)
+  class AVState {
+    @Param(Array("10000"))
+    var numElements: Int = 0
+
+    var inputData: Seq[AveragedValue] = _
+
+    @Setup(Level.Trial)
+    def setup(): Unit = {
+      inputData = Seq.fill(numElements)(AveragedValue(Random.nextInt(1000).toLong))
+    }
+  }
+}
+
+class AveragedValueBenchmark {
+  import AveragedValueBenchmark._
+  import AveragedGroup.{ plus, sumOption }
+
+  @Benchmark
+  def timePlus(state: AVState, bh: Blackhole) =
+    bh.consume(state.inputData.reduce(plus(_, _)))
+
+  @Benchmark
+  def timeSumOption(state: AVState, bh: Blackhole) =
+    bh.consume(sumOption(state.inputData))
+}

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/HLLBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/HLLBenchmark.scala
@@ -1,15 +1,15 @@
-package com.twitter.algebird.benchmark
+package com.twitter.algebird
+package benchmark
 
-import com.twitter.algebird._
 import scala.util.Random
 import com.twitter.bijection._
 
 import com.twitter.algebird.util._
-import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
 import scala.math._
+
 class OldMonoid(bits: Int) extends HyperLogLogMonoid(bits) {
   import HyperLogLog._
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala
@@ -17,42 +17,97 @@ limitations under the License.
 package com.twitter.algebird
 
 /**
- * AveragedValue tracks the count and mean, or average value, of a
- * data stream.
+ * Tracks the count and mean value of Doubles in a data stream.
  *
- * Adding two instances of AveragedValue with `+` is equivalent to
- * taking an average of the two streams, with each stream weighted by
- * its count.
+ * Adding two instances of [[AveragedValue]] with [[+]]
+ * is equivalent to taking an average of the two streams, with each
+ * stream weighted by its count.
  *
- * The mean calculation uses an online algorithm suitable for large
- * numbers of records, similar to:
- * http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
+ * The mean calculation uses a numerically stable online algorithm
+ * suitable for large numbers of records, similar to Chan et. al.'s
+ * [[http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
+ * parallel variance algorithm on Wikipedia]]. As long as your count
+ * doesn't overflow a Long, the mean calculation won't overflow.
  *
- * See [[MomentsGroup.getCombinedMean]] for the code.
- *
- * @param count the number of items aggregated into this instance
- * @param value the average value of all items aggregated into this instance
+ * @see [[MomentsGroup.getCombinedMean]] for implementation of [[+]]
+ * @param count the number of aggregated items
+ * @param value the average value of all aggregated items
  */
 case class AveragedValue(count: Long, value: Double) {
+  /**
+   * Returns a copy of this instance with a negative value. Note that
+   *
+   * {{{
+   * a + -b == a - b
+   * }}}
+   */
   def unary_- : AveragedValue = copy(count = -count)
+
+  /**
+   * Averages this instance with the *opposite* of the supplied
+   * [[AveragedValue]] instance, effectively subtracting out that
+   * instance's contribution to the mean.
+   *
+   * @param r the instance to subtract
+   * @return an instance with `r`'s stream subtracted out
+   */
   def -(r: AveragedValue): AveragedValue = AveragedGroup.minus(this, r)
+
+  /**
+   * Averages this instance with another [[AveragedValue]] instance.
+   * @param r the other instance
+   * @return an instance representing the mean of this instance and `r`.
+   */
   def +(r: AveragedValue): AveragedValue = AveragedGroup.plus(this, r)
 }
 
+/**
+ * Provides a set of operations needed to create and use
+ * [[AveragedValue]] instances.
+ */
 object AveragedValue {
-  // TODO: Change to Group[AveragedValue] in 0.13.0 (https://github.com/twitter/algebird/issues/587)
+  /** implicit instance of [[Group]][AveragedValue] */
   implicit val group = AveragedGroup
 
+  /**
+   * Returns an [[Aggregator]] that uses [[AveragedValue]] to
+   * calculate the mean of all `Double` values in the stream. Each
+   * Double value receives a count of 1 during aggregation.
+   */
   def aggregator: Aggregator[Double, AveragedValue, Double] = Averager
 
+  /**
+   * Returns an [[Aggregator]] that uses [[AveragedValue]] to
+   * calculate the mean of all values in the stream. Each numeric
+   * value receives a count of `1` during aggregation.
+   *
+   * @tparam N numeric type to convert into `Double`
+   */
   def numericAggregator[N](implicit num: Numeric[N]): MonoidAggregator[N, AveragedValue, Double] =
     Aggregator.prepareMonoid { n: N => AveragedValue(num.toDouble(n)) }
       .andThenPresent(_.value)
 
+  /**
+   * Creates [[AveragedValue]] with a value of `v` and a count of 1.
+   *
+   * @tparam V type with an implicit conversion to Double
+   */
   def apply[V <% Double](v: V): AveragedValue = apply(1L, v)
+
+  /**
+   * Creates an [[AveragedValue]] with a count of of `c` and a value
+   * of `v`.
+   *
+   * @tparam V type with an implicit conversion to Double
+   */
   def apply[V <% Double](c: Long, v: V): AveragedValue = new AveragedValue(c, v)
 }
 
+/**
+ * [[Group]] implementation for [[AveragedValue]].
+ *
+ * @define T `AveragedValue`
+ */
 object AveragedGroup extends Group[AveragedValue] {
   import MomentsGroup.getCombinedMean
 
@@ -62,6 +117,11 @@ object AveragedGroup extends Group[AveragedValue] {
 
   override def negate(av: AveragedValue) = -av
 
+  /**
+   * Optimized implementation of [[plus]]. Uses internal mutation to
+   * combine the supplied [[AveragedValue]] instances without creating
+   * intermediate objects.
+   */
   override def sumOption(iter: TraversableOnce[AveragedValue]): Option[AveragedValue] =
     if (iter.isEmpty) None
     else {
@@ -75,14 +135,23 @@ object AveragedGroup extends Group[AveragedValue] {
       Some(AveragedValue(count, average))
     }
 
-  def plus(left: AveragedValue, right: AveragedValue): AveragedValue = {
-    val n = left.count
-    val k = right.count
-    val newAve = getCombinedMean(n, left.value, k, right.value)
+  /**
+   * @inheritdoc
+   * @see [[AveragedValue.+]] for the implementation
+   */
+  def plus(l: AveragedValue, r: AveragedValue): AveragedValue = {
+    val n = l.count
+    val k = r.count
+    val newAve = getCombinedMean(n, l.value, k, r.value)
     AveragedValue(n + k, newAve)
   }
 }
 
+/**
+ * [[Aggregator]] that uses [[AveragedValue]] to calculate the mean
+ * of all `Double` values in the stream. Each Double value receives a
+ * count of 1 during aggregation.
+ */
 object Averager extends MonoidAggregator[Double, AveragedValue, Double] {
   val monoid = AveragedGroup
   def prepare(value: Double) = AveragedValue(value)

--- a/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala
@@ -59,6 +59,26 @@ case class AveragedValue(count: Long, value: Double) {
    * @return an instance representing the mean of this instance and `r`.
    */
   def +(r: AveragedValue): AveragedValue = AveragedGroup.plus(this, r)
+
+  /**
+   * Returns a new instance that averages `that` into this instance.
+   *
+   * @param that value to average into this instance
+   * @return an instance representing the mean of this instance and `that`.
+   */
+  def +(that: Double): AveragedValue =
+    AveragedValue(
+      count + 1L,
+      MomentsGroup.getCombinedMean(count, value, 1L, that))
+
+  /**
+   * Returns a new instance that averages `that` into this instance.
+   *
+   * @param that value to average into this instance
+   * @return an instance representing the mean of this instance and `that`.
+   */
+  def +[N](that: N)(implicit num: Numeric[N]): AveragedValue =
+    this + num.toDouble(that)
 }
 
 /**

--- a/algebird-core/src/main/scala/com/twitter/algebird/First.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/First.scala
@@ -16,32 +16,63 @@ limitations under the License.
 package com.twitter.algebird
 
 /**
- * First tracks the "most recent" item by the order in which items
- * are seen.
+ * Tracks the "least recent", or earliest, wrapped instance of `T` by
+ * the order in which items are seen.
+ *
+ * @param get wrapped instance of `T`
  */
 case class First[@specialized(Int, Long, Float, Double) +T](get: T) {
+  /**
+   * Returns this instance, always.
+   *
+   * @param r ignored instance of `First[U]`
+   */
   def +[U >: T](r: First[U]): First[U] = this
 }
 
+/**
+ * Provides a set of operations and typeclass instances needed to use
+ * [[First]] instances.
+ */
 object First extends FirstInstances {
+  /**
+   * Returns an [[Aggregator]] that selects the first instance of `T`
+   * in the aggregated stream.
+   */
   def aggregator[T]: FirstAggregator[T] = FirstAggregator()
 }
 
 private[algebird] sealed abstract class FirstInstances {
-  def firstSemigroup[T] = new Semigroup[T] {
-    def plus(l: T, r: T): T = l
+  /**
+   * Returns a [[Semigroup]] instance with a `plus` implementation
+   * that always returns the first (ie, the left) `T` argument.
+   *
+   * This semigroup's `sumOption` is efficient; it only selects the
+   * head of the `TraversableOnce` instance, leaving the rest
+   * untouched.
+   */
+  def firstSemigroup[T]: Semigroup[T] =
+    new Semigroup[T] {
+      def plus(l: T, r: T): T = l
 
-    override def sumOption(iter: TraversableOnce[T]): Option[T] =
-      if (iter.isEmpty) None else Some(iter.toIterator.next)
-  }
+      override def sumOption(iter: TraversableOnce[T]): Option[T] =
+        if (iter.isEmpty) None else Some(iter.toIterator.next)
+    }
 
+  /**
+   * Returns a [[Semigroup]] instance for [[First]][T]. The `plus`
+   * implementation always returns the first (ie, the left) `First[T]`
+   * argument.
+   */
   implicit def semigroup[T]: Semigroup[First[T]] = firstSemigroup[First[T]]
 }
 
+/**
+ * [[Aggregator]] that selects the first instance of `T` in the
+ * aggregated stream.
+ */
 case class FirstAggregator[T]() extends Aggregator[T, T, T] {
   def prepare(v: T) = v
-
   val semigroup: Semigroup[T] = First.firstSemigroup[T]
-
   def present(v: T) = v
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/Max.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Max.scala
@@ -17,47 +17,101 @@ package com.twitter.algebird
 
 import scala.annotation.tailrec
 
-// To use the MaxSemigroup wrap your item in Max
+/**
+ * Tracks the maximum wrapped instance of some ordered type `T`.
+ *
+ * [[Max]][T] is a [[Semigroup]] for all types `T`. If `T` has some
+ * minimum element (`Long` has `Long.MinValue`, for example), then
+ * [[Max]][T] is a [[Monoid]].
+ *
+ * @param get wrapped instance of `T`
+ */
 case class Max[@specialized(Int, Long, Float, Double) +T](get: T) {
+  /**
+   * If this instance wraps a larger `T` than `r`, returns this
+   * instance, else returns `r`.
+   *
+   * @param r instance of `Max[U]` for comparison
+   */
   def max[U >: T](r: Max[U])(implicit ord: Ordering[U]): Max[U] =
     Max.ordering.max(this, r)
+
+  /**
+   * Identical to [[max]].
+   *
+   * @param r instance of `Max[U]` for comparison
+   */
   def +[U >: T](r: Max[U])(implicit ord: Ordering[U]): Max[U] = max(r)
 }
 
+/**
+ * Provides a set of operations and typeclass instances needed to use
+ * [[Max]] instances.
+ */
 object Max extends MaxInstances {
+  /**
+   * Returns an [[Aggregator]] that selects the maximum instance of an
+   * ordered type `T` in the aggregated stream.
+   */
   def aggregator[T](implicit ord: Ordering[T]): MaxAggregator[T] = MaxAggregator()(ord)
 
-  // TODO: Note that this is a semilattice, for when we merge
-  // typelevel/algebra.
+  /**
+   * Returns a [[Semigroup]] instance with a `plus` implementation
+   * that always returns the maximum `T` argument.
+   *
+   * @todo Note that this is a semilattice, for when we merge  typelevel/algebra.
+   */
   def maxSemigroup[T](implicit ord: Ordering[T]): Semigroup[T] =
     Semigroup.from { (l: T, r: T) => ord.max(l, r) }
 }
 
 private[algebird] sealed abstract class MaxInstances {
   implicit def equiv[T](implicit eq: Equiv[T]): Equiv[Max[T]] = Equiv.by(_.get)
+  implicit def ordering[T: Ordering]: Ordering[Max[T]] = Ordering.by(_.get)
 
   private[this] def plus[T](implicit ord: Ordering[T]) = {
     (l: Max[T], r: Max[T]) => if (ord.gteq(l.get, r.get)) l else r
   }
 
-  // Zero should have the property that it <= all T
+  /**
+   * Returns a [[Monoid]] instance for [[Max]][T] that combines
+   * instances using [[Max.max]] and uses `zero` for its identity.
+   *
+   * @param zero identity of the returned [[Monoid]] instance
+   * @note `zero` must be `<=` every element of `T` for the returned instance to be lawful.
+   */
   def monoid[T: Ordering](zero: => T): Monoid[Max[T]] = Monoid.from(Max(zero))(plus)
 
-  // There's no need to override `sumOption`, since the default
-  // implementation does no allocation other than the outer `Option`
-  // and `plus` doesn't do any allocation.
-  implicit def semigroup[T: Ordering]: Semigroup[Max[T]] = Semigroup.from(plus)
+  /**
+   * Returns a [[Semigroup]] instance for [[Max]][T]. The `plus`
+   * implementation always returns the maximum `Max[T]` argument.
+   */
+  implicit def semigroup[T: Ordering]: Semigroup[Max[T]] =
+    // There's no need to override `sumOption`, since the default
+    // implementation does no allocation other than the outer `Option`
+    // and `plus` doesn't do any allocation.
+    Semigroup.from(plus)
 
-  implicit def ordering[T: Ordering]: Ordering[Max[T]] = Ordering.by(_.get)
-
+  /** [[Monoid]] for [[Max]][Int] with `zero == Int.MinValue` */
   implicit def intMonoid: Monoid[Max[Int]] = monoid(Int.MinValue)
+
+  /** [[Monoid]] for [[Max]][Long] with `zero == Long.MinValue` */
   implicit def longMonoid: Monoid[Max[Long]] = monoid(Long.MinValue)
+
+  /** [[Monoid]] for [[Max]][Double] with `zero == Double.MinValue` */
   implicit def doubleMonoid: Monoid[Max[Double]] = monoid(Double.MinValue)
+
+  /** [[Monoid]] for [[Max]][Float] with `zero == Float.MinValue` */
   implicit def floatMonoid: Monoid[Max[Float]] = monoid(Float.MinValue)
 
-  // These have a lower bound, but not an upperbound, so the Max forms a monoid:
+  /** [[Monoid]] for [[Max]][String] with `zero == ""` */
   implicit def stringMonoid: Monoid[Max[String]] = monoid("")
 
+  /**
+   * Returns a [[Monoid]] instance for `Max[List[T]]` that compares
+   * lists first by length and then element-wise by `T`, and returns
+   * the maximum value.
+   */
   implicit def listMonoid[T: Ordering]: Monoid[Max[List[T]]] = monoid[List[T]](Nil)(
     new Ordering[List[T]] {
       @tailrec
@@ -76,7 +130,7 @@ private[algebird] sealed abstract class MaxInstances {
   // TODO: Replace with
   // cast.kernel.instances.StaticMethods.iteratorCompare when we
   // merge with cats.
-  def iteratorCompare[T](xs: Iterator[T], ys: Iterator[T])(implicit ord: Ordering[T]): Int = {
+  private def iteratorCompare[T](xs: Iterator[T], ys: Iterator[T])(implicit ord: Ordering[T]): Int = {
     while (true) {
       if (xs.hasNext) {
         if (ys.hasNext) {
@@ -94,6 +148,11 @@ private[algebird] sealed abstract class MaxInstances {
     0
   }
 
+  /**
+   * Returns a [[Monoid]] instance for `Max[Vector[T]]` that compares
+   * lists first by length and then element-wise by `T`, and returns
+   * the maximum value.
+   */
   implicit def vectorMonoid[T: Ordering]: Monoid[Max[Vector[T]]] =
     monoid[Vector[T]](Vector.empty[T])(
       new Ordering[Vector[T]] {
@@ -103,6 +162,11 @@ private[algebird] sealed abstract class MaxInstances {
         }
       })
 
+  /**
+   * Returns a [[Monoid]] instance for `Max[Stream[T]]` that compares
+   * lists first by length and then element-wise by `T`, and returns
+   * the maximum value.
+   */
   implicit def streamMonoid[T: Ordering]: Monoid[Max[Stream[T]]] =
     monoid[Stream[T]](Stream.empty[T])(
       new Ordering[Stream[T]] {
@@ -113,6 +177,10 @@ private[algebird] sealed abstract class MaxInstances {
       })
 }
 
+/**
+ * [[Aggregator]] that selects the maximum instance of `T` in the
+ * aggregated stream.
+ */
 case class MaxAggregator[T](implicit ord: Ordering[T]) extends Aggregator[T, T, T] {
   def prepare(v: T) = v
   val semigroup = Max.maxSemigroup[T]

--- a/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
@@ -15,39 +15,92 @@ limitations under the License.
 */
 package com.twitter.algebird
 
-// To use the MinSemigroup wrap your item in a Min object
+/**
+ * Tracks the minimum wrapped instance of some ordered type `T`.
+ *
+ * [[Min]][T] is a [[Semigroup]] for all types `T`. If `T` has some
+ * maximum element (`Long` has `Long.MaxValue`, for example), then
+ * [[Min]][T] is a [[Monoid]].
+ *
+ * @param get wrapped instance of `T`
+ */
 case class Min[@specialized(Int, Long, Float, Double) +T](get: T) {
+  /**
+   * If this instance wraps a smaller `T` than `r`, returns this
+   * instance, else returns `r`.
+   *
+   * @param r instance of `Min[U]` for comparison
+   */
   def min[U >: T](r: Min[U])(implicit ord: Ordering[U]): Min[U] =
     Min.ordering.min(this, r)
+
+  /**
+   * Identical to [[min]].
+   *
+   * @param r instance of `Min[U]` for comparison
+   */
   def +[U >: T](r: Min[U])(implicit ord: Ordering[U]): Min[U] = min(r)
 }
 
+/**
+ * Provides a set of operations and typeclass instances needed to use
+ * [[Min]] instances.
+ */
 object Min extends MinInstances {
+  /**
+   * Returns an [[Aggregator]] that selects the minimum instance of an
+   * ordered type `T` in the aggregated stream.
+   */
   def aggregator[T](implicit ord: Ordering[T]): MinAggregator[T] = MinAggregator()(ord)
+
+  /**
+   * Returns a [[Semigroup]] instance with a `plus` implementation
+   * that always returns the minimum `T` argument.
+   */
   def minSemigroup[T](implicit ord: Ordering[T]): Semigroup[T] =
     Semigroup.from { (l: T, r: T) => ord.min(l, r) }
 }
 
 private[algebird] sealed abstract class MinInstances {
   implicit def equiv[T](implicit eq: Equiv[T]): Equiv[Min[T]] = Equiv.by(_.get)
+  implicit def ordering[T: Ordering]: Ordering[Min[T]] = Ordering.by(_.get)
 
   private[this] def plus[T](implicit ord: Ordering[T]) = {
     (l: Min[T], r: Min[T]) => if (ord.lteq(l.get, r.get)) l else r
   }
 
-  // Zero should have the property that it >= all T
+  /**
+   * Returns a [[Monoid]] instance for [[Min]][T] that combines
+   * instances using [[Min.min]] and uses `zero` for its identity.
+   *
+   * @param zero identity of the returned [[Monoid]] instance
+   * @note `zero` must be `>=` every element of `T` for the returned instance to be lawful.
+   */
   def monoid[T: Ordering](zero: => T): Monoid[Min[T]] = Monoid.from(Min(zero))(plus)
 
+  /**
+   * Returns a [[Semigroup]] instance for [[Min]][T]. The `plus`
+   * implementation always returns the minimum `Min[T]` argument.
+   */
   implicit def semigroup[T: Ordering]: Semigroup[Min[T]] = Semigroup.from(plus)
 
-  implicit def ordering[T: Ordering]: Ordering[Min[T]] = Ordering.by(_.get)
-
+  /** [[Monoid]] for [[Min]][Int] with `zero == Int.MaxValue` */
   implicit def intMonoid: Monoid[Min[Int]] = monoid(Int.MaxValue)
+
+  /** [[Monoid]] for [[Min]][Long] with `zero == Long.MaxValue` */
   implicit def longMonoid: Monoid[Min[Long]] = monoid(Long.MaxValue)
+
+  /** [[Monoid]] for [[Min]][Double] with `zero == Double.MaxValue` */
   implicit def doubleMonoid: Monoid[Min[Double]] = monoid(Double.MaxValue)
+
+  /** [[Monoid]] for [[Min]][Float] with `zero == Float.MaxValue` */
   implicit def floatMonoid: Monoid[Min[Float]] = monoid(Float.MaxValue)
 }
 
+/**
+ * [[Aggregator]] that selects the minimum instance of `T` in the
+ * aggregated stream.
+ */
 case class MinAggregator[T](implicit ord: Ordering[T]) extends Aggregator[T, T, T] {
   def prepare(v: T) = v
   val semigroup = Min.minSemigroup[T]

--- a/algebird-core/src/main/scala/com/twitter/algebird/Monoid.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Monoid.scala
@@ -29,9 +29,9 @@ import scala.collection.{ Map => ScMap }
  * Monoid (take a deep breath, and relax about the weird name):
  *   This is a semigroup that has an additive identity (called zero), such that a+0=a, 0+a=a, for every a
  */
-
 @implicitNotFound(msg = "Cannot find Monoid type class for ${T}")
 trait Monoid[@specialized(Int, Long, Float, Double) T] extends Semigroup[T] {
+  /** Returns the identity element of `$T` for [[plus]]. */
   def zero: T //additive identity
   def isNonZero(v: T): Boolean = (v != zero)
   def assertNotZero(v: T) {

--- a/algebird-core/src/main/scala/com/twitter/algebird/Semigroup.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Semigroup.scala
@@ -25,14 +25,36 @@ import scala.annotation.{ implicitNotFound, tailrec }
 import macros.caseclass._
 
 /**
- * Semigroup:
- *   This is a class with a plus method that is associative: a+(b+c) = (a+b)+c
+ * A semigroup is any type `T` with an associative operation (`plus`):
+ *
+ * {{{
+ * a plus (b plus c) = (a plus b) plus c
+ * }}}
+ *
+ * Example instances:
+ *  - `Semigroup[Int]`: `plus` `Int#+`
+ *  - `Semigroup[List[T]]`: `plus` is `List#++`
+ *
+ * @define T T
  */
 @implicitNotFound(msg = "Cannot find Semigroup type class for ${T}")
 trait Semigroup[@specialized(Int, Long, Float, Double) T] extends java.io.Serializable {
-  def plus(l: T, r: T): T
   /**
-   * override this if there is a faster way to do this sum than reduceLeftOption on plus
+   * Combines two `$T` instances associatively.
+   *
+   * @return result of combining `l` and `r`
+   */
+  def plus(l: T, r: T): T
+
+  /**
+   * Returns an instance of `$T` calculated by summing all instances in
+   * `iter` in one pass. Returns `None` if `iter` is empty, else
+   * `Some[$T]`.
+   *
+   * @param iter instances of `$T` to be combined
+   * @return `None` if `iter` is empty, else an option value containing the summed `$T`
+   * @note Override if there is a faster way to compute this sum than
+   *       `iter.reduceLeftOption` using [[plus]].
    */
   def sumOption(iter: TraversableOnce[T]): Option[T] =
     iter.reduceLeftOption { plus(_, _) }
@@ -47,6 +69,8 @@ abstract class AbstractSemigroup[T] extends Semigroup[T]
  * wrong, use Left.  plus does the normal thing for plus(Right, Right), or plus(Left, Left),
  * but if exactly one is Left, we return that value (to keep the error condition).
  * Typically, the left value will be a string representing the errors.
+ *
+ * @define T Either[L, R]
  */
 class EitherSemigroup[L, R](implicit semigroupl: Semigroup[L], semigroupr: Semigroup[R]) extends Semigroup[Either[L, R]] {
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/AveragedValueLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AveragedValueLaws.scala
@@ -38,6 +38,12 @@ class AveragedValueLaws extends CheckProperties {
     }
   }
 
+  property("AveragedValue can absorb numbers directly") {
+    forAll { (base: AveragedValue, x: Long) =>
+      (base + AveragedValue(x)) == (base + x)
+    }
+  }
+
   property("AveragedValue works by + or sumOption") {
     forAll { v: NonEmptyVector[Double] =>
       val avgs = v.items.map(AveragedValue(_))

--- a/algebird-test/src/test/scala/com/twitter/algebird/AveragedValueLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AveragedValueLaws.scala
@@ -2,15 +2,64 @@ package com.twitter.algebird
 
 import com.twitter.algebird.BaseProperties._
 import com.twitter.algebird.scalacheck.arbitrary._
+import com.twitter.algebird.scalacheck.NonEmptyVector
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop.forAll
 
 class AveragedValueLaws extends CheckProperties {
-  property("AveragedValue Group laws") {
+  def avg[T](v: Vector[T])(implicit num: Numeric[T]): Double = {
+    val items = v.map(num.toDouble(_))
+    val sum = items.sum
+    val count = items.size
+    sum / count
+  }
+
+  property("AveragedValue is a group and commutative") {
     implicit val equiv: Equiv[AveragedValue] =
       Equiv.fromFunction { (avl, avr) =>
         ((avl.count == 0L) && (avr.count == 0L)) || {
           approxEq(1e-10)(avl.value, avr.value) && (avl.count == avr.count)
         }
       }
-    groupLawsEquiv[AveragedValue]
+    groupLawsEquiv[AveragedValue] && isCommutativeEquiv[AveragedValue]
+  }
+
+  property("AveragedValue.aggregator returns the average") {
+    forAll { v: NonEmptyVector[Double] =>
+      approxEq(1e-10)(avg(v.items), AveragedValue.aggregator(v.items))
+    }
+  }
+
+  property("AveragedValue instances subtract") {
+    forAll { (l: AveragedValue, r: AveragedValue) =>
+      l + -l == Monoid.zero[AveragedValue] &&
+        l - l == Monoid.zero[AveragedValue] &&
+        l - r == l + -r
+    }
+  }
+
+  property("AveragedValue works by + or sumOption") {
+    forAll { v: NonEmptyVector[Double] =>
+      val avgs = v.items.map(AveragedValue(_))
+      val sumOpt = Semigroup.sumOption[AveragedValue](avgs).get
+      val byPlus = avgs.reduce(_ + _)
+
+      approxEq(1e-10)(avg(v.items), sumOpt.value) &&
+        approxEq(1e-10)(sumOpt.value, byPlus.value)
+    }
+  }
+
+  def numericAggregatorTest[T: Numeric: Arbitrary] =
+    forAll { v: NonEmptyVector[T] =>
+      val averaged = AveragedValue.numericAggregator[T].apply(v.items)
+      approxEq(1e-10)(avg(v.items), averaged)
+    }
+
+  property("AveragedValue.numericAggregator averages BigInt") {
+    numericAggregatorTest[BigInt]
+  }
+
+  property("AveragedValue.numericAggregator averages Long") {
+    numericAggregatorTest[Long]
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,6 @@ def docsSourcesAndProjects(sv: String): (Boolean, Seq[ProjectReference]) =
       algebirdCore,
       algebirdUtil,
       algebirdBijection,
-      algebirdBenchmark,
       algebirdSpark))
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,7 @@ lazy val algebird = Project(
   base = file("."),
   settings = sharedSettings)
   .settings(noPublishSettings)
+  .settings(coverageExcludedPackages := "<empty>;.*\\.benchmark\\..*")
   .aggregate(
   algebirdTest,
   algebirdCore,

--- a/docs/src/main/tut/datatypes/averaged_value.md
+++ b/docs/src/main/tut/datatypes/averaged_value.md
@@ -29,6 +29,12 @@ longVal + doubleVal
 longVal + doubleVal + intVal
 ```
 
+You can also add numbers directly to an `AveragedValue` instance:
+
+```tut:book
+longVal + 12
+```
+
 `AveragedValue` is a commutative group. This means you can add instances in any order:
 
 ```tut:book

--- a/docs/src/main/tut/datatypes/averaged_value.md
+++ b/docs/src/main/tut/datatypes/averaged_value.md
@@ -8,8 +8,47 @@ scaladoc: "#com.twitter.algebird.AveragedValue"
 
 # Averaged Value
 
+The `AveragedValue` data structure allows you to keep track of the count and mean of a stream of numbers with only one pass over the data.
+
+## Algebraic Properties
+
+Here's a note on how to add them.
+
+Stability... so the online algorithm here: <https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm>
+
+is numerically stable when the counts are really unequal. "This algorithm is much less prone to loss of precision due to [catastrophic cancellation](https://en.wikipedia.org/wiki/Loss_of_significance)"
+
+This section on the parallel algorithm: <https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm>
+
+shows the actual algorithm that we use here.... BUT it's numerically unstable when the counts are close to each other and both large, because the numerical error in the difference of the means doesn't get scaled down. In such cases, says wiki, prefer the vanilla version. And that's exactly what we do.
+
+Also note that it's a group. You can subtract values, or negate the thing.
+
+### Notes
+
+This means that for big data we won't overflow. If the right side is small, < 2^63 items, ie within a long, you'll use the special algo.
+
+If the numbers are roughly equal then you MIGHT get an overflow. But you're often not adding multiple enormous numbers (~2^62).
+
+Numerically stable is key too.
+
+## Usage Examples
+
+- plus, minus, negative
+- use it to fold a bunch of longs
+- show the aggregator
+
+## Related Data Structures
+
+- decayedvalue
+- moments
+
+### Links
+
+- Source: [AveragedValue.scala](https://github.com/twitter/algebird/blob/develop/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala)
+- Tests: [AveragedValueLaws.scala](https://github.com/twitter/algebird/blob/develop/algebird-test/src/test/scala/com/twitter/algebird/AveragedValueLaws.scala)
+- Scaladoc: [AveragedValue]({{site.baseurl}}/api#com.twitter.algebird.AveragedValue)
+
 ### Documentation Help
 
-We'd love your help fleshing out this documentation! You can edit this page in your browser by clicking [this link](https://github.com/twitter/algebird/edit/develop/docs/src/main/tut/datatypes/averaged_value.md). These links might be helpful:
-
-- [AveragedValue.scala](https://github.com/twitter/algebird/blob/develop/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala)
+We'd love your help fleshing out this documentation! You can edit this page in your browser by clicking [this link](https://github.com/twitter/algebird/edit/develop/docs/src/main/tut/datatypes/averaged_value.md).

--- a/docs/src/main/tut/datatypes/first_and_last.md
+++ b/docs/src/main/tut/datatypes/first_and_last.md
@@ -72,7 +72,7 @@ See [the docs on `Min` and `Max`](min_and_max.html) for more information.
 ### Links
 
 - Source: [First.scala](https://github.com/twitter/algebird/blob/develop/algebird-core/src/main/scala/com/twitter/algebird/First.scala) and [Last.scala](https://github.com/twitter/algebird/blob/develop/algebird-core/src/main/scala/com/twitter/algebird/Last.scala)
-- Tests: [FirstSpec.scala](https://github.com/twitter/algebird/blob/develop/algebird-test/src/test/scala/com/twitter/algebird/FirstSpec.scala) and [LastSpec.scala](https://github.com/twitter/algebird/blob/develop/algebird-test/src/test/scala/com/twitter/algebird/LastSpec.scala)
+- Tests: [FirstLaws.scala](https://github.com/twitter/algebird/blob/develop/algebird-test/src/test/scala/com/twitter/algebird/FirstLaws.scala) and [LastLaws.scala](https://github.com/twitter/algebird/blob/develop/algebird-test/src/test/scala/com/twitter/algebird/LastLaws.scala)
 - Scaladoc: [First]({{site.baseurl}}/api#com.twitter.algebird.First) and [Last]({{site.baseurl}}/api#com.twitter.algebird.Last)
 
 ### Documentation Help

--- a/docs/src/main/tut/datatypes/min_and_max.md
+++ b/docs/src/main/tut/datatypes/min_and_max.md
@@ -105,7 +105,7 @@ See [the docs on `First` and `Last`](first_and_last.html) for more information.
 ### Links
 
 - Source: [Min.scala](https://github.com/twitter/algebird/blob/develop/algebird-core/src/main/scala/com/twitter/algebird/Min.scala) and [Max.scala](https://github.com/twitter/algebird/blob/develop/algebird-core/src/main/scala/com/twitter/algebird/Max.scala)
-- Tests: [MinSpec.scala](https://github.com/twitter/algebird/blob/develop/algebird-test/src/test/scala/com/twitter/algebird/MinSpec.scala) and [MaxSpec.scala](https://github.com/twitter/algebird/blob/develop/algebird-test/src/test/scala/com/twitter/algebird/MaxSpec.scala)
+- Tests: [MinLaws.scala](https://github.com/twitter/algebird/blob/develop/algebird-test/src/test/scala/com/twitter/algebird/MinLaws.scala) and [MaxLaws.scala](https://github.com/twitter/algebird/blob/develop/algebird-test/src/test/scala/com/twitter/algebird/MaxLaws.scala)
 - Scaladoc: [Min]({{site.baseurl}}/api#com.twitter.algebird.Min) and [Max]({{site.baseurl}}/api#com.twitter.algebird.Max)
 
 ### Documentation Help


### PR DESCRIPTION
This PR increases test coverage and adds a documentation page for `AveragedValue`. It also adds a `sumOption` implementation. (This comes after #591, to take advantage of the benchmarking goodies.)

Run the benchmark with:

```
jmh:run -t1 -f 1 -wi 15 -i 20 .*AveragedValueBenchmark.*
```

Here are the results:
```
[info] Benchmark                             (numElements)   Mode  Cnt      Score      Error  Units
[info] AveragedValueBenchmark.timePlus               10000  thrpt   20   6474.320 ±   65.222  ops/s
[info] AveragedValueBenchmark.timeSumOption          10000  thrpt   15  15057.069 ±  305.026  ops/s
[success] Total time: 73 s, completed Dec 1, 2016 2:54:13 PM
```

So, about a 2.3x speedup from the optimized `sumOption` impl.