### PR TITLE
bail out of SemigroupMacro.sumOption for `to.isEmpty`

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/macros/SemigroupMacro.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/macros/SemigroupMacro.scala
@@ -53,15 +53,17 @@ object SemigroupMacro {
     val getBlock = Block(getSumOptions, result)
 
     q"""
-    override def sumOption(to: _root_.scala.collection.TraversableOnce[$T]): _root_.scala.Option[$T] = {
-      val buf = new _root_.com.twitter.algebird.ArrayBufferedOperation[$T,$T](1000) with _root_.com.twitter.algebird.BufferedReduce[$T] {
-        def operate(items: _root_.scala.Seq[$T]): $T = {
-          $getBlock
+    override def sumOption(to: _root_.scala.collection.TraversableOnce[$T]): _root_.scala.Option[$T] =
+      if (to.isEmpty) None
+      else {
+        val buf = new _root_.com.twitter.algebird.ArrayBufferedOperation[$T,$T](1000) with _root_.com.twitter.algebird.BufferedReduce[$T] {
+          def operate(items: _root_.scala.Seq[$T]): $T = {
+            $getBlock
+          }
         }
+        to.foreach(buf.put(_))
+        buf.flush
       }
-      to.foreach(buf.put(_))
-      buf.flush
-    }
     """
   }
 


### PR DESCRIPTION
Saves us an object instantiation for an empty list.