### PR TITLE
better toString implementation for ExpHist

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/ExpHist.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/ExpHist.scala
@@ -153,6 +153,9 @@ case class ExpHist(conf: ExpHist.Config, buckets: Vector[ExpHist.Bucket], total:
       val absoluteError = (oldestBucketSize - 1) / 2.0
       absoluteError / minInsideWindow
     }
+
+  override def toString: String =
+    s"ExpHist(conf: $conf, time: $time, guess: $guess, lowerBoundSum: $lowerBoundSum, upperBoundSum: $upperBoundSum)"
 }
 
 object ExpHist {

--- a/algebird-core/src/main/scala/com/twitter/algebird/ExpHist.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/ExpHist.scala
@@ -155,7 +155,7 @@ case class ExpHist(conf: ExpHist.Config, buckets: Vector[ExpHist.Bucket], total:
     }
 
   override def toString: String =
-    s"ExpHist(conf: $conf, time: $time, guess: $guess, lowerBoundSum: $lowerBoundSum, upperBoundSum: $upperBoundSum)"
+    s"ExpHist(conf = $conf, time = $time, guess = $guess, lowerBoundSum = $lowerBoundSum, upperBoundSum = $upperBoundSum)"
 }
 
 object ExpHist {

--- a/docs/src/main/tut/datatypes/approx/exponential_histogram.md
+++ b/docs/src/main/tut/datatypes/approx/exponential_histogram.md
@@ -53,8 +53,8 @@ val approximateSum = full.guess
 full.relativeError
 val maxError = actualSum * full.relativeError
 
-assert(full.guess <= actualSum + maxError)
-assert(full.guess >= actualSum - maxError)
+full.guess <= actualSum + maxError
+full.guess >= actualSum - maxError
 ```
 
 ## l-Canonical Representation


### PR DESCRIPTION
The string representation now looks like this:

```scala
full: com.twitter.algebird.ExpHist = ExpHist(conf: Config(0.01,200), time: Timestamp(200), guess: 19972.5, lowerBoundSum: 19844, upperBoundSum: 20100)
```
The current implementation prints like this:

```scala
// full: com.twitter.algebird.ExpHist = ExpHist(Config(0.01,200),Vector(Bucket(1,Timestamp(200)),
 Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)),
 Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)),
 Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)),
 Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)),
 Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)),
 Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)),
 Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)),
 Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)),
 Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)), Bucket(1,Timestamp(200)), ...
```