### PR TITLE
Polymorphic Bloom filters

### DIFF
--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterCreateBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterCreateBenchmark.scala
@@ -11,17 +11,21 @@ object BloomFilterCreateBenchmark {
     Seq.fill(nbrOfStrings)(Random.nextString(lengthOfStrings))
   }
 
-  implicit def stringToBytes(s: String): Array[Byte] = s.getBytes()
-
   @State(Scope.Benchmark)
   class BloomFilterState {
-    @Param(Array("4", "5", "6"))
-    var nbrOfHashes: Int = 0
+    @Param(Array("100", "1000", "10000"))
+    var nbrOfElements: Int = 0
 
-    @Param(Array("16", "32", "64"))
-    var width: Int = 0
+    @Param(Array("0.001", "0.01"))
+    var falsePositiveRate: Double = 0
 
-    val randomString = createRandomString(1000, 10)
+    var randomStrings: Seq[String] = _
+
+    @Setup(Level.Trial)
+    def setup(): Unit = {
+      randomStrings = createRandomString(nbrOfElements, 10)
+    }
+
   }
 }
 
@@ -31,8 +35,8 @@ class BloomFilterCreateBenchmark {
 
   @Benchmark
   def createBloomFilter(bloomFilterState: BloomFilterState): BF[String] = {
-    val bfMonoid = new BloomFilterMonoid[String](bloomFilterState.nbrOfHashes, bloomFilterState.width)
-    val bf = bfMonoid.create(bloomFilterState.randomString: _*)
+    val bfMonoid = BloomFilter[String](bloomFilterState.nbrOfElements, bloomFilterState.falsePositiveRate)
+    val bf = bfMonoid.create(bloomFilterState.randomStrings: _*)
     bf
   }
 }

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterCreateBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterCreateBenchmark.scala
@@ -1,0 +1,39 @@
+package com.twitter.algebird
+package benchmark
+
+import org.openjdk.jmh.annotations._
+
+import scala.util.Random
+
+object BloomFilterCreateBenchmark {
+
+  def createRandomString(nbrOfStrings: Int, lengthOfStrings: Int): Seq[String] = {
+    Seq.fill(nbrOfStrings)(Random.nextString(lengthOfStrings))
+  }
+
+  implicit def stringToBytes(s: String): Array[Byte] = s.getBytes()
+
+  @State(Scope.Benchmark)
+  class BloomFilterState {
+    @Param(Array("4", "5", "6"))
+    var nbrOfHashes: Int = 0
+
+    @Param(Array("16", "32", "64"))
+    var width: Int = 0
+
+    val randomString = createRandomString(1000, 10)
+  }
+}
+
+class BloomFilterCreateBenchmark {
+
+  import BloomFilterCreateBenchmark._
+
+  @Benchmark
+  def createBloomFilter(bloomFilterState: BloomFilterState): BF[String] = {
+    val bfMonoid = new BloomFilterMonoid[String](bloomFilterState.nbrOfHashes, bloomFilterState.width)
+    val bf = bfMonoid.create(bloomFilterState.randomString: _*)
+    bf
+  }
+}
+

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterQueryBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterQueryBenchmark.scala
@@ -1,0 +1,30 @@
+package com.twitter.algebird
+package benchmark
+
+import org.openjdk.jmh.annotations._
+
+object BloomFilterQueryBenchmark {
+
+  import BloomFilterCreateBenchmark.stringToBytes
+
+  @State(Scope.Benchmark)
+  class BloomFilterState {
+    @Param(Array("4", "5", "6"))
+    var nbrOfHashes: Int = 0
+
+    @Param(Array("16", "32", "64"))
+    var width: Int = 0
+    val bfMonoid = new BloomFilterMonoid[String](6, 32)
+    val randomStrings = BloomFilterCreateBenchmark.createRandomString(1000, 10)
+    val bf = bfMonoid.create(randomStrings: _*)
+  }
+}
+
+class BloomFilterQueryBenchmark {
+  import BloomFilterQueryBenchmark._
+
+  @Benchmark
+  def queryBloomFilter(bloomFilterState: BloomFilterState): ApproximateBoolean = {
+    bloomFilterState.bf.contains("1")
+  }
+}

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterQueryBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterQueryBenchmark.scala
@@ -5,18 +5,22 @@ import org.openjdk.jmh.annotations._
 
 object BloomFilterQueryBenchmark {
 
-  import BloomFilterCreateBenchmark.stringToBytes
-
   @State(Scope.Benchmark)
   class BloomFilterState {
-    @Param(Array("4", "5", "6"))
-    var nbrOfHashes: Int = 0
 
-    @Param(Array("16", "32", "64"))
-    var width: Int = 0
-    val bfMonoid = new BloomFilterMonoid[String](6, 32)
-    val randomStrings = BloomFilterCreateBenchmark.createRandomString(1000, 10)
-    val bf = bfMonoid.create(randomStrings: _*)
+    @Param(Array("100", "1000", "10000"))
+    var nbrOfElements: Int = 0
+
+    @Param(Array("0.001", "0.01"))
+    var falsePositiveRate: Double = 0
+
+    var bf: BF[String] = _
+
+    @Setup(Level.Trial)
+    def setup(): Unit = {
+      val randomStrings = BloomFilterCreateBenchmark.createRandomString(nbrOfElements, 10)
+      bf = BloomFilter[String](nbrOfElements, falsePositiveRate).create(randomStrings: _*)
+    }
   }
 }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -44,7 +44,7 @@ class RichCBitSet(val cb: CBitSet) {
 
 object BloomFilter {
 
-  def apply[A](numEntries: Int, fpProb: Double)(implicit hash: Hash128[A]) = {
+  def apply[A](numEntries: Int, fpProb: Double)(implicit hash: Hash128[A]): BloomFilterMonoid[A] = {
     val width = BloomFilter.optimalWidth(numEntries, fpProb)
     val numHashes = BloomFilter.optimalNumHashes(numEntries, width)
     BloomFilterMonoid[A](numHashes, width)(hash)

--- a/algebird-core/src/main/scala/com/twitter/algebird/Hash128.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Hash128.scala
@@ -21,11 +21,18 @@ package com.twitter.algebird
  * Used for HLL, but possibly other applications
  */
 trait Hash128[-K] extends java.io.Serializable {
-  def hash(k: K): (Long, Long)
+
+  val DefaultSeed: Long
+
+  def hashWithSeed(seed: Long, k: K): (Long, Long)
+
+  def hash(k: K): (Long, Long) = hashWithSeed(DefaultSeed, k)
+
   def contramap[L](fn: L => K): Hash128[L] = {
     val self = this
     new Hash128[L] {
-      def hash(l: L) = self.hash(fn(l))
+      val DefaultSeed = Hash128.DefaultSeed
+      def hashWithSeed(seed: Long, l: L) = self.hashWithSeed(seed, fn(l))
     }
   }
 }
@@ -40,14 +47,17 @@ object Hash128 extends java.io.Serializable {
 
   val DefaultSeed = 12345678L
 
-  def murmur128ArrayByte(seed: Long): Hash128[Array[Byte]] = new Hash128[Array[Byte]] {
-    def hash(k: Array[Byte]) = MurmurHash128(seed)(k)
+  def murmur128ArrayByte(): Hash128[Array[Byte]] = new Hash128[Array[Byte]] {
+    val DefaultSeed = Hash128.DefaultSeed
+    def hashWithSeed(seed: Long, k: Array[Byte]) = MurmurHash128(seed)(k)
   }
-  def murmur128ArrayInt(seed: Long): Hash128[Array[Int]] = new Hash128[Array[Int]] {
-    def hash(k: Array[Int]) = MurmurHash128(seed)(k)
+  def murmur128ArrayInt(): Hash128[Array[Int]] = new Hash128[Array[Int]] {
+    val DefaultSeed = Hash128.DefaultSeed
+    def hashWithSeed(seed: Long, k: Array[Int]) = MurmurHash128(seed)(k)
   }
-  def murmur128ArrayLong(seed: Long): Hash128[Array[Long]] = new Hash128[Array[Long]] {
-    def hash(k: Array[Long]) = MurmurHash128(seed)(k)
+  def murmur128ArrayLong(): Hash128[Array[Long]] = new Hash128[Array[Long]] {
+    val DefaultSeed = Hash128.DefaultSeed
+    def hashWithSeed(seed: Long, k: Array[Long]) = MurmurHash128(seed)(k)
   }
 
   /**
@@ -56,18 +66,20 @@ object Hash128 extends java.io.Serializable {
    * but has been more commonly used in HLL.
    */
   def murmur128Utf8String(seed: Long): Hash128[String] =
-    murmur128ArrayByte(seed).contramap(_.getBytes("UTF-8"))
+    murmur128ArrayByte().contramap(_.getBytes("UTF-8"))
 
   def murmur128Int(seed: Long): Hash128[Int] = new Hash128[Int] {
-    def hash(k: Int) = MurmurHash128(seed)(k)
+    val DefaultSeed = Hash128.DefaultSeed
+    def hashWithSeed(seed: Long, k: Int) = MurmurHash128(seed)(k)
   }
   def murmur128Long(seed: Long): Hash128[Long] = new Hash128[Long] {
-    def hash(k: Long) = MurmurHash128(seed)(k)
+    val DefaultSeed = Hash128.DefaultSeed
+    def hashWithSeed(seed: Long, k: Long) = MurmurHash128(seed)(k)
   }
 
-  implicit lazy val arrayByteHash: Hash128[Array[Byte]] = murmur128ArrayByte(DefaultSeed)
-  implicit lazy val arrayIntHash: Hash128[Array[Int]] = murmur128ArrayInt(DefaultSeed)
-  implicit lazy val arrayLongHash: Hash128[Array[Long]] = murmur128ArrayLong(DefaultSeed)
+  implicit lazy val arrayByteHash: Hash128[Array[Byte]] = murmur128ArrayByte()
+  implicit lazy val arrayIntHash: Hash128[Array[Int]] = murmur128ArrayInt()
+  implicit lazy val arrayLongHash: Hash128[Array[Long]] = murmur128ArrayLong()
   implicit lazy val stringHash: Hash128[String] = murmur128Utf8String(DefaultSeed)
   implicit lazy val intHash: Hash128[Int] = murmur128Int(DefaultSeed)
   implicit lazy val longHash: Hash128[Long] = murmur128Long(DefaultSeed)

--- a/algebird-core/src/main/scala/com/twitter/algebird/Hash128.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Hash128.scala
@@ -22,7 +22,7 @@ package com.twitter.algebird
  */
 trait Hash128[-K] extends java.io.Serializable {
 
-  val DefaultSeed: Long
+  def DefaultSeed: Long
 
   def hashWithSeed(seed: Long, k: K): (Long, Long)
 
@@ -31,7 +31,7 @@ trait Hash128[-K] extends java.io.Serializable {
   def contramap[L](fn: L => K): Hash128[L] = {
     val self = this
     new Hash128[L] {
-      val DefaultSeed = Hash128.DefaultSeed
+      val DefaultSeed = self.DefaultSeed
       def hashWithSeed(seed: Long, l: L) = self.hashWithSeed(seed, fn(l))
     }
   }
@@ -47,16 +47,16 @@ object Hash128 extends java.io.Serializable {
 
   val DefaultSeed = 12345678L
 
-  def murmur128ArrayByte(): Hash128[Array[Byte]] = new Hash128[Array[Byte]] {
-    val DefaultSeed = Hash128.DefaultSeed
+  def murmur128ArrayByte(seed: Long): Hash128[Array[Byte]] = new Hash128[Array[Byte]] {
+    val DefaultSeed = seed
     def hashWithSeed(seed: Long, k: Array[Byte]) = MurmurHash128(seed)(k)
   }
-  def murmur128ArrayInt(): Hash128[Array[Int]] = new Hash128[Array[Int]] {
-    val DefaultSeed = Hash128.DefaultSeed
+  def murmur128ArrayInt(seed: Long): Hash128[Array[Int]] = new Hash128[Array[Int]] {
+    val DefaultSeed = seed
     def hashWithSeed(seed: Long, k: Array[Int]) = MurmurHash128(seed)(k)
   }
-  def murmur128ArrayLong(): Hash128[Array[Long]] = new Hash128[Array[Long]] {
-    val DefaultSeed = Hash128.DefaultSeed
+  def murmur128ArrayLong(seed: Long): Hash128[Array[Long]] = new Hash128[Array[Long]] {
+    val DefaultSeed = seed
     def hashWithSeed(seed: Long, k: Array[Long]) = MurmurHash128(seed)(k)
   }
 
@@ -65,21 +65,21 @@ object Hash128 extends java.io.Serializable {
    * than the UTF-16 based approach in Murmur128.apply(CharSequence),
    * but has been more commonly used in HLL.
    */
-  def murmur128Utf8String(seed: Long): Hash128[String] =
-    murmur128ArrayByte().contramap(_.getBytes("UTF-8"))
+  def murmur128Utf8String(defaultSeed: Long): Hash128[String] =
+    murmur128ArrayByte(defaultSeed).contramap(_.getBytes("UTF-8"))
 
-  def murmur128Int(seed: Long): Hash128[Int] = new Hash128[Int] {
-    val DefaultSeed = Hash128.DefaultSeed
+  def murmur128Int(defaultSeed: Long): Hash128[Int] = new Hash128[Int] {
+    val DefaultSeed = defaultSeed
     def hashWithSeed(seed: Long, k: Int) = MurmurHash128(seed)(k)
   }
-  def murmur128Long(seed: Long): Hash128[Long] = new Hash128[Long] {
-    val DefaultSeed = Hash128.DefaultSeed
+  def murmur128Long(defaultSeed: Long): Hash128[Long] = new Hash128[Long] {
+    val DefaultSeed = defaultSeed
     def hashWithSeed(seed: Long, k: Long) = MurmurHash128(seed)(k)
   }
 
-  implicit lazy val arrayByteHash: Hash128[Array[Byte]] = murmur128ArrayByte()
-  implicit lazy val arrayIntHash: Hash128[Array[Int]] = murmur128ArrayInt()
-  implicit lazy val arrayLongHash: Hash128[Array[Long]] = murmur128ArrayLong()
+  implicit lazy val arrayByteHash: Hash128[Array[Byte]] = murmur128ArrayByte(DefaultSeed)
+  implicit lazy val arrayIntHash: Hash128[Array[Int]] = murmur128ArrayInt(DefaultSeed)
+  implicit lazy val arrayLongHash: Hash128[Array[Long]] = murmur128ArrayLong(DefaultSeed)
   implicit lazy val stringHash: Hash128[String] = murmur128Utf8String(DefaultSeed)
   implicit lazy val intHash: Hash128[Int] = murmur128Int(DefaultSeed)
   implicit lazy val longHash: Hash128[Long] = murmur128Long(DefaultSeed)

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -6,13 +6,8 @@ import org.scalacheck.{ Arbitrary, Gen, Properties }
 import org.scalatest.{ Matchers, WordSpec }
 import org.scalacheck.Prop._
 
-object ImplicitStringToBytesView {
-  implicit def stringToBytes(s: String): Array[Byte] = s.getBytes()
-}
-
 class BloomFilterLaws extends CheckProperties {
 
-  import ImplicitStringToBytesView.stringToBytes
   import com.twitter.algebird.BaseProperties._
 
   val NUM_HASHES = 6
@@ -30,7 +25,6 @@ class BloomFilterLaws extends CheckProperties {
 }
 
 class BFHashIndices extends CheckProperties {
-  import ImplicitStringToBytesView.stringToBytes
 
   val NUM_HASHES = 10
   val WIDTH = 4752800
@@ -102,8 +96,6 @@ class BFHashIndices extends CheckProperties {
 
 class BloomFilterFalsePositives[T: Gen](falsePositiveRate: Double) extends ApproximateProperty {
 
-  import ImplicitStringToBytesView.stringToBytes
-
   type Exact = Set[T]
   type Approx = BF[String]
 
@@ -136,8 +128,6 @@ class BloomFilterFalsePositives[T: Gen](falsePositiveRate: Double) extends Appro
 }
 
 class BloomFilterCardinality[T: Gen] extends ApproximateProperty {
-
-  import ImplicitStringToBytesView.stringToBytes
 
   type Exact = Set[T]
   type Approx = BF[String]
@@ -183,8 +173,6 @@ class BloomFilterProperties extends ApproximateProperties("BloomFilter") {
 }
 
 class BloomFilterTest extends WordSpec with Matchers {
-
-  import ImplicitStringToBytesView.stringToBytes
 
   val RAND = new scala.util.Random
 
@@ -270,7 +258,6 @@ class BloomFilterTest extends WordSpec with Matchers {
         stream.close()
         stream.toByteArray
       }
-
 
       val items = (1 until 10).map(_.toString)
       val bf = BloomFilter[String](10, 0.1).create(items: _*)

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -6,37 +6,45 @@ import org.scalacheck.{ Arbitrary, Gen, Properties }
 import org.scalatest.{ Matchers, WordSpec }
 import org.scalacheck.Prop._
 
+object ImplicitStringToBytesView {
+  implicit def stringToBytes(s: String): Array[Byte] = s.getBytes()
+}
+
 class BloomFilterLaws extends CheckProperties {
+
+  import ImplicitStringToBytesView.stringToBytes
   import com.twitter.algebird.BaseProperties._
 
   val NUM_HASHES = 6
   val WIDTH = 32
 
-  implicit val bfMonoid = new BloomFilterMonoid(NUM_HASHES, WIDTH)
+  implicit val bfMonoid = new BloomFilterMonoid[String](NUM_HASHES, WIDTH)
   implicit val bfGen =
     Arbitrary {
       for (v <- Gen.choose(0, 10000)) yield (bfMonoid.create(v.toString))
     }
 
   property("BloomFilter is a Monoid") {
-    monoidLaws[BF]
+    monoidLaws[BF[String]]
   }
 }
 
 class BFHashIndices extends CheckProperties {
+  import ImplicitStringToBytesView.stringToBytes
+
   val NUM_HASHES = 10
   val WIDTH = 4752800
 
-  implicit val bfHash: Arbitrary[BFHash] =
+  implicit val bfHash: Arbitrary[BFHash[String]] =
     Arbitrary {
       for {
         hashes <- Gen.choose(1, 10)
         width <- Gen.choose(100, 5000000)
-      } yield BFHash(hashes, width)
+      } yield BFHash[String](hashes, width)
     }
 
   property("Indices are non negative") {
-    forAll { (hash: BFHash, v: Long) =>
+    forAll { (hash: BFHash[String], v: Long) =>
       hash.apply(v.toString).forall { e =>
         e >= 0
       }
@@ -74,16 +82,16 @@ class BFHashIndices extends CheckProperties {
     }
   }
 
-  implicit val pairOfHashes: Arbitrary[(BFHash, NegativeBFHash)] =
+  implicit val pairOfHashes: Arbitrary[(BFHash[String], NegativeBFHash)] =
     Arbitrary {
       for {
         hashes <- Gen.choose(1, 10)
         width <- Gen.choose(100, 5000000)
-      } yield (BFHash(hashes, width), NegativeBFHash(hashes, width))
+      } yield (BFHash[String](hashes, width), NegativeBFHash(hashes, width))
     }
 
   property("Indices of the two versions of BFHashes are the same, unless the first one contains negative index") {
-    forAll { (pair: (BFHash, NegativeBFHash), v: Long) =>
+    forAll { (pair: (BFHash[String], NegativeBFHash), v: Long) =>
       val s = v.toString
       val (hash, negativeHash) = pair
       val indices = negativeHash.apply(s)
@@ -93,8 +101,11 @@ class BFHashIndices extends CheckProperties {
 }
 
 class BloomFilterFalsePositives[T: Gen](falsePositiveRate: Double) extends ApproximateProperty {
+
+  import ImplicitStringToBytesView.stringToBytes
+
   type Exact = Set[T]
-  type Approx = BF
+  type Approx = BF[String]
 
   type Input = T
   type Result = Boolean
@@ -107,7 +118,7 @@ class BloomFilterFalsePositives[T: Gen](falsePositiveRate: Double) extends Appro
   } yield set
 
   def makeApproximate(set: Set[T]) = {
-    val bfMonoid = BloomFilter(set.size, falsePositiveRate)
+    val bfMonoid = BloomFilter[String](set.size, falsePositiveRate)
 
     val strings = set.map(_.toString).toSeq
     bfMonoid.create(strings: _*)
@@ -121,12 +132,15 @@ class BloomFilterFalsePositives[T: Gen](falsePositiveRate: Double) extends Appro
 
   def exactResult(s: Set[T], t: T) = s.contains(t)
 
-  def approximateResult(bf: BF, t: T) = bf.contains(t.toString)
+  def approximateResult(bf: BF[String], t: T) = bf.contains(t.toString)
 }
 
 class BloomFilterCardinality[T: Gen] extends ApproximateProperty {
+
+  import ImplicitStringToBytesView.stringToBytes
+
   type Exact = Set[T]
-  type Approx = BF
+  type Approx = BF[String]
 
   type Input = Unit
   type Result = Long
@@ -140,7 +154,7 @@ class BloomFilterCardinality[T: Gen] extends ApproximateProperty {
   } yield set
 
   def makeApproximate(set: Set[T]) = {
-    val bfMonoid = BloomFilter(set.size, falsePositiveRate)
+    val bfMonoid = BloomFilter[String](set.size, falsePositiveRate)
 
     val strings = set.map(_.toString).toSeq
     bfMonoid.create(strings: _*)
@@ -149,7 +163,7 @@ class BloomFilterCardinality[T: Gen] extends ApproximateProperty {
   def inputGenerator(set: Set[T]) = Gen.const(())
 
   def exactResult(s: Set[T], u: Unit) = s.size
-  def approximateResult(bf: BF, u: Unit) = bf.size
+  def approximateResult(bf: BF[String], u: Unit) = bf.size
 }
 
 class BloomFilterProperties extends ApproximateProperties("BloomFilter") {
@@ -170,6 +184,8 @@ class BloomFilterProperties extends ApproximateProperties("BloomFilter") {
 
 class BloomFilterTest extends WordSpec with Matchers {
 
+  import ImplicitStringToBytesView.stringToBytes
+
   val RAND = new scala.util.Random
 
   "BloomFilter" should {
@@ -178,7 +194,7 @@ class BloomFilterTest extends WordSpec with Matchers {
       (0 to 100).foreach{
         _ =>
           {
-            val bfMonoid = new BloomFilterMonoid(RAND.nextInt(5) + 1, RAND.nextInt(64) + 32)
+            val bfMonoid = new BloomFilterMonoid[String](RAND.nextInt(5) + 1, RAND.nextInt(64) + 32)
             val numEntries = 5
             val entries = (0 until numEntries).map(_ => RAND.nextInt.toString)
             val bf = bfMonoid.create(entries: _*)
@@ -200,7 +216,7 @@ class BloomFilterTest extends WordSpec with Matchers {
               {
                 val numEntries = RAND.nextInt(10) + 1
 
-                val bfMonoid = BloomFilter(numEntries, fpProb)
+                val bfMonoid = BloomFilter[String](numEntries, fpProb)
 
                 val entries = RAND.shuffle((0 until 1000).toList).take(numEntries + 1).map(_.toString)
                 val bf = bfMonoid.create(entries.drop(1): _*)
@@ -217,7 +233,7 @@ class BloomFilterTest extends WordSpec with Matchers {
     }
 
     "approximate cardinality" in {
-      val bfMonoid = BloomFilterMonoid(10, 100000)
+      val bfMonoid = BloomFilterMonoid[String](10, 100000)
       Seq(10, 100, 1000, 10000).foreach { exactCardinality =>
         val items = (1 until exactCardinality).map { _.toString }
         val bf = bfMonoid.create(items: _*)
@@ -233,7 +249,7 @@ class BloomFilterTest extends WordSpec with Matchers {
       (0 to 10).foreach{
         _ =>
           {
-            val aggregator = BloomFilterAggregator(RAND.nextInt(5) + 1, RAND.nextInt(64) + 32)
+            val aggregator = BloomFilterAggregator[String](RAND.nextInt(5) + 1, RAND.nextInt(64) + 32)
             val numEntries = 5
             val entries = (0 until numEntries).map(_ => RAND.nextInt.toString)
             val bf = aggregator(entries)
@@ -246,7 +262,7 @@ class BloomFilterTest extends WordSpec with Matchers {
     }
 
     "not serialize @transient dense BFInstance" in {
-      def serialize(bf: BF): Array[Byte] = {
+      def serialize(bf: BF[String]): Array[Byte] = {
         val stream = new ByteArrayOutputStream()
         val out = new ObjectOutputStream(stream)
         out.writeObject(bf)
@@ -255,8 +271,9 @@ class BloomFilterTest extends WordSpec with Matchers {
         stream.toByteArray
       }
 
+
       val items = (1 until 10).map(_.toString)
-      val bf = BloomFilter(10, 0.1).create(items: _*)
+      val bf = BloomFilter[String](10, 0.1).create(items: _*)
       val bytesBeforeSizeCalled = Bytes(serialize(bf))
       val beforeSize = bf.size
       assert(bf.contains("1").isTrue)
@@ -271,7 +288,7 @@ class BloomFilterTest extends WordSpec with Matchers {
     "not have negative hash values" in {
       val NUM_HASHES = 2
       val WIDTH = 4752800
-      val bfHash = BFHash(NUM_HASHES, WIDTH)
+      val bfHash = BFHash[String](NUM_HASHES, WIDTH)
       val s = "7024497610539761509"
       val index = bfHash.apply(s).head
 
@@ -285,7 +302,7 @@ class BloomFilterTest extends WordSpec with Matchers {
       (0 to 100).foreach {
         _ =>
           {
-            val bfMonoid = new BloomFilterMonoid(RAND.nextInt(5) + 1, RAND.nextInt(64) + 32)
+            val bfMonoid = new BloomFilterMonoid[String](RAND.nextInt(5) + 1, RAND.nextInt(64) + 32)
             val numEntries = 5
             val entries = (0 until numEntries).map(_ => RAND.nextInt.toString)
             val bf = bfMonoid.create(entries: _*)

--- a/docs/src/main/tut/datatypes/approx/bloom_filter.md
+++ b/docs/src/main/tut/datatypes/approx/bloom_filter.md
@@ -44,7 +44,7 @@ val bf1 = bfMonoid1.create("1", "2", "3", "4", "100")
 val approxBool1 = bf1.contains("1")
 val res1 = approxBool1.isTrue
 
-// Out you can specify a estimate of the number of elements
+// You can also specify an estimate of the number of elements
 // which will be added to the set, and a desired false positive
 // frequency like this:
 val bloomFilterMonoid2 = BloomFilter(numEntries = 100, fpProb = 0.01)

--- a/docs/src/main/tut/datatypes/approx/bloom_filter.md
+++ b/docs/src/main/tut/datatypes/approx/bloom_filter.md
@@ -30,16 +30,11 @@ example usage:
 ```tut:book
 import com.twitter.algebird._
 
-// We need to provide a implicit conversion from of the Bloom filter,
-// in this case String, to Hash128. Conveniently Hash128 has a number
-// of built in conversions so we do not need to define our own.
-implicit def stringToHash128 = Hash128.stringHash
-
 // It's possible to create a Bloom filter with a set number of
 // hashes, and with a set width.
 val NUM_HASHES = 6
 val WIDTH = 32
-val bfMonoid1 = new BloomFilterMonoid(NUM_HASHES, WIDTH)
+val bfMonoid1 = new BloomFilterMonoid[String](NUM_HASHES, WIDTH)
 val bf1 = bfMonoid1.create("1", "2", "3", "4", "100")
 val approxBool1 = bf1.contains("1")
 val res1 = approxBool1.isTrue
@@ -47,7 +42,7 @@ val res1 = approxBool1.isTrue
 // You can also specify an estimate of the number of elements
 // which will be added to the set, and a desired false positive
 // frequency like this:
-val bloomFilterMonoid2 = BloomFilter(numEntries = 100, fpProb = 0.01)
+val bloomFilterMonoid2 = BloomFilter[String](numEntries = 100, fpProb = 0.01)
 val bf2 = bloomFilterMonoid2.create("1", "2", "3", "4", "100")
 val approxBool2 = bf2.contains("1")
 val res2 = approxBool2.isTrue

--- a/docs/src/main/tut/datatypes/approx/bloom_filter.md
+++ b/docs/src/main/tut/datatypes/approx/bloom_filter.md
@@ -8,16 +8,50 @@ scaladoc: "#com.twitter.algebird.BloomFilter"
 
 # Bloom Filter
 
+A Bloom filter is a data structure invented by Burton Howard Bloom in 1970. It makes it possible to check for set
+membership in a space efficient way. It does in a probabilistic manner, probiding the property that there may be false
+ positives, but its guaranteed to have no false negatives.
+
+A Bloom filter is created by initializing a bit array of n bits, with all bits set to 0. Elements are then added by
+computing m hash functions which output values correspond to the indexes in the byte array with a uniform random
+distribution. As these hash functions are computed, the bytes in the array corresponding to the hash function output
+are set to 1. This is done for all elements added to the set.
+
+To query the filter for membership of a element, the same m hash functions are computed for that element, and the
+corresponding bits are checked. If all bits are not set to 1, we know that the element was not part of the set. However,
+if all bits are set to one the element might be a member of the set.
+
+The size of a Bloom filter depends on the number of input elements, and the desired false positive rate.
+
+To read more about Bloom filters see wikipedia: https://en.wikipedia.org/wiki/Bloom_filter
+
 example usage:
 
 ```tut:book
 import com.twitter.algebird._
+
+// We need to provide a implicit conversion from of the Bloom filter,
+// in this case String, to Hash128. Conveniently Hash128 has a number
+// of built in conversions so we do not need to define our own.
+implicit def stringToHash128 = Hash128.stringHash
+
+// It's possible to create a Bloom filter with a set number of
+// hashes, and with a set width.
 val NUM_HASHES = 6
 val WIDTH = 32
-val bfMonoid = new BloomFilterMonoid(NUM_HASHES, WIDTH)
-val bf = bfMonoid.create("1", "2", "3", "4", "100")
-val approxBool = bf.contains("1")
-val res = approxBool.isTrue
+val bfMonoid1 = new BloomFilterMonoid(NUM_HASHES, WIDTH)
+val bf1 = bfMonoid1.create("1", "2", "3", "4", "100")
+val approxBool1 = bf1.contains("1")
+val res1 = approxBool1.isTrue
+
+// Out you can specify a estimate of the number of elements
+// which will be added to the set, and a desired false positive
+// frequency like this:
+val bloomFilterMonoid2 = BloomFilter(numEntries = 100, fpProb = 0.01)
+val bf2 = bloomFilterMonoid2.create("1", "2", "3", "4", "100")
+val approxBool2 = bf2.contains("1")
+val res2 = approxBool2.isTrue
+
 ```
 
 ### Documentation Help


### PR DESCRIPTION
This relates to #606. It makes `BloomFilter` polymorphic, fixes the tests to match that (while still using `String` as the type in the tests), and it adds some basic benchmarks for creating and querying the Bloom filters.

One major change in this is that the interface has been changed so that many of the functions now require a implicit view from `A => Array[Byte]`, leading to usage looking something like this:

```
implicit def stringToBytes(s: String): Array[Byte] = s.getBytes()

val NUM_HASHES = 6
val WIDTH = 32

val bfMonoid = new BloomFilterMonoid[String](NUM_HASHES, WIDTH)
val bf = bfMonoid.create("1", "2", "3", "4", "100")

val approxBool = bf.contains("1")
val res = approxBool.isTrue
```

When it comes to the benchmarks I've never used setup benchmarks using this type of framework (or any framework at all to be honest), so I'm not sure I got it right, nor that I picked sensible values for the parameters to test. However I hope it can still serve as a useful scaffold if one wants to address the performance issues mentioned in #606.