### PR TITLE
Add MonoidAggregator.collectBefore

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -513,6 +513,16 @@ trait MonoidAggregator[-A, B, +C] extends Aggregator[A, B, C] { self =>
     }
 
   /**
+   * Only transform values where the function is defined, else discard
+   */
+  def composeBefore[A2](fn: PartialFunction[A2, A]): MonoidAggregator[A2, B, C] =
+    new MonoidAggregator[A2, B, C] {
+      def prepare(a: A2) = if (fn.isDefinedAt(a)) self.prepare(fn(a)) else self.monoid.zero
+      def monoid = self.monoid
+      def present(b: B) = self.present(b)
+    }
+
+  /**
    * Only aggregate items that match a predicate
    */
   def filterBefore[A1 <: A](pred: A1 => Boolean): MonoidAggregator[A1, B, C] =

--- a/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -515,7 +515,7 @@ trait MonoidAggregator[-A, B, +C] extends Aggregator[A, B, C] { self =>
   /**
    * Only transform values where the function is defined, else discard
    */
-  def composeBefore[A2](fn: PartialFunction[A2, A]): MonoidAggregator[A2, B, C] =
+  def collectBefore[A2](fn: PartialFunction[A2, A]): MonoidAggregator[A2, B, C] =
     new MonoidAggregator[A2, B, C] {
       def prepare(a: A2) = if (fn.isDefinedAt(a)) self.prepare(fn(a)) else self.monoid.zero
       def monoid = self.monoid

--- a/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
@@ -216,9 +216,9 @@ class AggregatorLaws extends CheckProperties {
     }
   }
 
-  property("MonoidAggregator.composeCollect is like filter + compose") {
+  property("MonoidAggregator.collectBefore is like filter + compose") {
     forAll { (in: List[Int], ag: MonoidAggregator[Int, Int, Int], fn: Int => Option[Int]) =>
-      val cp = ag.composeBefore[Int] { case x if fn(x).isDefined => fn(x).get }
+      val cp = ag.collectBefore[Int] { case x if fn(x).isDefined => fn(x).get }
       val fp = ag.composePrepare[Int](fn(_).get).filterBefore[Int](fn(_).isDefined)
       cp(in) == fp(in)
     }

--- a/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
@@ -135,12 +135,33 @@ class AggregatorLaws extends CheckProperties {
     }
   }
   property("Aggregator.sortedTake same as List.sorted.take") {
-    // sortByTake currently fails this law
     forAll { (in: List[Int], t0: Int) =>
       val t = math.max(t0, 1)
       val l = in.sorted.take(t)
       val a = (Aggregator.sortedTake[Int](t).apply(in))
       l == a
+    }
+  }
+  property("Aggregator.sortByTake same as List.sortBy(fn).take") {
+    forAll { (in: List[Int], t0: Int, fn: Int => Int) =>
+      val t = math.max(t0, 1)
+      val l = in.sortBy(fn).take(t)
+      val a = (Aggregator.sortByTake(t)(fn).apply(in))
+      // since we considered two things equivalent under fn,
+      // we have to use that here:
+      val ord = Ordering.Iterable(Ordering.by(fn))
+      ord.equiv(l, a)
+    }
+  }
+  property("Aggregator.sortByReverseTake same as List.sortBy(fn).reverse.take") {
+    forAll { (in: List[Int], t0: Int, fn: Int => Int) =>
+      val t = math.max(t0, 1)
+      val l = in.sortBy(fn).reverse.take(t)
+      val a = (Aggregator.sortByReverseTake(t)(fn).apply(in))
+      // since we considered two things equivalent under fn,
+      // we have to use that here:
+      val ord = Ordering.Iterable(Ordering.by(fn))
+      ord.equiv(l, a)
     }
   }
   property("Aggregator.immutableSortedTake same as List.sorted.take") {


### PR DESCRIPTION
adds `collectBefore` to MonoidAggregator.

Also too a moment to increase Aggregator test coverage, which is nice. Thanks to this plugin for helping me find untested methods:

https://chrome.google.com/webstore/detail/codecov-extension/keefkhehidemnokodkdkejapdgfjmijf