### PR TITLE
Bloom filter distance function

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -377,7 +377,7 @@ sealed abstract class BF[A] extends java.io.Serializable {
    * `a` and `b`. The distance is defined as the number of bits that
    * need to change to in order to transform one filter into the other.
    */
-  def hammingDistance[A](that: BF[A]): Int = {
+  def hammingDistance(that: BF[A]): Int = {
     assert((this.width == that.width) && (this.numHashes == that.numHashes),
       "To compute a distance between two Bloom filters they" +
         "have to be of equal width and the same number of hashes." +

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -379,9 +379,9 @@ sealed abstract class BF[A] extends java.io.Serializable {
    */
   def hammingDistance(that: BF[A]): Int = {
     assert((this.width == that.width) && (this.numHashes == that.numHashes),
-      "To compute a distance between two Bloom filters they" +
-        "have to be of equal width and the same number of hashes." +
-        s"A was of width ${this.width} and had ${this.numHashes}, and" +
+      "To compute a distance between two Bloom filters they " +
+        "have to be of equal width and the same number of hashes. " +
+        s"A was of width ${this.width} and had ${this.numHashes}, and " +
         s"B was of width ${that.width} and had ${that.numHashes}")
 
     val aSet = this.toBitSet

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -378,12 +378,6 @@ sealed abstract class BF[A] extends java.io.Serializable {
    * need to change to in order to transform one filter into the other.
    */
   def hammingDistance(that: BF[A]): Int = {
-    assert((this.width == that.width) && (this.numHashes == that.numHashes),
-      "To compute a distance between two Bloom filters they " +
-        "have to be of equal width and the same number of hashes. " +
-        s"A was of width ${this.width} and had ${this.numHashes} hashes, and " +
-        s"B was of width ${that.width} and had ${that.numHashes} hashes.")
-
     val aSet = this.toBitSet
     val bSet = that.toBitSet
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -381,8 +381,8 @@ sealed abstract class BF[A] extends java.io.Serializable {
     assert((this.width == that.width) && (this.numHashes == that.numHashes),
       "To compute a distance between two Bloom filters they " +
         "have to be of equal width and the same number of hashes. " +
-        s"A was of width ${this.width} and had ${this.numHashes}, and " +
-        s"B was of width ${that.width} and had ${that.numHashes}")
+        s"A was of width ${this.width} and had ${this.numHashes} hashes, and " +
+        s"B was of width ${that.width} and had ${that.numHashes} hashes.")
 
     val aSet = this.toBitSet
     val bSet = that.toBitSet

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -402,7 +402,7 @@ class BloomFilterTest extends WordSpec with Matchers {
   }
 
   "BloomFilters" should {
-    "should not be able to compute Hamming distance to each other when they are note" +
+    "should not be able to compute Hamming distance to each other when they are not " +
       "of equal width and have the same number of hashes" in {
 
         val elems = Seq("A", "B", "C")

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -60,12 +60,21 @@ class BloomFilterLaws extends CheckProperties {
     }
   }
 
+  property("the distance between a filter and an empty filter should be the the number of bits" +
+    "set in the existing filter") {
+    forAll { (a: BF[String]) =>
+      a.hammingDistance(bfMonoid.zero) == a.numBits
+    }
+  }
+
   property("all equivalent filters should have 0 Hamming distance") {
     forAll { (a: BF[String], b: BF[String]) =>
       if (Equiv[BF[String]].equiv(a, b))
         a.hammingDistance(b) == 0
-      else
-        a.hammingDistance(b) != 0
+      else {
+        val dist = a.hammingDistance(b)
+        (dist > 0) && (dist <= a.width)
+      }
     }
   }
 
@@ -449,6 +458,11 @@ class BloomFilterTest extends WordSpec with Matchers {
 
       val distance2 = thirdBloomFilter.hammingDistance(forthBloomFilter)
       assert(distance2 === 8)
+
+      val emptyBloomFilter = createBFWithItems(List())
+      val distanceToEmpty = thirdBloomFilter.hammingDistance(emptyBloomFilter)
+      assert(distanceToEmpty === thirdBloomFilter.numBits)
+
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -56,22 +56,22 @@ class BloomFilterLaws extends CheckProperties {
 
   property("the distance between a filter and itself should be 0") {
     forAll { (a: BF[String]) =>
-      BloomFilter.hammingDistance(a, a) == 0
+      a.hammingDistance(a) == 0
     }
   }
 
   property("all equivalent filters should have 0 Hamming distance") {
     forAll { (a: BF[String], b: BF[String]) =>
       if (Equiv[BF[String]].equiv(a, b))
-        BloomFilter.hammingDistance(a, b) == 0
+        a.hammingDistance(b) == 0
       else
-        BloomFilter.hammingDistance(a, b) != 0
+        a.hammingDistance(b) != 0
     }
   }
 
-  property("distance between filters should be symetrical") {
+  property("distance between filters should be symmetrical") {
     forAll { (a: BF[String], b: BF[String]) =>
-      BloomFilter.hammingDistance(a, b) == BloomFilter.hammingDistance(b, a)
+      a.hammingDistance(b) == b.hammingDistance(a)
     }
   }
 
@@ -417,11 +417,11 @@ class BloomFilterTest extends WordSpec with Matchers {
         val bf3 = bfMonoid3.create(elems: _*)
 
         assertThrows[AssertionError]{
-          BloomFilter.hammingDistance(bf1, bf2)
+          bf1.hammingDistance(bf2)
         }
 
         assertThrows[AssertionError]{
-          BloomFilter.hammingDistance(bf2, bf3)
+          bf2.hammingDistance(bf3)
         }
 
       }
@@ -439,7 +439,7 @@ class BloomFilterTest extends WordSpec with Matchers {
       val firstBloomFilter = createBFWithItems(Seq("A"))
       val secondBloomFilter = createBFWithItems(Seq("C"))
 
-      val distance1 = BloomFilter.hammingDistance(firstBloomFilter, secondBloomFilter)
+      val distance1 = firstBloomFilter.hammingDistance(secondBloomFilter)
       assert(distance1 === 4)
 
       val thirdBloomFilter = createBFWithItems(Seq("A", "B", "C"))
@@ -447,7 +447,7 @@ class BloomFilterTest extends WordSpec with Matchers {
       // even though these examples are small and thus sparse.
       val forthBloomFilter = toDense(createBFWithItems(Seq("C", "D", "E")))
 
-      val distance2 = BloomFilter.hammingDistance(thirdBloomFilter, forthBloomFilter)
+      val distance2 = thirdBloomFilter.hammingDistance(forthBloomFilter)
       assert(distance2 === 8)
     }
   }

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -60,7 +60,7 @@ class BloomFilterLaws extends CheckProperties {
     }
   }
 
-  property("the distance between a filter and an empty filter should be the the number of bits" +
+  property("the distance between a filter and an empty filter should be the number of bits" +
     "set in the existing filter") {
     forAll { (a: BF[String]) =>
       a.hammingDistance(bfMonoid.zero) == a.numBits
@@ -411,31 +411,7 @@ class BloomFilterTest extends WordSpec with Matchers {
   }
 
   "BloomFilters" should {
-    "should not be able to compute Hamming distance to each other when they are not " +
-      "of equal width and have the same number of hashes" in {
-
-        val elems = Seq("A", "B", "C")
-
-        val bfMonoid1 = new BloomFilterMonoid[String](numHashes = 4, width = 64)
-        val bf1 = bfMonoid1.create(elems: _*)
-
-        val bfMonoid2 = new BloomFilterMonoid[String](numHashes = 5, width = 64)
-        val bf2 = bfMonoid2.create(elems: _*)
-
-        val bfMonoid3 = new BloomFilterMonoid[String](numHashes = 5, width = 128)
-        val bf3 = bfMonoid3.create(elems: _*)
-
-        assertThrows[AssertionError]{
-          bf1.hammingDistance(bf2)
-        }
-
-        assertThrows[AssertionError]{
-          bf2.hammingDistance(bf3)
-        }
-
-      }
-
-    "be able to compute compute Hamming distance to each other" in {
+    "be able to compute Hamming distance to each other" in {
       import BloomFilterTestUtils._
 
       def createBFWithItems(entries: Seq[String]): BF[String] = {


### PR DESCRIPTION
I've added a function to compute the Hamming distance between two Bloom filters. I'm not entierly sure if this is general enough that it is of interest to others than me, but I though I'd make a PR and hear what you folks think.

My reason for implementing it here (and for my previous PR regarding Bloom filters) is that I'm looking at implementing Bloom trees as described by [Solomon and Kingsford (2016)](http://www.nature.com/nbt/journal/v34/n3/full/nbt.3442.html), and then they use the Hamming distance between Bloom filters to decide on the path through the tree.

Like I said, if you think that it's to niche feel free to close this and I'll simply just place it in the Bloom tree code I'm working on instead.