### PR TITLE
Commute set addition operands to avoid potentially quadratic performance

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Monoid.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Monoid.scala
@@ -152,7 +152,10 @@ class ArrayMonoid[T: ClassTag](implicit semi: Semigroup[T]) extends Monoid[Array
  */
 class SetMonoid[T] extends Monoid[Set[T]] {
   override def zero = Set[T]()
-  override def plus(left: Set[T], right: Set[T]) = left ++ right
+  override def plus(left: Set[T], right: Set[T]) = {
+    val (longer, shorter) = if (left.size > right.size) (left, right) else (right, left)
+    longer ++ shorter
+  }
   override def sumOption(items: TraversableOnce[Set[T]]): Option[Set[T]] =
     if (items.isEmpty) None
     else {

--- a/algebird-core/src/main/scala/com/twitter/algebird/Monoid.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Monoid.scala
@@ -152,10 +152,12 @@ class ArrayMonoid[T: ClassTag](implicit semi: Semigroup[T]) extends Monoid[Array
  */
 class SetMonoid[T] extends Monoid[Set[T]] {
   override def zero = Set[T]()
-  override def plus(left: Set[T], right: Set[T]) = {
-    val (longer, shorter) = if (left.size > right.size) (left, right) else (right, left)
-    longer ++ shorter
-  }
+  override def plus(left: Set[T], right: Set[T]) =
+    if (left.size > right.size) {
+      left ++ right
+    } else {
+      right ++ left
+    }
   override def sumOption(items: TraversableOnce[Set[T]]): Option[Set[T]] =
     if (items.isEmpty) None
     else {


### PR DESCRIPTION
### Summary

This PR implements a performance optimization in `SetMonoid.plus`. It ensures that the larger set will always appear on the left-hand-side of the operation. This prevents a ~quadratic when summing many small sets.

### Motivation

@avibryant and I noticed that naively summing a list of singleton sets in was super-duper slow. After a quick Scala repl experiment, we determined that performing `<small set> ++ <large set>` is dramatically _slower_ than performing `<large set> ++ <small set>`:

```
# Completes ~immediately:
scala> scala.collection.immutable.Range(0, 100000).foldLeft(Set.empty[Int]) {case (s, i) => s ++ Set(i)}
res2: scala.collection.immutable.Set[Int] = Set(...
# Did not complete within O(1 minute) and pinned a core on my laptop:
scala> scala.collection.immutable.Range(0, 100000).foldLeft(Set.empty[Int]) {case (s, i) => Set(i) ++ s}
```

### Testing

`sbt algebird-test/test`
