### PR TITLE
Optimize Hamming distance for Bloom Filters

### DIFF
--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterDistanceBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterDistanceBenchmark.scala
@@ -1,0 +1,85 @@
+package com.twitter.algebird
+package benchmark
+
+import org.openjdk.jmh.annotations._
+
+object BloomFilterDistanceBenchmark {
+
+  def toSparse[A](bf: BF[A]): BFSparse[A] = bf match {
+    case BFZero(hashes, width) => BFSparse(hashes, RichCBitSet(), width)
+    case BFItem(item, hashes, width) => BFSparse(hashes, RichCBitSet.fromArray(hashes(item)), width)
+    case bfs @ BFSparse(_, _, _) => bfs
+    case BFInstance(hashes, bitset, width) => BFSparse(hashes, RichCBitSet.fromBitSet(bitset), width)
+  }
+
+  def toDense[A](bf: BF[A]): BFInstance[A] = bf match {
+    case BFZero(hashes, width) => BFInstance.empty[A](hashes, width)
+    case BFItem(item, hashes, width) =>
+      val bs = LongBitSet.empty(width)
+      bs += hashes(item)
+      BFInstance(hashes, bs.toBitSetNoCopy, width)
+    case bfs @ BFSparse(hashes, bitset, width) => bfs.dense
+    case bfi @ BFInstance(hashes, bitset, width) => bfi
+  }
+
+  @State(Scope.Benchmark)
+  class BloomFilterState {
+
+    import BloomFilterCreateBenchmark.createRandomString
+
+    val nbrOfElements: Int = 1000
+    val falsePositiveRate = 0.01
+
+    def randomElements = BloomFilterCreateBenchmark.createRandomString(nbrOfElements, 10)
+
+    val emptyBF1: BF[String] = BloomFilter[String](nbrOfElements, falsePositiveRate).zero
+    val emptyBF2: BF[String] = BloomFilter[String](nbrOfElements, falsePositiveRate).zero
+
+    val sparseBF1: BF[String] =
+      toSparse(BloomFilter[String](nbrOfElements, falsePositiveRate).create(randomElements: _*))
+    val sparesBF2: BF[String] =
+      toSparse(BloomFilter[String](nbrOfElements, falsePositiveRate).create(randomElements: _*))
+
+    val denseBF1: BF[String] = toDense(
+      BloomFilter[String](nbrOfElements, falsePositiveRate).create(randomElements: _*))
+    val denseBF2: BF[String] = toDense(
+      BloomFilter[String](nbrOfElements, falsePositiveRate).create(randomElements: _*))
+
+  }
+}
+
+class BloomFilterDistanceBenchmark {
+
+  import BloomFilterDistanceBenchmark._
+
+  @Benchmark
+  def distanceOfEmptyVsEmpty(bloomFilterState: BloomFilterState): Int = {
+    bloomFilterState.emptyBF1.hammingDistance(bloomFilterState.emptyBF2)
+  }
+
+  @Benchmark
+  def distanceOfEmptyVsSparse(bloomFilterState: BloomFilterState): Int = {
+    bloomFilterState.emptyBF1.hammingDistance(bloomFilterState.sparseBF1)
+  }
+
+  @Benchmark
+  def distanceOfEmptyVsDense(bloomFilterState: BloomFilterState): Int = {
+    bloomFilterState.emptyBF1.hammingDistance(bloomFilterState.denseBF1)
+  }
+
+  @Benchmark
+  def distanceOfSparseVsSparse(bloomFilterState: BloomFilterState): Int = {
+    bloomFilterState.sparseBF1.hammingDistance(bloomFilterState.sparesBF2)
+  }
+
+  @Benchmark
+  def distanceOfSparseVsDense(bloomFilterState: BloomFilterState): Int = {
+    bloomFilterState.sparseBF1.hammingDistance(bloomFilterState.denseBF1)
+  }
+
+  @Benchmark
+  def distanceOfDenseVsDense(bloomFilterState: BloomFilterState): Int = {
+    bloomFilterState.denseBF1.hammingDistance(bloomFilterState.denseBF1)
+  }
+
+}

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterDistanceBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterDistanceBenchmark.scala
@@ -25,8 +25,6 @@ object BloomFilterDistanceBenchmark {
   @State(Scope.Benchmark)
   class BloomFilterState {
 
-    import BloomFilterCreateBenchmark.createRandomString
-
     val nbrOfElements: Int = 1000
     val falsePositiveRate = 0.01
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -378,16 +378,21 @@ sealed abstract class BF[A] extends java.io.Serializable {
    * need to change to in order to transform one filter into the other.
    */
   def hammingDistance(that: BF[A]): Int = {
-    val aSet = this.toBitSet
-    val bSet = that.toBitSet
 
-    if (aSet.isEmpty) {
-      that.numBits
-    } else if (bSet.isEmpty) {
-      this.numBits
-    } else {
-      (aSet ^ bSet).size
+    (this, that) match {
+      // Comparing with empty filter should give number
+      // of bits in other set
+      case (x: BFZero[A], y: BFZero[A]) => 0
+      case (x: BFZero[A], y: BF[A]) => y.numBits
+      case (x: BF[A], y: BFZero[A]) => x.numBits
+
+      // Special case for Sparse vs. Sparse
+      case (x: BFSparse[A], y: BFSparse[A]) => x.bits.xorCardinality(y.bits)
+
+      // Otherwise compare as bit sets
+      case (_, _) => (this.toBitSet ^ that.toBitSet).size
     }
+
   }
 }
 


### PR DESCRIPTION
I've introduced a basic benchmark for the computation of Hamming Distance between two Bloom Filters. The benchmark code itself duplicates some code from the tests since I couldn't figure out if it was possible to import the test utility code from the test module, and I didn't know where else to place it.

Before optimization I got the following benchmark results:

```
[info] Benchmark                                               Mode  Cnt         Score          Error  Units
[info] BloomFilterDistanceBenchmark.distanceOfDenseVsDense    thrpt    3   2723595.987 ±   548998.665  ops/s
[info] BloomFilterDistanceBenchmark.distanceOfEmptyVsDense    thrpt    3   7004540.087 ±  5203376.533  ops/s
[info] BloomFilterDistanceBenchmark.distanceOfEmptyVsEmpty    thrpt    3  10893632.441 ± 10973525.424  ops/s
[info] BloomFilterDistanceBenchmark.distanceOfEmptyVsSparse   thrpt    3     24994.400 ±     9480.975  ops/s
[info] BloomFilterDistanceBenchmark.distanceOfSparseVsDense   thrpt    3     43607.790 ±      667.854  ops/s
[info] BloomFilterDistanceBenchmark.distanceOfSparseVsSparse  thrpt    3     22042.031 ±     8375.452  ops/s
```
And after optimizing the `hammingDistance` function I got the following:

```
[info] Benchmark                                               Mode  Cnt          Score          Error  Units
[info] BloomFilterDistanceBenchmark.distanceOfDenseVsDense    thrpt    3    3322006.369 ±  1060777.755  ops/s
[info] BloomFilterDistanceBenchmark.distanceOfEmptyVsDense    thrpt    3   10810094.920 ±  7810596.149  ops/s
[info] BloomFilterDistanceBenchmark.distanceOfEmptyVsEmpty    thrpt    3  249574048.862 ± 68069466.861  ops/s
[info] BloomFilterDistanceBenchmark.distanceOfEmptyVsSparse   thrpt    3      57779.455 ±    14319.510  ops/s
[info] BloomFilterDistanceBenchmark.distanceOfSparseVsDense   thrpt    3      46475.534 ±     8134.608  ops/s
[info] BloomFilterDistanceBenchmark.distanceOfSparseVsSparse  thrpt    3    5398034.322 ±  1136571.252  ops/s
```

A simple view of this is just looking at the quotas of the before and after optimization results:

![image](https://cloud.githubusercontent.com/assets/1788862/22265776/c2456144-e27d-11e6-84b2-886a6d202237.png)

The most significant improvement is seen in calculating the distance between two sparse filters, which is to be expected, since this avoids the slow conversion of the sparse bit set to a normal bit set.