### PR TITLE
Use more algebra types

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird
 
+import algebra.CommutativeGroup
+
 /**
  * Tracks the count and mean value of Doubles in a data stream.
  *
@@ -128,7 +130,7 @@ object AveragedValue {
  *
  * @define T `AveragedValue`
  */
-object AveragedGroup extends Group[AveragedValue] {
+object AveragedGroup extends Group[AveragedValue] with CommutativeGroup[AveragedValue] {
   import MomentsGroup.getCombinedMean
 
   val zero = AveragedValue(0L, 0.0)

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -16,11 +16,11 @@ limitations under the License.
 
 package com.twitter.algebird
 
-import scala.collection.immutable.BitSet
-import scala.collection.JavaConverters._
-
-import com.googlecode.javaewah.{ EWAHCompressedBitmap => CBitSet }
+import algebra.BoundedSemilattice
 import com.googlecode.javaewah.IntIterator
+import com.googlecode.javaewah.{ EWAHCompressedBitmap => CBitSet }
+import scala.collection.JavaConverters._
+import scala.collection.immutable.BitSet
 
 object RichCBitSet {
   def apply(xs: Int*): CBitSet = fromArray(xs.toArray)
@@ -183,7 +183,7 @@ object BloomFilter {
  * http://en.wikipedia.org/wiki/Bloom_filter
  *
  */
-case class BloomFilterMonoid[A](numHashes: Int, width: Int)(implicit hash: Hash128[A]) extends Monoid[BF[A]] {
+case class BloomFilterMonoid[A](numHashes: Int, width: Int)(implicit hash: Hash128[A]) extends Monoid[BF[A]] with BoundedSemilattice[BF[A]] {
   val hashes: BFHash[A] = BFHash[A](numHashes, width)(hash)
 
   val zero: BF[A] = BFZero[A](hashes, width)

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird
 
+import algebra.CommutativeMonoid
+
 /**
  * A Count-Min sketch is a probabilistic data structure used for summarizing
  * streams of data in sub-linear space.
@@ -97,7 +99,7 @@ package com.twitter.algebird
  *           include Spire's `SafeLong` and `Numerical` data types (https://github.com/non/spire), though Algebird does
  *           not include the required implicits for CMS-hashing (cf. [[CMSHasherImplicits]].
  */
-class CMSMonoid[K: CMSHasher](eps: Double, delta: Double, seed: Int, maxExactCountOpt: Option[Int] = None) extends Monoid[CMS[K]] {
+class CMSMonoid[K: CMSHasher](eps: Double, delta: Double, seed: Int, maxExactCountOpt: Option[Int] = None) extends Monoid[CMS[K]] with CommutativeMonoid[CMS[K]] {
 
   val params = {
     val hashes: Seq[CMSHash[K]] = CMSFunctions.generateHashes(eps, delta, seed)

--- a/algebird-core/src/main/scala/com/twitter/algebird/First.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/First.scala
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package com.twitter.algebird
 
+import algebra.Band
+
 /**
  * Tracks the "least recent", or earliest, wrapped instance of `T` by
  * the order in which items are seen.
@@ -51,8 +53,8 @@ private[algebird] sealed abstract class FirstInstances {
    * head of the `TraversableOnce` instance, leaving the rest
    * untouched.
    */
-  def firstSemigroup[T]: Semigroup[T] =
-    new Semigroup[T] {
+  def firstSemigroup[T]: Semigroup[T] with Band[T] =
+    new Semigroup[T] with Band[T] {
       def plus(l: T, r: T): T = l
 
       override def sumOption(iter: TraversableOnce[T]): Option[T] =
@@ -64,7 +66,7 @@ private[algebird] sealed abstract class FirstInstances {
    * implementation always returns the first (ie, the left) `First[T]`
    * argument.
    */
-  implicit def semigroup[T]: Semigroup[First[T]] = firstSemigroup[First[T]]
+  implicit def semigroup[T]: Semigroup[First[T]] with Band[First[T]] = firstSemigroup[First[T]]
 }
 
 /**

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -19,6 +19,8 @@ package com.twitter.algebird
 import java.nio.ByteBuffer
 import java.lang.Math
 
+import algebra.BoundedSemilattice
+
 /** A super lightweight (hopefully) version of BitSet */
 @deprecated("This is no longer used.", since = "0.12.3")
 case class BitSetLite(in: Array[Byte]) {
@@ -550,7 +552,7 @@ case class DenseHLL(bits: Int, v: Bytes) extends HLL {
  * Error is about 1.04/sqrt(2^{bits}), so you want something like 12 bits for 1% error
  * which means each HLLInstance is about 2^{12} = 4kb per instance.
  */
-class HyperLogLogMonoid(val bits: Int) extends Monoid[HLL] {
+class HyperLogLogMonoid(val bits: Int) extends Monoid[HLL] with BoundedSemilattice[HLL] {
   import HyperLogLog._
 
   assert(bits > 3, "Use at least 4 bits (2^(bits) = bytes consumed)")

--- a/algebird-core/src/main/scala/com/twitter/algebird/Last.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Last.scala
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package com.twitter.algebird
 
+import algebra.Band
+
 /**
  * Tracks the "most recent", or last, wrapped instance of `T` by the
  * order in which items are seen.
@@ -47,14 +49,22 @@ private[algebird] sealed abstract class LastInstances {
    * Returns a [[Semigroup]] instance with a `plus` implementation
    * that always returns the last (ie, the right) `T` argument.
    */
-  def lastSemigroup[T]: Semigroup[T] = Semigroup.from { (l, r) => r }
+  def lastSemigroup[T]: Semigroup[T] with Band[T] =
+    new Semigroup[T] with Band[T] {
+      def plus(l: T, r: T): T = r
+      override def sumOption(ts: TraversableOnce[T]): Option[T] = {
+        var res: Option[T] = None
+        ts.foreach { t => res = Some(t) }
+        res
+      }
+    }
 
   /**
    * Returns a [[Semigroup]] instance for [[Last]][T]. The `plus`
    * implementation always returns the last (ie, the right) `Last[T]`
    * argument.
    */
-  implicit def semigroup[T]: Semigroup[Last[T]] = lastSemigroup[Last[T]]
+  implicit def semigroup[T]: Semigroup[Last[T]] with Band[Last[T]] = lastSemigroup[Last[T]]
 }
 
 /**

--- a/algebird-core/src/main/scala/com/twitter/algebird/MapAlgebra.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/MapAlgebra.scala
@@ -15,10 +15,10 @@ limitations under the License.
 */
 package com.twitter.algebird
 
-import scala.collection.{ Map => ScMap }
-import scala.collection.mutable.{ Builder, Map => MMap }
-
 import com.twitter.algebird.macros.{ Cuber, Roller }
+import scala.collection.mutable.{ Builder, Map => MMap }
+import scala.collection.{ Map => ScMap }
+import algebra.ring.Rng
 
 trait MapOperations[K, V, M <: ScMap[K, V]] {
   def add(oldMap: M, kv: (K, V)): M
@@ -132,15 +132,10 @@ class ScMapGroup[K, V](implicit val group: Group[V]) extends ScMapMonoid[K, V]()
 /**
  * You can think of this as a Sparse vector ring
  */
-trait GenericMapRing[K, V, M <: ScMap[K, V]] extends Ring[M] with MapOperations[K, V, M] {
+trait GenericMapRing[K, V, M <: ScMap[K, V]] extends Rng[M] with MapOperations[K, V, M] {
 
   implicit def ring: Ring[V]
 
-  // It is possible to implement this, but we need a special "identity map" which we
-  // deal with as if it were map with all possible keys (.get(x) == ring.one for all x).
-  // Then we have to manage the delta from this map as we add elements.  That said, it
-  // is not actually needed in matrix multiplication, so we are punting on it for now.
-  override def one = sys.error("multiplicative identity for Map unimplemented")
   override def times(x: M, y: M): M = {
     val (big, small, bigOnLeft) = if (x.size > y.size) { (x, y, true) } else { (y, x, false) }
     small.foldLeft(zero) { (oldMap, kv) =>

--- a/algebird-core/src/main/scala/com/twitter/algebird/Max.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Max.scala
@@ -78,12 +78,14 @@ private[algebird] sealed abstract class MaxInstances {
    * @param zero identity of the returned [[Monoid]] instance
    * @note `zero` must be `<=` every element of `T` for the returned instance to be lawful.
    */
-  def monoid[T: Ordering](z: => T): Monoid[Max[T]] with BoundedSemilattice[Max[T]] =
+  def monoid[T: Ordering](zero: => T): Monoid[Max[T]] with BoundedSemilattice[Max[T]] = {
+    val z = zero // avoid confusion below when overriding zero
     new Monoid[Max[T]] with BoundedSemilattice[Max[T]] {
       val zero = Max(z)
       val ord = implicitly[Ordering[T]]
       def plus(l: Max[T], r: Max[T]): Max[T] = if (ord.gteq(l.get, r.get)) l else r
     }
+  }
 
   /**
    * Returns a [[Semigroup]] instance for [[Max]][T]. The `plus`
@@ -104,10 +106,18 @@ private[algebird] sealed abstract class MaxInstances {
   /** [[Monoid]] for [[Max]][Long] with `zero == Long.MinValue` */
   implicit def longMonoid: Monoid[Max[Long]] with BoundedSemilattice[Max[Long]] = monoid(Long.MinValue)
 
-  /** [[Monoid]] for [[Max]][Double] with `zero == Double.MinValue` */
+  /**
+   * [[Monoid]] for [[Max]][Double] with `zero == Double.MinValue`
+   * Note: MinValue > NegativeInfinity, but people may
+   * be relying on this emitting a non-infinite number. Sadness
+   */
   implicit def doubleMonoid: Monoid[Max[Double]] with BoundedSemilattice[Max[Double]] = monoid(Double.MinValue)
 
-  /** [[Monoid]] for [[Max]][Float] with `zero == Float.MinValue` */
+  /**
+   * [[Monoid]] for [[Max]][Float] with `zero == Float.MinValue`
+   * Note: MinValue > NegativeInfinity, but people may
+   * be relying on this emitting a non-infinite number. Sadness
+   */
   implicit def floatMonoid: Monoid[Max[Float]] with BoundedSemilattice[Max[Float]] = monoid(Float.MinValue)
 
   /** [[Monoid]] for [[Max]][String] with `zero == ""` */

--- a/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
@@ -76,12 +76,14 @@ private[algebird] sealed abstract class MinInstances {
    * @param zero identity of the returned [[Monoid]] instance
    * @note `zero` must be `>=` every element of `T` for the returned instance to be lawful.
    */
-  def monoid[T: Ordering](z: => T): Monoid[Min[T]] with BoundedSemilattice[Min[T]] =
+  def monoid[T: Ordering](zero: => T): Monoid[Min[T]] with BoundedSemilattice[Min[T]] = {
+    val z = zero // avoid confusion below when overriding zero
     new Monoid[Min[T]] with BoundedSemilattice[Min[T]] {
       val zero = Min(z)
       val ord = implicitly[Ordering[T]]
       def plus(l: Min[T], r: Min[T]): Min[T] = if (ord.lteq(l.get, r.get)) l else r
     }
+  }
 
   /**
    * Returns a [[Semigroup]] instance for [[Min]][T]. The `plus`
@@ -99,10 +101,18 @@ private[algebird] sealed abstract class MinInstances {
   /** [[Monoid]] for [[Min]][Long] with `zero == Long.MaxValue` */
   implicit def longMonoid: Monoid[Min[Long]] with BoundedSemilattice[Min[Long]] = monoid(Long.MaxValue)
 
-  /** [[Monoid]] for [[Min]][Double] with `zero == Double.MaxValue` */
+  /**
+   * [[Monoid]] for [[Min]][Double] with `zero == Double.MaxValue`
+   * Note: MaxValue < PositiveInfinity, but people may
+   * be relying on this emitting a non-infinite number. Sadness
+   */
   implicit def doubleMonoid: Monoid[Min[Double]] with BoundedSemilattice[Min[Double]] = monoid(Double.MaxValue)
 
-  /** [[Monoid]] for [[Min]][Float] with `zero == Float.MaxValue` */
+  /**
+   * [[Monoid]] for [[Min]][Float] with `zero == Float.MaxValue`
+   * Note: MaxValue < PositiveInfinity, but people may
+   * be relying on this emitting a non-infinite number. Sadness
+   */
   implicit def floatMonoid: Monoid[Min[Float]] with BoundedSemilattice[Min[Float]] = monoid(Float.MaxValue)
 }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package com.twitter.algebird
 
+import algebra.{ BoundedSemilattice, Semilattice }
+
 /**
  * Tracks the minimum wrapped instance of some ordered type `T`.
  *
@@ -57,17 +59,15 @@ object Min extends MinInstances {
    * Returns a [[Semigroup]] instance with a `plus` implementation
    * that always returns the minimum `T` argument.
    */
-  def minSemigroup[T](implicit ord: Ordering[T]): Semigroup[T] =
-    Semigroup.from { (l: T, r: T) => ord.min(l, r) }
+  def minSemigroup[T](implicit ord: Ordering[T]): Semigroup[T] with Semilattice[T] =
+    new Semigroup[T] with Semilattice[T] {
+      def plus(l: T, r: T) = ord.min(l, r)
+    }
 }
 
 private[algebird] sealed abstract class MinInstances {
   implicit def equiv[T](implicit eq: Equiv[T]): Equiv[Min[T]] = Equiv.by(_.get)
   implicit def ordering[T: Ordering]: Ordering[Min[T]] = Ordering.by(_.get)
-
-  private[this] def plus[T](implicit ord: Ordering[T]) = {
-    (l: Min[T], r: Min[T]) => if (ord.lteq(l.get, r.get)) l else r
-  }
 
   /**
    * Returns a [[Monoid]] instance for [[Min]][T] that combines
@@ -76,25 +76,34 @@ private[algebird] sealed abstract class MinInstances {
    * @param zero identity of the returned [[Monoid]] instance
    * @note `zero` must be `>=` every element of `T` for the returned instance to be lawful.
    */
-  def monoid[T: Ordering](zero: => T): Monoid[Min[T]] = Monoid.from(Min(zero))(plus)
+  def monoid[T: Ordering](z: => T): Monoid[Min[T]] with BoundedSemilattice[Min[T]] =
+    new Monoid[Min[T]] with BoundedSemilattice[Min[T]] {
+      val zero = Min(z)
+      val ord = implicitly[Ordering[T]]
+      def plus(l: Min[T], r: Min[T]): Min[T] = if (ord.lteq(l.get, r.get)) l else r
+    }
 
   /**
    * Returns a [[Semigroup]] instance for [[Min]][T]. The `plus`
    * implementation always returns the minimum `Min[T]` argument.
    */
-  implicit def semigroup[T: Ordering]: Semigroup[Min[T]] = Semigroup.from(plus)
+  implicit def semigroup[T: Ordering]: Semigroup[Min[T]] with Semilattice[Min[T]] =
+    new Semigroup[Min[T]] with Semilattice[Min[T]] {
+      val ord = implicitly[Ordering[T]]
+      def plus(l: Min[T], r: Min[T]): Min[T] = if (ord.gteq(l.get, r.get)) l else r
+    }
 
   /** [[Monoid]] for [[Min]][Int] with `zero == Int.MaxValue` */
-  implicit def intMonoid: Monoid[Min[Int]] = monoid(Int.MaxValue)
+  implicit def intMonoid: Monoid[Min[Int]] with BoundedSemilattice[Min[Int]] = monoid(Int.MaxValue)
 
   /** [[Monoid]] for [[Min]][Long] with `zero == Long.MaxValue` */
-  implicit def longMonoid: Monoid[Min[Long]] = monoid(Long.MaxValue)
+  implicit def longMonoid: Monoid[Min[Long]] with BoundedSemilattice[Min[Long]] = monoid(Long.MaxValue)
 
   /** [[Monoid]] for [[Min]][Double] with `zero == Double.MaxValue` */
-  implicit def doubleMonoid: Monoid[Min[Double]] = monoid(Double.MaxValue)
+  implicit def doubleMonoid: Monoid[Min[Double]] with BoundedSemilattice[Min[Double]] = monoid(Double.MaxValue)
 
   /** [[Monoid]] for [[Min]][Float] with `zero == Float.MaxValue` */
-  implicit def floatMonoid: Monoid[Min[Float]] = monoid(Float.MaxValue)
+  implicit def floatMonoid: Monoid[Min[Float]] with BoundedSemilattice[Min[Float]] = monoid(Float.MaxValue)
 }
 
 /**

--- a/algebird-core/src/main/scala/com/twitter/algebird/MinPlus.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/MinPlus.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird
 
+import algebra.ring.Rig
+
 /*
  * The Min-Plus algebra, or tropical semi-ring is useful for computing shortest
  * paths on graphs:
@@ -30,10 +32,8 @@ sealed trait MinPlus[+V] extends Any with java.io.Serializable
 case object MinPlusZero extends MinPlus[Nothing]
 case class MinPlusValue[V](get: V) extends AnyVal with MinPlus[V]
 
-class MinPlusSemiring[V](implicit monoid: Monoid[V], ord: Ordering[V]) extends Ring[MinPlus[V]] {
+class MinPlusSemiring[V](implicit monoid: Monoid[V], ord: Ordering[V]) extends Rig[MinPlus[V]] {
   override def zero = MinPlusZero
-  override def negate(mv: MinPlus[V]) =
-    sys.error("MinPlus is a semi-ring, there is no additive inverse")
   override def one: MinPlus[V] = MinPlusValue(monoid.zero)
   // a+b = min(a,b)
   override def plus(left: MinPlus[V], right: MinPlus[V]) =
@@ -54,5 +54,9 @@ class MinPlusSemiring[V](implicit monoid: Monoid[V], ord: Ordering[V]) extends R
 }
 
 object MinPlus extends java.io.Serializable {
-  implicit def semiring[V: Monoid: Ordering]: Ring[MinPlus[V]] = new MinPlusSemiring[V]
+  /**
+   * This is unsafe but here for legacy reasons
+   */
+  implicit def semiring[V: Monoid: Ordering]: Ring[MinPlus[V]] = new UnsafeFromAlgebraRig(rig[V])
+  implicit def rig[V: Monoid: Ordering]: Rig[MinPlus[V]] = new MinPlusSemiring[V]
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/MomentsGroup.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/MomentsGroup.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.algebird
 
+import algebra.CommutativeGroup
+
 /**
  * A class to calculate the first five central moments over a sequence of Doubles.
  * Given the first five central moments, we can then calculate metrics like skewness
@@ -49,7 +51,7 @@ case class Moments(m0: Long, m1: Double, m2: Double, m3: Double, m4: Double) {
 }
 
 object Moments {
-  implicit val group: Group[Moments] = MomentsGroup
+  implicit val group: Group[Moments] with CommutativeGroup[Moments] = MomentsGroup
   val aggregator = MomentsAggregator
 
   def numericAggregator[N](implicit num: Numeric[N]): MonoidAggregator[N, Moments, Moments] =
@@ -69,7 +71,7 @@ object Moments {
 /**
  * A monoid to perform moment calculations.
  */
-object MomentsGroup extends Group[Moments] {
+object MomentsGroup extends Group[Moments] with CommutativeGroup[Moments] {
 
   /**
    * When combining averages, if the counts sizes are too close we

--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -161,6 +161,12 @@ class FromAlgebraRing[T](r: ARing[T]) extends Ring[T] {
   override def product(ts: TraversableOnce[T]): T = r.product(ts)
 }
 
+/**
+ * In some legacy cases, we have implemented Rings where we lacked
+ * the full laws. This allows you to be precise (only implement
+ * the structure you have), but unsafely use it as a Ring in legacy code
+ * that is expecting a Ring.
+ */
 class UnsafeFromAlgebraRig[T](r: Rig[T]) extends Ring[T] {
   override def zero: T = r.zero
   override def one: T = r.one
@@ -175,6 +181,12 @@ class UnsafeFromAlgebraRig[T](r: Rig[T]) extends Ring[T] {
   override def product(ts: TraversableOnce[T]): T = r.product(ts)
 }
 
+/**
+ * In some legacy cases, we have implemented Rings where we lacked
+ * the full laws. This allows you to be precise (only implement
+ * the structure you have), but unsafely use it as a Ring in legacy code
+ * that is expecting a Ring.
+ */
 class UnsafeFromAlgebraRng[T](r: Rng[T]) extends Ring[T] {
   override def zero: T = r.zero
   override def one: T =
@@ -187,7 +199,7 @@ class UnsafeFromAlgebraRng[T](r: Rng[T]) extends Ring[T] {
   override def times(a: T, b: T): T = r.times(a, b)
   override def product(ts: TraversableOnce[T]): T =
     if (ts.isEmpty) one
-    else ts.reduce(r.times)
+    else ts.reduce(r.times) // avoid calling one, since that will throw here
 }
 
 private[algebird] trait RingImplicits0 extends NumericRingProvider {

--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package com.twitter.algebird
 
 import java.lang.{ Integer => JInt, Short => JShort, Long => JLong, Float => JFloat, Double => JDouble, Boolean => JBool }
-import algebra.ring.{ Ring => ARing }
+import algebra.ring.{ Ring => ARing, Rig, Rng }
 import algebra.CommutativeGroup
 
 import scala.annotation.implicitNotFound
@@ -161,6 +161,35 @@ class FromAlgebraRing[T](r: ARing[T]) extends Ring[T] {
   override def product(ts: TraversableOnce[T]): T = r.product(ts)
 }
 
+class UnsafeFromAlgebraRig[T](r: Rig[T]) extends Ring[T] {
+  override def zero: T = r.zero
+  override def one: T = r.one
+  override def plus(a: T, b: T): T = r.plus(a, b)
+  override def negate(t: T): T =
+    sys.error(s"$r is a Rig, there is no additive inverse")
+  override def minus(a: T, b: T): T =
+    sys.error(s"$r is a Rig, there is no additive inverse")
+  override def sum(ts: TraversableOnce[T]): T = r.sum(ts)
+  override def sumOption(ts: TraversableOnce[T]): Option[T] = r.trySum(ts)
+  override def times(a: T, b: T): T = r.times(a, b)
+  override def product(ts: TraversableOnce[T]): T = r.product(ts)
+}
+
+class UnsafeFromAlgebraRng[T](r: Rng[T]) extends Ring[T] {
+  override def zero: T = r.zero
+  override def one: T =
+    sys.error(s"multiplicative identity for Rng $r unimplemented")
+  override def plus(a: T, b: T): T = r.plus(a, b)
+  override def negate(t: T): T = r.negate(t)
+  override def minus(a: T, b: T): T = r.minus(a, b)
+  override def sum(ts: TraversableOnce[T]): T = r.sum(ts)
+  override def sumOption(ts: TraversableOnce[T]): Option[T] = r.trySum(ts)
+  override def times(a: T, b: T): T = r.times(a, b)
+  override def product(ts: TraversableOnce[T]): T =
+    if (ts.isEmpty) one
+    else ts.reduce(r.times)
+}
+
 private[algebird] trait RingImplicits0 extends NumericRingProvider {
   implicit def fromAlgebraRing[T](implicit r: ARing[T]): Ring[T] =
     new FromAlgebraRing(r)
@@ -202,8 +231,14 @@ object Ring extends GeneratedRingImplicits with ProductRings with RingImplicits0
   implicit def doubleRing: Ring[Double] = DoubleRing
   implicit def jdoubleRing: Ring[JDouble] = JDoubleRing
   implicit def indexedSeqRing[T: Ring]: Ring[IndexedSeq[T]] = new IndexedSeqRing[T]
+  /**
+   * This is actually a Rng but we leave the unsafe Ring for legacy reasons
+   */
   implicit def mapRing[K, V](implicit ring: Ring[V]): Ring[Map[K, V]] =
-    new MapRing[K, V]()(ring)
+    new UnsafeFromAlgebraRng(new MapRing[K, V]()(ring))
+  /**
+   * This is actually a Rng but we leave the unsafe Ring for legacy reasons
+   */
   implicit def scMapRing[K, V](implicit ring: Ring[V]): Ring[scala.collection.Map[K, V]] =
-    new ScMapRing[K, V]()(ring)
+    new UnsafeFromAlgebraRng(new ScMapRing[K, V]()(ring))
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -16,9 +16,10 @@ limitations under the License.
 
 package com.twitter.algebird
 
-import scala.collection.breakOut
+import algebra.CommutativeMonoid
 import com.twitter.algebird.CMSHasherImplicits._
 import com.twitter.algebird.matrix.AdaptiveMatrix
+import scala.collection.breakOut
 
 /**
  * A Sketch Map is a generalized version of the Count-Min Sketch that is an
@@ -40,7 +41,7 @@ case class SketchMapHash[K](hasher: CMSHash[Long], seed: Int)(implicit serializa
  * Responsible for creating instances of SketchMap.
  */
 class SketchMapMonoid[K, V](val params: SketchMapParams[K])(implicit valueOrdering: Ordering[V], monoid: Monoid[V])
-  extends Monoid[SketchMap[K, V]] {
+  extends Monoid[SketchMap[K, V]] with CommutativeMonoid[SketchMap[K, V]] {
 
   /**
    * A zero Sketch Map is one with zero elements.


### PR DESCRIPTION
This labels many (I hope all) types we have with more precise types:

see:
https://github.com/typelevel/algebra/blob/master/docs/src/main/tut/typeclasses/overview.md

for an overview of the types.

@sritchie @piyushnarang @non please take a look. I want to get as many of these as possible added if we can so we don't break compatibility by wanting to add some we missed.