### PR TITLE
Address ambiguous implicit for Semigroup[Max[String]]

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Max.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Max.scala
@@ -67,7 +67,32 @@ object Max extends MaxInstances {
     }
 }
 
-private[algebird] sealed abstract class MaxInstances {
+private[algebird] sealed abstract class MaxInstances extends LowPriorityMaxInstances {
+  /** [[Monoid]] for [[Max]][Int] with `zero == Int.MinValue` */
+  implicit def intMonoid: Monoid[Max[Int]] with BoundedSemilattice[Max[Int]] = monoid(Int.MinValue)
+
+  /** [[Monoid]] for [[Max]][Long] with `zero == Long.MinValue` */
+  implicit def longMonoid: Monoid[Max[Long]] with BoundedSemilattice[Max[Long]] = monoid(Long.MinValue)
+
+  /**
+   * [[Monoid]] for [[Max]][Double] with `zero == Double.MinValue`
+   * Note: MinValue > NegativeInfinity, but people may
+   * be relying on this emitting a non-infinite number. Sadness
+   */
+  implicit def doubleMonoid: Monoid[Max[Double]] with BoundedSemilattice[Max[Double]] = monoid(Double.MinValue)
+
+  /**
+   * [[Monoid]] for [[Max]][Float] with `zero == Float.MinValue`
+   * Note: MinValue > NegativeInfinity, but people may
+   * be relying on this emitting a non-infinite number. Sadness
+   */
+  implicit def floatMonoid: Monoid[Max[Float]] with BoundedSemilattice[Max[Float]] = monoid(Float.MinValue)
+
+  /** [[Monoid]] for [[Max]][String] with `zero == ""` */
+  implicit def stringMonoid: Monoid[Max[String]] = monoid("")
+}
+
+private[algebird] sealed abstract class LowPriorityMaxInstances {
   implicit def equiv[T](implicit eq: Equiv[T]): Equiv[Max[T]] = Equiv.by(_.get)
   implicit def ordering[T: Ordering]: Ordering[Max[T]] = Ordering.by(_.get)
 
@@ -99,29 +124,6 @@ private[algebird] sealed abstract class MaxInstances {
       val ord = implicitly[Ordering[T]]
       def plus(l: Max[T], r: Max[T]): Max[T] = if (ord.gteq(l.get, r.get)) l else r
     }
-
-  /** [[Monoid]] for [[Max]][Int] with `zero == Int.MinValue` */
-  implicit def intMonoid: Monoid[Max[Int]] with BoundedSemilattice[Max[Int]] = monoid(Int.MinValue)
-
-  /** [[Monoid]] for [[Max]][Long] with `zero == Long.MinValue` */
-  implicit def longMonoid: Monoid[Max[Long]] with BoundedSemilattice[Max[Long]] = monoid(Long.MinValue)
-
-  /**
-   * [[Monoid]] for [[Max]][Double] with `zero == Double.MinValue`
-   * Note: MinValue > NegativeInfinity, but people may
-   * be relying on this emitting a non-infinite number. Sadness
-   */
-  implicit def doubleMonoid: Monoid[Max[Double]] with BoundedSemilattice[Max[Double]] = monoid(Double.MinValue)
-
-  /**
-   * [[Monoid]] for [[Max]][Float] with `zero == Float.MinValue`
-   * Note: MinValue > NegativeInfinity, but people may
-   * be relying on this emitting a non-infinite number. Sadness
-   */
-  implicit def floatMonoid: Monoid[Max[Float]] with BoundedSemilattice[Max[Float]] = monoid(Float.MinValue)
-
-  /** [[Monoid]] for [[Max]][String] with `zero == ""` */
-  implicit def stringMonoid: Monoid[Max[String]] = monoid("")
 
   /**
    * Returns a [[Monoid]] instance for `Max[List[T]]` that compares

--- a/algebird-test/src/test/scala/com/twitter/algebird/MaxLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MaxLaws.scala
@@ -16,6 +16,11 @@ class MaxLaws extends CheckProperties {
   // Test equiv import.
   val equiv = implicitly[Equiv[Max[Int]]]
 
+  // Testing that these ones can be found
+  val sgInt = implicitly[Semigroup[Max[Int]]]
+  val sgString = implicitly[Semigroup[Max[String]]]
+  val monoidString = implicitly[Monoid[Max[String]]]
+
   property("Max.{ +, max } works on ints") { maxTest[Int] }
 
   property("Max.aggregator returns the maximum item") {


### PR DESCRIPTION
Currently, `Max.stringMonoid ` and `Max.semigroup` collide when looking up for a `Semigroup[Max[String]]`. This PR addresses this ambiguity by giving `Max.stringMonoid` a higher priority.

Note that this problem seems to happen only for `String`, not the primitive types that have specific implicit instances too, but with more specific types. This PR still moves the latter instances along with `stringMonoid`, for readability.