### PR TITLE
Removed claim for 2.12 support from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A list of contributors to the project can be found here: [Contributors](https://
 
 Algebird modules are available on maven central. The current groupid and version for all modules is, respectively, `"com.twitter"` and  `0.13.0`.
 
-See [Algebird's page on the Scaladex](https://index.scala-lang.org/twitter/algebird) for information on all published artifacts and their associated Scala versions. Algebird currently supports Scala 2.10, 2.11 and 2.12.
+See [Algebird's page on the Scaladex](https://index.scala-lang.org/twitter/algebird) for information on all published artifacts and their associated Scala versions. Algebird currently supports Scala 2.10 and 2.11.
 
 ## Projects using Algebird
 


### PR DESCRIPTION
It's not true since algebird_2.12 is not out afaik, plus https://index.scala-lang.org/twitter/algebird says 2.10 and 2.11 only. Let me know if I'm wrong.