### PR TITLE
Re-enable mima on 0.13.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,19 @@ sudo: false
 matrix:
   include:
     - scala: 2.10.6
-      # script: ./sbt ++$TRAVIS_SCALA_VERSION clean test mimaReportBinaryIssues"
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean test
+      script: ./sbt ++$TRAVIS_SCALA_VERSION clean test mimaReportBinaryIssues"
+      #script: ./sbt ++$TRAVIS_SCALA_VERSION clean test
 
     - scala: 2.11.8
-      #script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport mimaReportBinaryIssues
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport
+      script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport mimaReportBinaryIssues
+      #script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport
       after_success:
         - bash <(curl -s https://codecov.io/bash)
 
     - scala: 2.12.1
       jdk: oraclejdk8
-      # script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "++$TRAVIS_SCALA_VERSION docs/makeMicrosite"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "++$TRAVIS_SCALA_VERSION docs/makeMicrosite"
+      #script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "++$TRAVIS_SCALA_VERSION docs/makeMicrosite"
 
 before_install:
   - export PATH=${PATH}:./vendor/bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 matrix:
   include:
     - scala: 2.10.6
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean test mimaReportBinaryIssues"
+      script: ./sbt ++$TRAVIS_SCALA_VERSION clean test mimaReportBinaryIssues
       #script: ./sbt ++$TRAVIS_SCALA_VERSION clean test
 
     - scala: 2.11.8

--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,7 @@ val noBinaryCompatCheck = Set[String]("benchmark", "caliper")
 def youngestForwardCompatible(subProj: String) =
   Some(subProj)
     .filterNot(noBinaryCompatCheck.contains(_))
-    .map { s => "com.twitter" %% ("algebird-" + s) % "0.12.2" }
+    .map { s => "com.twitter" %% ("algebird-" + s) % "0.13.0" }
 
 lazy val algebird = Project(
   id = "algebird",


### PR DESCRIPTION
would be nice to publish frequent updates and hopefully keep binary compatibility for a long time.