### PR TITLE
Mio/issue 583

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
@@ -195,8 +195,6 @@ object AdaptiveVector {
 
     Equiv.fromFunction[AdaptiveVector[V]] { (l, r) =>
       (l, r) match {
-        // don't need this case
-        // if we allow sparseVectors of different lengths
         case _ if (isZeroVector(l) && isZeroVector(r)) =>
           (l.size == 0) || (r.size == 0) || Equiv[V].equiv(l.sparseValue, r.sparseValue)
         case (l @ DenseVector(_, lsv, _), r @ DenseVector(_, rsv, _)) =>

--- a/algebird-core/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
@@ -82,47 +82,91 @@ object AdaptiveVector {
     else fromVector(toVector(v), sv)
 
   private class AVSemigroup[V: Semigroup] extends Semigroup[AdaptiveVector[V]] {
-    private def valueIsNonZero(v: V): Boolean = implicitly[Semigroup[V]] match {
-      case m: Monoid[_] => m.isNonZero(v)
-      case _ => true
+
+    private def alignSparseValues(left: AdaptiveVector[V], right: AdaptiveVector[V]): (AdaptiveVector[V], AdaptiveVector[V]) = {
+      if (left.sparseValue != right.sparseValue) {
+        if (left.denseCount > right.denseCount) (withSparse(left, right.sparseValue), right)
+        else (left, withSparse(right, left.sparseValue))
+      } else { (left, right) }
     }
 
-    def plus(left: AdaptiveVector[V], right: AdaptiveVector[V]) = {
+    def isZeroVector(v: AdaptiveVector[V]): Boolean = implicitly[Semigroup[V]] match {
+      case m: Monoid[_] =>
+        (v.size == 0) || {
+          val sparseAreZero = if (m.isNonZero(v.sparseValue)) (v.denseCount == v.size) else true
+          sparseAreZero && v.denseIterator.forall { idxv => !m.isNonZero(idxv._2) }
+        }
+      case _ => (v.size == 0)
+    }
+
+    def isZeroValue(v: V): Boolean = implicitly[Semigroup[V]] match {
+      case m: Monoid[_] => !m.isNonZero(v)
+      case _ => false
+    }
+
+    def plus(left: AdaptiveVector[V], right: AdaptiveVector[V]): AdaptiveVector[V] = {
       if (left.sparseValue != right.sparseValue) {
-        if (left.denseCount > right.denseCount) plus(withSparse(left, right.sparseValue), right)
-        else plus(left, withSparse(right, left.sparseValue))
+        val (newLeft, newRight) = alignSparseValues(left, right)
+        plus(newLeft, newRight)
       } else {
         // they have the same sparse value
         val maxSize = Ordering[Int].max(left.size, right.size)
         (left, right) match {
+          case _ if isZeroVector(left) => right
+          case _ if isZeroVector(right) => left
           case (DenseVector(lv, ls, ld), DenseVector(rv, rs, rd)) =>
             val vec = Semigroup.plus[IndexedSeq[V]](lv, rv) match {
               case v: Vector[_] => v.asInstanceOf[Vector[V]]
               case notV => Vector(notV: _*)
             }
             fromVector(vec, ls)
-
-          case _ if valueIsNonZero(left.sparseValue) =>
+          case _ if !isZeroValue(left.sparseValue) => // sparseValue is NOT monoid.zero
             fromVector(Vector(Semigroup.plus(toVector(left): IndexedSeq[V],
               toVector(right): IndexedSeq[V]): _*),
               left.sparseValue)
-          case _ => // sparse is zero:
+          case _ => // sparseValue IS zero
             fromMap(Semigroup.plus(toMap(left), toMap(right)),
               left.sparseValue,
               maxSize)
         }
       }
     }
+
+    // private def monoidPlus(left: AdaptiveVector[V], right: AdaptiveVector[V]): AdaptiveVector[V] = {
+    //   if (left.sparseValue != right.sparseValue) { monoidPlus(alignSparseValues(left, right)) }
+    //   else {
+    //     val maxSize = Ordering[Int].max(left.size, right.size)
+    //     val m = implicitly[Monoid[V]]
+    //     (left, right) match {
+    //       case _ if isZeroVector(left) => right
+    //       case _ if isZeroVector(right) => left
+    //       case (DenseVector(_, _, _), DenseVector(_, _, _)) => semigroupPlus(left, right)
+    //       case _ if m.isNonzero(left.sparseValue) => // sparseValue is NOT monoid.zero
+    //         semigroupPlus(left, right)
+    //       case _ => // sparseValue IS zero
+    //         fromMap(Semigroup.plus(toMap(left), toMap(right)),
+    //           left.sparseValue,
+    //           maxSize)
+    //     }
+    //   }
+    // }
+
+    // def plus(left: AdaptiveVector[V], right: AdaptiveVector[V]) = {
+    //   implicitly[Semigroup[V]] match {
+    //     case m: Monoid[_] => monoidPlus(left, right)
+    //     case _ => semigroupPlus(left, right)
+    //   }
+    // }
   }
   private class AVMonoid[V: Monoid] extends AVSemigroup[V] with Monoid[AdaptiveVector[V]] {
     val zero = AdaptiveVector.fill[V](0)(Monoid.zero[V])
     override def isNonZero(v: AdaptiveVector[V]) = !isZero(v)
-
-    def isZero(v: AdaptiveVector[V]) = (v.size == 0) || {
-      val sparseAreZero = if (Monoid.isNonZero(v.sparseValue)) (v.denseCount == v.size) else true
-      sparseAreZero &&
-        v.denseIterator.forall { idxv => !Monoid.isNonZero(idxv._2) }
-    }
+    def isZero(v: AdaptiveVector[V]) = isZeroVector(v)
+    // def isZero(v: AdaptiveVector[V]) = (v.size == 0) || {
+    //   val sparseAreZero = if (Monoid.isNonZero(v.sparseValue)) (v.denseCount == v.size) else true
+    //   sparseAreZero &&
+    //     v.denseIterator.forall { idxv => !Monoid.isNonZero(idxv._2) }
+    // }
   }
   private class AVGroup[V: Group] extends AVMonoid[V] with Group[AdaptiveVector[V]] {
     override def negate(v: AdaptiveVector[V]) =
@@ -153,11 +197,26 @@ object AdaptiveVector {
     Equiv[V].equiv(l.sparseValue, r.sparseValue) && iteq
   }
 
-  implicit def equiv[V: Equiv]: Equiv[AdaptiveVector[V]] =
-    Equiv.fromFunction[AdaptiveVector[V]] { (l, r) =>
-      (l.size == r.size) && (denseEquiv[V].equiv(l, r) ||
-        toVector(l).view.zip(toVector(r)).forall { case (lv, rv) => Equiv[V].equiv(lv, rv) })
+  implicit def equiv[V: Equiv]: Equiv[AdaptiveVector[V]] = {
+
+    def isExtension(left: AdaptiveVector[V], right: AdaptiveVector[V]): Boolean = {
+      if (left.size > right.size) {
+        val diff = left.size - right.size
+        left == right.extend(diff)
+        // This is morally correct, but may be very inefficient.
+        // A better option might be to define take/drop
+        // and see if left.drop(right.size) is all sparseValues
+      } else { isExtension(right, left) }
     }
+
+    Equiv.fromFunction[AdaptiveVector[V]] { (l, r) =>
+      if (isExtension(l, r)) true
+      else {
+        (l.size == r.size) && (denseEquiv[V].equiv(l, r) ||
+          toVector(l).view.zip(toVector(r)).forall { case (lv, rv) => Equiv[V].equiv(lv, rv) })
+      }
+    }
+  }
 }
 
 /**

--- a/algebird-core/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
@@ -172,8 +172,8 @@ object AdaptiveVector {
 
     Equiv.fromFunction[AdaptiveVector[V]] { (l, r) =>
       (isZeroVector(l) && isZeroVector(r)) ||
-        ((l.size == r.size) && (denseEquiv[V].equiv(l, r) ||
-          toVector(l).view.zip(toVector(r)).forall { case (lv, rv) => Equiv[V].equiv(lv, rv) }))
+        ((l.size == r.size) && (denseEquiv[V].equiv(l, r)) ||
+          (toVector(l).view.zip(toVector(r)).forall { case (lv, rv) => Equiv[V].equiv(lv, rv) }))
     }
   }
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
@@ -104,7 +104,7 @@ object AdaptiveVector {
       case _ => false
     }
 
-    def plus(left: AdaptiveVector[V], right: AdaptiveVector[V]): AdaptiveVector[V] = {
+    def plus(left: AdaptiveVector[V], right: AdaptiveVector[V]) = {
       if (left.sparseValue != right.sparseValue) {
         val (newLeft, newRight) = alignSparseValues(left, right)
         plus(newLeft, newRight)

--- a/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
@@ -340,8 +340,9 @@ class CollectionSpecification extends CheckProperties {
     monoidLaws[AdaptiveVector[String]]
   }
 
-  property("AdaptiveVector[Int] semigroup does not sum sparseValues") {
-    implicit val arb = Arbitrary(arbAV(1))
-    dontSumSparseValues[AdaptiveVector[Int]]
+  property("AdaptiveVector[String] semigroup does not sum sparseValues") {
+    // TODO: make this not fail when the sparse value is not monid.zero
+    implicit val arb = Arbitrary(arbAV(""))
+    dontSumSparseValues[AdaptiveVector[String]]
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
@@ -302,12 +302,11 @@ class CollectionSpecification extends CheckProperties {
 
   def dontSumSparseValues[T: Semigroup: Arbitrary]: Prop =
     'dontSumSparseValues |: forAll { (a: T) =>
-      val sem: Semigroup[T] = implicitly
       def denseCount(v: T): Int = v match {
         case v: AdaptiveVector[_] => v.denseCount
         case _ => 0
       }
-      denseCount(sem.plus(a,a)) == denseCount(a)
+      denseCount(Semigroup.plus(a,a)) == denseCount(a)
     }
 
   property("AdaptiveVector[Int] has a semigroup") {
@@ -315,34 +314,34 @@ class CollectionSpecification extends CheckProperties {
     semigroupLaws[AdaptiveVector[Int]]
   }
 
-  property("AdaptiveVector[Int] has a monoid when sparseValue IS monoid.zero") {
+  property("AdaptiveVector[Int] has a monoid when sparseValue is monoid.zero") {
     implicit val arb = Arbitrary(arbAV(0))
     monoidLaws[AdaptiveVector[Int]]
   }
 
-  property("AdaptiveVector[Int] has a monoid when sparseValue is NOT monoid.zero") {
+  property("AdaptiveVector[Int] has a monoid when sparseValue is not monoid.zero") {
     implicit val arb = Arbitrary(arbAV(2))
     monoidLaws[AdaptiveVector[Int]]
   }
 
-  property("AdaptiveVector[Int] has a group") {
-    implicit val arb = Arbitrary(arbAV(1))
+  property("AdaptiveVector[Int] has a group when sparse value is monoid.zero") {
+    //The group structure relies on adding sparse values
+    implicit val arb = Arbitrary(arbAV(0))
     groupLaws[AdaptiveVector[Int]]
   }
 
-  property("AdaptiveVector[String] has a monoid when sparseValue IS monoid.zero") {
+  property("AdaptiveVector[String] has a monoid when sparseValue is monoid.zero") {
     implicit val arb = Arbitrary(arbAV(""))
     monoidLaws[AdaptiveVector[String]]
   }
 
-  property("AdaptiveVector[String] has a monoid when sparseValue is NOT monoid.zero") {
+  property("AdaptiveVector[String] has a monoid when sparseValue is not monoid.zero") {
     implicit val arb = Arbitrary(arbAV("yo"))
     monoidLaws[AdaptiveVector[String]]
   }
 
   property("AdaptiveVector[String] semigroup does not sum sparseValues") {
-    // TODO: make this not fail when the sparse value is not monid.zero
-    implicit val arb = Arbitrary(arbAV(""))
+    implicit val arb = Arbitrary(arbAV("yo"))
     dontSumSparseValues[AdaptiveVector[String]]
   }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CollectionSpecification.scala
@@ -304,10 +304,17 @@ class CollectionSpecification extends CheckProperties {
     semigroupLaws[AdaptiveVector[Int]]
   }
 
-  property("AdaptiveVector[Int] has a monoid") {
+  property("AdaptiveVector[Int] has a monoid when sparseValue IS monoid.zero") {
     // TODO: remove this equiv instance once #583 is resolved.
-    implicit val equiv = AdaptiveVector.denseEquiv[Int]
+    // implicit val equiv = AdaptiveVector.denseEquiv[Int]
     implicit val arb = Arbitrary(arbAV(0))
+    monoidLaws[AdaptiveVector[Int]]
+  }
+
+  property("AdaptiveVector[Int] has a monoid when sparseValue is NOT monoid.zero") {
+    // TODO: remove this equiv instance once #583 is resolved.
+    // implicit val equiv = AdaptiveVector.denseEquiv[Int]
+    implicit val arb = Arbitrary(arbAV(2))
     monoidLaws[AdaptiveVector[Int]]
   }
 
@@ -316,10 +323,27 @@ class CollectionSpecification extends CheckProperties {
     groupLaws[AdaptiveVector[Int]]
   }
 
-  property("AdaptiveVector[String] has a monoid") {
+  // property("AdaptiveVector[String] has a monoid when sparseValue IS monoid.zero") {
+  //   // TODO: remove this equiv instance once #583 is resolved.
+  //   // implicit val equiv = AdaptiveVector.denseEquiv[String]
+  //   implicit val arb = Arbitrary(arbAV(""))
+  //   monoidLaws[AdaptiveVector[String]]
+  // }
+
+  property("AdaptiveVector[String] has a monoid when sparseValue is NOT monoid.zero") {
     // TODO: remove this equiv instance once #583 is resolved.
-    implicit val equiv = AdaptiveVector.denseEquiv[String]
-    implicit val arb = Arbitrary(arbAV(""))
+    // implicit val equiv = AdaptiveVector.denseEquiv[String]
+    implicit val arb = Arbitrary(arbAV("yo"))
     monoidLaws[AdaptiveVector[String]]
   }
+
+  // property("AdaptiveVector[Int] semigroup does not sum sparseValues") {
+  //   forAll { magnitude: Int =>
+  //     val size = if ( magnitude > 0 ) { magnitude } else { -magnitude }
+  //     val v = SparseVector(Map.empty, 2, size)
+  //     // A vector of sparseValues which are NOT monoid.zero
+  //     Semigroup.plus(v, v) == v
+  //   }
+  // }
+
 }

--- a/build.sbt
+++ b/build.sbt
@@ -42,8 +42,8 @@ def docsSourcesAndProjects(sv: String): (Boolean, Seq[ProjectReference]) =
       algebirdTest,
       algebirdCore,
       algebirdUtil,
-      algebirdBijection,
-      algebirdSpark
+      algebirdBijection
+      // algebirdSpark
     ))
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,8 +42,8 @@ def docsSourcesAndProjects(sv: String): (Boolean, Seq[ProjectReference]) =
       algebirdTest,
       algebirdCore,
       algebirdUtil,
-      algebirdBijection
-      // algebirdSpark
+      algebirdBijection,
+      algebirdSpark
     ))
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -183,8 +183,8 @@ lazy val algebird = Project(
   algebirdCore,
   algebirdUtil,
   algebirdBijection,
-  algebirdBenchmark//,
-  //algebirdSpark
+  algebirdBenchmark,
+  algebirdSpark
 )
 
 def module(name: String) = {

--- a/build.sbt
+++ b/build.sbt
@@ -183,8 +183,8 @@ lazy val algebird = Project(
   algebirdCore,
   algebirdUtil,
   algebirdBijection,
-  algebirdBenchmark,
-  algebirdSpark
+  algebirdBenchmark//,
+  //algebirdSpark
 )
 
 def module(name: String) = {


### PR DESCRIPTION
Fixing [issue 583](https://github.com/twitter/algebird/issues/583) that `AdaptiveVector` monoid fails monoid laws when the `sparseValue` is `monoid.zero`.