### PR TITLE
Create a Bloom Filter from an iterator

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -245,7 +245,12 @@ case class BloomFilterMonoid[A](numHashes: Int, width: Int)(implicit hash: Hash1
   /**
    * Create a bloom filter with multiple items.
    */
-  def create(data: A*): BF[A] = sum(data.iterator.map(BFItem(_, hashes, width)))
+  def create(data: A*): BF[A] = create(data.iterator)
+
+  /**
+    * Create a bloom filter with multiple items from an iterator
+    */
+  def create(data: Iterator[A]): BF[A] = sum(data.map(BFItem(_, hashes, width)))
 }
 
 object BF {

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -278,6 +278,20 @@ class BloomFilterTest extends WordSpec with Matchers {
 
   "BloomFilter" should {
 
+    "be possible to create from an iterator" in {
+      val bfMonoid = new BloomFilterMonoid[String](RAND.nextInt(5) + 1, RAND.nextInt(64) + 32)
+      val entries = (0 until 100).map(_ => RAND.nextInt.toString)
+      val bf = bfMonoid.create(entries.iterator)
+      assert(bf.isInstanceOf[BF[String]])
+    }
+
+    "be possible to create from a sequence" in {
+      val bfMonoid = new BloomFilterMonoid[String](RAND.nextInt(5) + 1, RAND.nextInt(64) + 32)
+      val entries = (0 until 100).map(_ => RAND.nextInt.toString)
+      val bf = bfMonoid.create(entries: _*)
+      assert(bf.isInstanceOf[BF[String]])
+    }
+
     "identify all true positives" in {
       (0 to 100).foreach{
         _ =>


### PR DESCRIPTION
This PR simply adds the option of creating a Bloom Filter directly from an iterator. I found this useful in my own code, so perhaps someone else will also find it useful.