### PR TITLE
Maven publish shouldn't inline code from dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ val sharedSettings = scalariformSettings ++  Seq(
 
   scalacOptions ++= {
     if (scalaVersion.value startsWith "2.12")
-      Seq("-opt:l:classpath")
+      Seq()
     else
       Seq("-optimize")
   },
@@ -251,7 +251,7 @@ lazy val algebirdBijection = module("bijection").settings(
 ).dependsOn(algebirdCore, algebirdTest % "test->test")
 
 lazy val algebirdSpark = module("spark").settings(
-    libraryDependencies += "org.apache.spark" %% "spark-core" % "1.3.0" % "provided",
+    libraryDependencies += "org.apache.spark" % "spark-core_2.10" % "1.3.0" % "provided",
     crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12"))
   ).dependsOn(algebirdCore, algebirdTest % "test->test")
 


### PR DESCRIPTION
Library is built with compiler option ```-opt:l:classpath``` but as it is stated in release note http://www.scala-lang.org/news/2.12.0/#new-optimizer : ```If you are building a library to publish on Maven Central, you should not inline code from dependencies. Users of your library might have different versions of those dependencies on the classpath, which breaks binary compatibility```, it shouldn't when publishing to Maven
Algebird library depends on scala-library and in connection with ```-opt:l:classpath``` flag, it inlines some methods which which uses Scala in version defined in build.sbt, and at the end it might results in binary incompatibility (when using other Scala versions than defined in build.sbt).