### PR TITLE
Fix a lambda serialization issue in SketchMap

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -140,7 +140,7 @@ case class SketchMapParams[K](seed: Int, width: Int, depth: Int, heavyHittersCou
     val numCounters = width
     (0 to (numHashes - 1)).map { _ =>
       val smhash: SketchMapHash[K] = SketchMapHash(CMSHash[Long](r.nextInt, 0, numCounters), seed)(serialization)
-      new (K => Int) { override def apply(k: K) = smhash(k) }
+      (k: K) => smhash(k)
     }
   }
 


### PR DESCRIPTION
Turns out `new (T => U)` is not serializable and this causes problem in Spark.

```scala
scala> val f = (x: Int) => x + 1
f: Int => Int = <function1>

scala> f.isInstanceOf[Serializable]
res0: Boolean = true

scala> val g = new (Int => Int) { override def apply(x: Int) = x + 1 }
g: Int => Int = <function1>

scala> g.isInstanceOf[Serializable]
res1: Boolean = false
```