### PR TITLE
Make derivation macros work for generic case classes

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/macros/GroupMacro.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/macros/GroupMacro.scala
@@ -13,7 +13,7 @@ object GroupMacro {
     ensureCaseClass(c)
 
     val implicitGroups = getParams(c).map {
-      param => q"implicitly[_root_.com.twitter.algebird.Group[${param.returnType}]]"
+      param => q"implicitly[_root_.com.twitter.algebird.Group[${param.typeSignatureIn(T.tpe)}]]"
     }
 
     val res = q"""

--- a/algebird-core/src/main/scala/com/twitter/algebird/macros/MonoidMacro.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/macros/MonoidMacro.scala
@@ -13,7 +13,7 @@ object MonoidMacro {
     ensureCaseClass(c)
 
     val implicitMonoids = getParams(c).map {
-      param => q"implicitly[_root_.com.twitter.algebird.Monoid[${param.returnType}]]"
+      param => q"implicitly[_root_.com.twitter.algebird.Monoid[${param.typeSignatureIn(T.tpe)}]]"
     }
 
     val res = q"""

--- a/algebird-core/src/main/scala/com/twitter/algebird/macros/RingMacro.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/macros/RingMacro.scala
@@ -16,7 +16,7 @@ object RingMacro {
     val companion = getCompanionObject(c)
 
     val implicitRings = params.map {
-      param => q"implicitly[_root_.com.twitter.algebird.Ring[${param.returnType}]]"
+      param => q"implicitly[_root_.com.twitter.algebird.Ring[${param.typeSignatureIn(T.tpe)}]]"
     }
 
     val timesList = params.zip(implicitRings).map {

--- a/algebird-core/src/main/scala/com/twitter/algebird/macros/SemigroupMacro.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/macros/SemigroupMacro.scala
@@ -13,7 +13,7 @@ object SemigroupMacro {
     ensureCaseClass(c)
 
     val implicitSemigroups = getParams(c).map {
-      param => q"implicitly[_root_.com.twitter.algebird.Semigroup[${param.returnType}]]"
+      param => q"implicitly[_root_.com.twitter.algebird.Semigroup[${param.typeSignatureIn(T.tpe)}]]"
     }
 
     val res = q"""

--- a/algebird-test/src/test/scala/com/twitter/algebird/macros/CaseClassMacrosTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/macros/CaseClassMacrosTest.scala
@@ -12,9 +12,11 @@ object CaseClassMacrosTest extends Properties("Case class macros") {
 
   implicit val arbitraryFoo: Arbitrary[Foo] = arbitrary[Foo]
   implicit val arbitraryBar: Arbitrary[Bar] = arbitrary[Bar]
+  implicit val arbitraryBaz: Arbitrary[Baz[Int]] = arbitrary[Baz[Int]]
 
   case class Foo(a: Int, b: Short, c: Long)
   case class Bar(a: Boolean, foo: Foo)
+  case class Baz[A](a: A, b: Short, c: A)
 
   property("Foo is a Semigroup") = semigroupLaws[Foo]
   property("Foo is a Monoid") = monoidLaws[Foo]
@@ -25,4 +27,9 @@ object CaseClassMacrosTest extends Properties("Case class macros") {
   property("Bar is a Monoid") = monoidLaws[Bar]
   property("Bar is a Group") = groupLaws[Bar]
   property("Bar is a Ring") = ringLaws[Bar]
+
+  property("Baz[Int] is a Semigroup") = semigroupLaws[Baz[Int]]
+  property("Baz[Int] is a Monoid") = monoidLaws[Baz[Int]]
+  property("Baz[Int] is a Group") = groupLaws[Baz[Int]]
+  property("Baz[Int] is a Ring") = ringLaws[Baz[Int]]
 }


### PR DESCRIPTION
`returnType` doesn't work appropriately if the member type is generic.