### PR TITLE
Add trailing window aggregator

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -17,6 +17,7 @@ limitations under the License.
 package com.twitter.algebird
 
 import scala.collection.immutable.Queue
+import Operators._
 
 /**
  *

--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -112,18 +112,15 @@ case class WindowMonoid[T](
 
   def plusM(a: Window[T], b: Window[T])(implicit m: Monoid[T]): Window[T] =
     if (b.items.size >= windowSize) {
-      var q = b.items
-      while (q.size > windowSize) {
-        q = q.tail
-      }
-      val total = m.sum(q)
-      Window(total, q)
+      val items = b.items.takeRight(windowSize)
+      val total = m.sum(items)
+      Window(total, items)
     } else {
       // we need windowSize - b.items.size from `a`
       val fromA = a.items.takeRight(windowSize - b.items.size)
-      val res = fromA ++ b.items
+      val items = fromA ++ b.items
       val total = m.sum(fromA) + b.total
-      Window(total, res)
+      Window(total, items)
     }
 
     def fromTraversable(ts: Traversable[T]): Window[T] = {

--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -76,17 +76,11 @@ case class WindowMonoid[T](
     windowSize: Int
 )(implicit p: Priority[Group[T], Monoid[T]])
     extends Monoid[Window[T]] {
-  val zero =
-    p match {
-      case Priority.Preferred(g) => Window(g.zero)
-      case Priority.Fallback(m)  => Window(m.zero)
-    }
+
+  def zero = p.fold(g => Window(g.zero))(m => Window(m.zero))
 
   def plus(a: Window[T], b: Window[T]): Window[T] =
-    p match {
-      case Priority.Preferred(g) => plusG(a, b)(g)
-      case Priority.Fallback(m)  => plusM(a, b)(m)
-    }
+    p.fold(g => plusG(a, b)(g))(m => plusM(a, b)(m))
 
   def plusG(a: Window[T], b: Window[T])(implicit g: Group[T]): Window[T] =
     if (b.items.size >= windowSize) {

--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -77,6 +77,8 @@ case class WindowMonoid[T](
 )(implicit p: Priority[Group[T], Monoid[T]])
     extends Monoid[Window[T]] {
 
+  require(windowSize >= 1, "Windows must have positive sizes")
+
   def zero = p.fold(g => Window(g.zero))(m => Window(m.zero))
 
   def plus(a: Window[T], b: Window[T]): Window[T] =

--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -98,6 +98,18 @@ case class WindowMonoid[T](
       val total = monT.sum(right)
       Window(total, Queue(right: _*))
     }
+
+    override def sumOption(ws: TraversableOnce[Window[T]]): Option[Window[T]] = {
+      if(ws.isEmpty) None
+      else {
+        val it = ws.toIterator
+        var queue = Queue[T]()
+        while (it.hasNext) {
+          queue = (queue ++ it.next.items).takeRight(windowSize)
+        }
+        Some(fromTraversable(queue))
+      }
+    }
 }
 
 /*

--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -25,6 +25,34 @@ import scala.collection.immutable.Queue
  *
  * @param total Known running total of `T`
  * @param items queue of known trailing elements.
+ *
+ *  Example usage:
+ *
+ *  case class W28[T](window: Window[T]) {
+ *    def total = this.window.total
+ *    def items = this.window.items
+ *    def size = this.window.size
+ *  }
+ *
+ *  object W28 {
+ *    val windowSize = 28
+ *    def apply[T](v: T): W28[T] = W28[T](Window(v))
+ *
+ *    implicit def w28Monoid[T](implicit p: Priority[Group[T], Monoid[T]]): Monoid[W28[T]] =
+ *      new Monoid[W28[T]] {
+ *        private val WT: Monoid[Window[T]] = WindowMonoid[T](windowSize)
+ *        def zero = W28[T](WT.zero)
+ *        def plus(a: W28[T], b: W28[T]): W28[T] =
+ *          W28[T](WT.plus(a.window, b.window))
+ *      }
+ *  }
+ *  val elements = getElements()
+ *
+ *  val trailing90Totals =
+ *    elements
+ *      .map{ W90 }
+ *      .scanLeft(W90(0)) { (a, b) => a + b }
+ *      .map{ _.total }
  */
 
 case class Window[T](total: T, items: Queue[T]) {
@@ -39,7 +67,7 @@ object Window {
 /**
  * Provides a natural monoid for combining windows truncated to some window size.
  *
- * @param windowSize
+ * @param windowSize Upper limit of the number of items in a window.
  */
 
 
@@ -111,30 +139,3 @@ case class WindowMonoid[T](
       }
     }
 }
-
-/*
-  Example usage:
-
-  case class W90[T](window: Window[T]) {
-    def total = this.window.total
-  }
-
-  object W90 {
-    def apply[T](v: T): W90[T] = W90[T](new Window(v))
-
-    implicit def w90Monoid[T: Monoid]: Monoid[W90[T]] = new Monoid[W90[T]] {
-      private val WT: Monoid[Window[T]] = WindowMonoid[T](90)
-      def zero = W90[T](WT.zero)
-      def plus(a: W90[T], b: W90[T]): W90[T] =
-        W90[T](WT.plus(a.window, b.window))
-    }
-  }
-
-  val elements = getElements()
-
-  val trailing90Totals =
-    elements
-      .map{ W90 ( _ ) }
-      .foldLeft(W90(0)) { (a, b) => a + b }
-      .map{ _.total }
- */

--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -33,6 +33,7 @@ case class Window[T](total: T, items: Queue[T]) {
 
 object Window {
   def apply[T](v: T): Window[T] = Window[T](v, Queue[T](v))
+  def from[T](ts: Traversable[T])(implicit m: WindowMonoid[T]) = m.fromTraversable(ts)
 }
 
 /**
@@ -89,6 +90,13 @@ case class WindowMonoid[T](
       val res = fromA ++ b.items
       val total = m.sum(fromA) + b.total
       Window(total, res)
+    }
+
+    def fromTraversable(ts: Traversable[T]): Window[T] = {
+      val monT: Monoid[T] = p.join
+      val right = ts.toList.takeRight(windowSize)
+      val total = monT.sum(right)
+      Window(total, Queue(right: _*))
     }
 }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -123,22 +123,22 @@ case class WindowMonoid[T](
       Window(total, items)
     }
 
-    def fromTraversable(ts: Traversable[T]): Window[T] = {
-      val monT: Monoid[T] = p.join
-      val right = ts.toList.takeRight(windowSize)
-      val total = monT.sum(right)
-      Window(total, Queue(right: _*))
-    }
+  def fromTraversable(ts: Traversable[T]): Window[T] = {
+    val monT: Monoid[T] = p.join
+    val right = ts.toList.takeRight(windowSize)
+    val total = monT.sum(right)
+    Window(total, Queue(right: _*))
+  }
 
-    override def sumOption(ws: TraversableOnce[Window[T]]): Option[Window[T]] = {
-      if(ws.isEmpty) None
-      else {
-        val it = ws.toIterator
-        var queue = Queue[T]()
-        while (it.hasNext) {
-          queue = (queue ++ it.next.items).takeRight(windowSize)
-        }
-        Some(fromTraversable(queue))
+  override def sumOption(ws: TraversableOnce[Window[T]]): Option[Window[T]] = {
+    if(ws.isEmpty) None
+    else {
+      val it = ws.toIterator
+      var queue = Queue[T]()
+      while (it.hasNext) {
+        queue = (queue ++ it.next.items).takeRight(windowSize)
       }
+      Some(fromTraversable(queue))
     }
+  }
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -79,7 +79,7 @@ case class WindowMonoid[T](
 
   require(windowSize >= 1, "Windows must have positive sizes")
 
-  def zero = p.fold(g => Window(g.zero))(m => Window(m.zero))
+  def zero = p.fold(g => Window[T](g.zero, Queue.empty[T]))(m => Window(m.zero, Queue.empty[T]))
 
   def plus(a: Window[T], b: Window[T]): Window[T] =
     p.fold(g => plusG(a, b)(g))(m => plusM(a, b)(m))
@@ -133,9 +133,12 @@ case class WindowMonoid[T](
     }
 
   def fromIterable(ts: Iterable[T]): Window[T] = {
-    val monT: Monoid[T] = p.join
-    val right = ts.toList.takeRight(windowSize)
-    val total = monT.sum(right)
-    Window(total, Queue(right: _*))
+    if(ts.size == 0) zero
+    else {
+      val monT: Monoid[T] = p.join
+      val right = ts.toList.takeRight(windowSize)
+      val total = monT.sum(right)
+      Window(total, Queue(right: _*))
+    }
   }
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -98,10 +98,16 @@ case class WindowMonoid[T](
       Window(total, q)
     } else {
       // we need windowSize - b.items.size from `a`
-      val fromA = a.items.takeRight(windowSize - b.items.size)
-      val res = fromA ++ b.items
-      val total = g.sum(fromA) + b.total
-      Window(total, res)
+      var truncA = a.items
+      var totalA = a.total
+      val truncTo = windowSize - b.size
+      while (truncA.size > truncTo) {
+        totalA = totalA - truncA.head
+        truncA = truncA.tail
+      }
+      val items = truncA ++ b.items
+      val total = totalA + b.total
+      Window(total, items)
     }
 
   def plusM(a: Window[T], b: Window[T])(implicit m: Monoid[T]): Window[T] =

--- a/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Window.scala
@@ -1,0 +1,120 @@
+/*
+Copyright 2018 Stripe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.algebird
+
+import scala.collection.immutable.Queue
+
+/**
+ *
+ * Convenience case class defined with a monoid for aggregating elements over
+ * a finite window.
+ *
+ * @param total Known running total of `T`
+ * @param items queue of known trailing elements.
+ */
+
+case class Window[T](total: T, items: Queue[T]) {
+  def size = this.items.size
+}
+
+object Window {
+  def apply[T](v: T): Window[T] = Window[T](v, Queue[T](v))
+}
+
+/**
+ * Provides a natural monoid for combining windows truncated to some window size.
+ *
+ * @param windowSize
+ */
+
+
+case class WindowMonoid[T](
+    windowSize: Int
+)(implicit p: Priority[Group[T], Monoid[T]])
+    extends Monoid[Window[T]] {
+  val zero =
+    p match {
+      case Priority.Preferred(g) => Window(g.zero)
+      case Priority.Fallback(m)  => Window(m.zero)
+    }
+
+  def plus(a: Window[T], b: Window[T]): Window[T] =
+    p match {
+      case Priority.Preferred(g) => plusG(a, b)(g)
+      case Priority.Fallback(m)  => plusM(a, b)(m)
+    }
+
+  def plusG(a: Window[T], b: Window[T])(implicit g: Group[T]): Window[T] =
+    if (b.items.size >= windowSize) {
+      var total: T = b.total
+      var q = b.items
+      while (q.size > windowSize) {
+        total = total - q.head
+        q = q.tail
+      }
+      Window(total, q)
+    } else {
+      // we need windowSize - b.items.size from `a`
+      val fromA = a.items.takeRight(windowSize - b.items.size)
+      val res = fromA ++ b.items
+      val total = g.sum(fromA) + b.total
+      Window(total, res)
+    }
+
+  def plusM(a: Window[T], b: Window[T])(implicit m: Monoid[T]): Window[T] =
+    if (b.items.size >= windowSize) {
+      var q = b.items
+      while (q.size > windowSize) {
+        q = q.tail
+      }
+      val total = m.sum(q)
+      Window(total, q)
+    } else {
+      // we need windowSize - b.items.size from `a`
+      val fromA = a.items.takeRight(windowSize - b.items.size)
+      val res = fromA ++ b.items
+      val total = m.sum(fromA) + b.total
+      Window(total, res)
+    }
+}
+
+/*
+  Example usage:
+
+  case class W90[T](window: Window[T]) {
+    def total = this.window.total
+  }
+
+  object W90 {
+    def apply[T](v: T): W90[T] = W90[T](new Window(v))
+
+    implicit def w90Monoid[T: Monoid]: Monoid[W90[T]] = new Monoid[W90[T]] {
+      private val WT: Monoid[Window[T]] = WindowMonoid[T](90)
+      def zero = W90[T](WT.zero)
+      def plus(a: W90[T], b: W90[T]): W90[T] =
+        W90[T](WT.plus(a.window, b.window))
+    }
+  }
+
+  val elements = getElements()
+
+  val trailing90Totals =
+    elements
+      .map{ W90 ( _ ) }
+      .foldLeft(W90(0)) { (a, b) => a + b }
+      .map{ _.total }
+ */

--- a/algebird-test/src/test/scala/com/twitter/algebird/WindowLawsTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/WindowLawsTest.scala
@@ -12,7 +12,37 @@ class WindowLaws extends CheckProperties {
     forAll { (ts0: List[Int], n: Int) =>
       val ts = ts0.takeRight(n)
       val mon = new WindowMonoid(n)
-      assert(mon.sum(ts0.map( Window(_) )).total == ts.sum)
+      assert(mon.sum(ts0.map(Window(_))).total == ts.sum)
+    }
+  }
+
+  property("We correctly create a window from traversable") {
+    forAll { (ts0: List[Int], n: Int) =>
+      val mon = new WindowMonoid(n)
+      val right = Queue(ts0.takeRight(n): _*)
+      val expected = Window(right.sum, right)
+      val got = mon.fromTraversable(ts0)
+      assert(got == expected)
+    }
+  }
+
+  property("We correctly combine windows") {
+    forAll { (left: List[Int], right: List[Int], n: Int) =>
+      val mon = new WindowMonoid(n)
+      val trunc = Queue((left ::: right).takeRight(n): _*)
+      val expected = Window(trunc.sum, trunc)
+      val got = mon.sum(mon.fromTraversable(left), mon.fromTraversable(right))
+      assert(expected == got)
+    }
+  }
+
+  property("We correctly overrode sumOption") {
+    forAll { (ts0: List[Int], n: Int) =>
+      val mon = new WindowMonoid(n)
+      val got = mon.sumOption(ts0.map { Window(_) })
+      val trunc = Queue(ts0.takeRight(n): _*)
+      val expected = if (n == 0) None else Some(Window(trunc.sum, trunc))
+      assert(expected == got)
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/WindowLawsTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/WindowLawsTest.scala
@@ -1,0 +1,20 @@
+package com.twitter.algebird
+
+import com.twitter.algebird.BaseProperties._
+import com.twitter.algebird.scalacheck.arbitrary._
+import com.twitter.algebird.scalacheck.NonEmptyVector
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop.forAll
+
+
+class WindowLaws extends CheckProperties {
+  property("We aggregate over only n items") {
+    forAll { (ts0: List[Int], n: Int) =>
+      val ts = ts0.takeRight(n)
+      val mon = new WindowMonoid(n)
+      assert(mon.sum(ts0.map( Window(_) )).total == ts.sum)
+    }
+  }
+
+  property("Window[Double] is a monoid") { monoidLaws[Window[Double]] }
+}


### PR DESCRIPTION
#### Description

Add WindowMonoid utility for aggregating over finite window. Window case class stores elements with a queue. The monoid combines windows while trimming their elements to the appropriate size. The monoid is also geared to aggregate elements with the group property more efficiently, as we can subtract from the total elements we push out of the queue upon aggregation.

#### Testing

Unit tests

r? @johnynek 