### PR TITLE
Correct Min.semigroup

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
@@ -92,7 +92,7 @@ private[algebird] sealed abstract class MinInstances {
   implicit def semigroup[T: Ordering]: Semigroup[Min[T]] with Semilattice[Min[T]] =
     new Semigroup[Min[T]] with Semilattice[Min[T]] {
       val ord = implicitly[Ordering[T]]
-      def plus(l: Min[T], r: Min[T]): Min[T] = if (ord.gteq(l.get, r.get)) l else r
+      def plus(l: Min[T], r: Min[T]): Min[T] = if (ord.lteq(l.get, r.get)) l else r
     }
 
   /** [[Monoid]] for [[Min]][Int] with `zero == Int.MaxValue` */

--- a/algebird-test/src/test/scala/com/twitter/algebird/MaxLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MaxLaws.scala
@@ -29,6 +29,13 @@ class MaxLaws extends CheckProperties {
     }
   }
 
+  property("Max.semigroup returns the maximum item") {
+    forAll { v: NonEmptyVector[Int] =>
+      val maxItems = v.items.map { Max(_) }
+      v.sorted.last == Max.semigroup[Int].combineAllOption(maxItems).get.get
+    }
+  }
+
   property("Max[Long] is a commutative monoid") {
     commutativeMonoidLaws[Max[Long]]
   }

--- a/algebird-test/src/test/scala/com/twitter/algebird/MaxLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MaxLaws.scala
@@ -13,6 +13,12 @@ class MaxLaws extends CheckProperties {
       l + r == realMax && (l max r) == realMax
     }
 
+  def maxSemiGroupTest[T: Arbitrary: Ordering] =
+    forAll { v: NonEmptyVector[T] =>
+      val maxItems = v.items.map { Max(_) }
+      v.items.max == Max.semigroup[T].combineAllOption(maxItems).get.get
+    }
+
   // Test equiv import.
   val equiv = implicitly[Equiv[Max[Int]]]
 
@@ -29,12 +35,9 @@ class MaxLaws extends CheckProperties {
     }
   }
 
-  property("Max.semigroup returns the maximum item") {
-    forAll { v: NonEmptyVector[Int] =>
-      val maxItems = v.items.map { Max(_) }
-      v.sorted.last == Max.semigroup[Int].combineAllOption(maxItems).get.get
-    }
-  }
+  property("Max.semigroup[Int] returns the maximum item") { maxSemiGroupTest[Int] }
+
+  property("Max.semigroup[Char] returns the maximum item") { maxSemiGroupTest[Char] }
 
   property("Max[Long] is a commutative monoid") {
     commutativeMonoidLaws[Max[Long]]

--- a/algebird-test/src/test/scala/com/twitter/algebird/MaxLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MaxLaws.scala
@@ -31,7 +31,7 @@ class MaxLaws extends CheckProperties {
 
   property("Max.aggregator returns the maximum item") {
     forAll { v: NonEmptyVector[Int] =>
-      v.sorted.last == Max.aggregator[Int].apply(v.items)
+      v.items.max == Max.aggregator[Int].apply(v.items)
     }
   }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/MinLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MinLaws.scala
@@ -13,6 +13,12 @@ class MinLaws extends CheckProperties {
       l + r == realMin && (l min r) == realMin
     }
 
+  def minSemigroupTest[T: Arbitrary: Ordering] =
+    forAll { v: NonEmptyVector[T] =>
+      val minItems = v.items.map { Min(_) }
+      v.items.min == Min.semigroup[T].combineAllOption(minItems).get.get
+    }
+
   // Test equiv import.
   val equiv = implicitly[Equiv[Min[Int]]]
 
@@ -22,16 +28,13 @@ class MinLaws extends CheckProperties {
 
   property("Min.aggregator returns the minimum item") {
     forAll { v: NonEmptyVector[Int] =>
-      v.sorted.head == Min.aggregator[Int].apply(v.items)
+      v.items.min == Min.aggregator[Int].apply(v.items)
     }
   }
 
-  property("Min.semigroup returns the minimum item") {
-    forAll { v: NonEmptyVector[Int] =>
-      val minItems = v.items.map { Min(_) }
-      v.sorted.head == Min.semigroup[Int].combineAllOption(minItems).get.get
-    }
-  }
+  property("Min.semigroup[Int] returns the minimum item") { minSemigroupTest[Int] }
+
+  property("Min.semigroup[Char] returns the minimum item") { minSemigroupTest[Char] }
 
   property("Min[String] is a commutative semigroup") {
     commutativeSemigroupLaws[Min[String]]

--- a/algebird-test/src/test/scala/com/twitter/algebird/MinLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MinLaws.scala
@@ -26,6 +26,13 @@ class MinLaws extends CheckProperties {
     }
   }
 
+  property("Min.semigroup returns the minimum item") {
+    forAll { v: NonEmptyVector[Int] =>
+      val minItems = v.items.map { Min(_) }
+      v.sorted.head == Min.semigroup[Int].combineAllOption(minItems).get.get
+    }
+  }
+
   property("Min[String] is a commutative semigroup") {
     commutativeSemigroupLaws[Min[String]]
   }


### PR DESCRIPTION
`Min.semigroup` was incorrectly returning the *greater* element.

This PR corrects the semigroup and adds tests to check the results from both `Min.semigroup` and `Max.semigroup` (which was already correct).