### PR TITLE
Lazy minhash implementation for scalability.

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/LazyMinHasher.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/LazyMinHasher.scala
@@ -1,0 +1,60 @@
+package com.twitter.algebird
+
+import java.nio._
+
+/**
+ * Base class minhash signatures; LazyMinHashSignature and MinHashSignature.
+ * The lazy minhash signature is used to store the values until the actual minhash signature is needed at
+ * aggregation time.  This is to avoid GC overload the early by avoiding early allocation of many large
+ * byte arrays.  Instead, only the values are stored using LazyMinHashWithValue, and we allocate the
+ * buffer and pass it to LazyMinHashWithBytes.
+ */
+abstract class LazyMinHash extends java.io.Serializable
+case class LazyMinHashWithValue(value: String) extends LazyMinHash
+case class LazyMinHashWithBytes(bytes: Array[Byte]) extends LazyMinHash
+
+/**
+ * This is used to make minhash algorithm more scalable by deferring per-element minhash signature generation
+ * to aggregation time.  The minhash byte array is created only when LazyMinHasher.plus()
+ * is called and immediately thrown away after aggregation.  This reduces the burden on GC as well as
+ * reducing the memory footprint significantly.
+ * Since lazy minhashes are wrappers, we also made the lazy minhaser a wrapper of any minhasher type.
+ */
+class LazyMinHasher[H](minHasher: MinHasher[H])(implicit n: Numeric[H])
+  extends Monoid[LazyMinHash] {
+  /** Create a minhash signature for a single String value */
+  def init(value: String): LazyMinHash = LazyMinHashWithValue(value)
+  /** Signature for empty set, needed to be a proper Monoid */
+  val zero: LazyMinHash = LazyMinHashWithBytes(minHasher.zero.bytes)
+
+  /** Set union */
+  override def plus(l: LazyMinHash, r: LazyMinHash): LazyMinHash = {
+    (l, r) match {
+      case (LazyMinHashWithBytes(l), LazyMinHashWithValue(r)) => {
+        LazyMinHashWithBytes(minHasher.plus(MinHashSignature(l), minHasher.init(r)).bytes)
+      }
+      case (LazyMinHashWithValue(l), LazyMinHashWithBytes(r)) => {
+        LazyMinHashWithBytes(minHasher.plus(minHasher.init(l), MinHashSignature(r)).bytes)
+      }
+      case (LazyMinHashWithBytes(l), LazyMinHashWithBytes(r)) => {
+        LazyMinHashWithBytes(minHasher.plus(MinHashSignature(l), MinHashSignature(r)).bytes)
+      }
+      case (LazyMinHashWithValue(l), LazyMinHashWithValue(r)) => {
+        LazyMinHashWithBytes(minHasher.plus(minHasher.init(l), minHasher.init(r)).bytes)
+      }
+      case _ => throw new Exception(s"Unhandled term types in plus operation for LazyMinHasher")
+    }
+  }
+
+  def toMinHash(lazySig: LazyMinHash): MinHashSignature = {
+    lazySig match {
+      case LazyMinHashWithValue(k) => minHasher.init(k)
+      case LazyMinHashWithBytes(b) => MinHashSignature(b)
+      case _ => throw new Exception(s"Unhandled LazyMinHash type ${lazySig.getClass.getName}")
+    }
+  }
+
+  /** Esimate Jaccard similarity (size of union / size of intersection) */
+  def similarity(left: LazyMinHash, right: LazyMinHash): Double =
+    minHasher.similarity(toMinHash(left), toMinHash(right))
+}


### PR DESCRIPTION
This is an incremental fix to solve the scalability problem in MinHasher.  Current minhasher allocates hash buffer for every element in the init() method only to use it in the plus() method before throwing it away.  This should be fine for small number of hashes and relatively small number of items, but causes GC and heap errors when scaled.  I've encountered the problem when testing with 25K hashes on several million items.  The problem continued when I tried to run it on a much larger dataset on our hadoop cluster using Scalding.
This pull request includes a new LazyMinHasher which just holds the values until aggregation time without doing any buffer allocation.  It does buffer allocation in plus() method and then immediately throws it out.  Because short lived objects are more easily garbage collected, the burden on GC is significantly lower.  Also, because there is only two hash buffers kept in the memory at a given time rather than first allocating all of them, the memory footprint is much lower.
To reproduce the problem, increase the test sample size to ~1M in MinHasherTest.scala, and the new numBands val to ~25K.  This should break the MinHasher32 test while LazyMinHasher still passes.
