### PR TITLE
remove implicit from the caseclass macros

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/macros/caseclass.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/macros/caseclass.scala
@@ -4,9 +4,9 @@ import com.twitter.algebird._
 import scala.language.experimental.macros
 
 object caseclass {
-  implicit def semigroup[T]: Semigroup[T] =
+  def semigroup[T]: Semigroup[T] =
     macro SemigroupMacro.caseClassSemigroup[T]
-  implicit def monoid[T]: Monoid[T] = macro MonoidMacro.caseClassMonoid[T]
-  implicit def group[T]: Group[T] = macro GroupMacro.caseClassGroup[T]
-  implicit def ring[T]: Ring[T] = macro RingMacro.caseClassRing[T]
+  def monoid[T]: Monoid[T] = macro MonoidMacro.caseClassMonoid[T]
+  def group[T]: Group[T] = macro GroupMacro.caseClassGroup[T]
+  def ring[T]: Ring[T] = macro RingMacro.caseClassRing[T]
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/macros/package.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/macros/package.scala
@@ -12,7 +12,7 @@ package object macros {
 
     val isCaseClass = tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isCaseClass
     if (!isCaseClass)
-      c.abort(c.enclosingPosition, s"$T is not a case class")
+      c.abort(c.enclosingPosition, s"${tpe.typeSymbol} is not a case class")
   }
 
   private[macros] def getParams[T](c: Context)(

--- a/algebird-test/src/test/scala/com/twitter/algebird/macros/CaseClassMacrosTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/macros/CaseClassMacrosTest.scala
@@ -1,7 +1,6 @@
 package com.twitter.algebird.macros
 
 import com.twitter.algebird._
-import com.twitter.algebird.macros.caseclass._
 import com.twitter.algebird.macros.ArbitraryCaseClassMacro.arbitrary
 
 import org.scalacheck.{Arbitrary, Properties}
@@ -15,8 +14,19 @@ object CaseClassMacrosTest extends Properties("Case class macros") {
   implicit val arbitraryBaz: Arbitrary[Baz[Int]] = arbitrary[Baz[Int]]
 
   case class Foo(a: Int, b: Short, c: Long)
+  object Foo {
+    implicit val fooRing: Ring[Foo] = caseclass.ring
+  }
+
   case class Bar(a: Boolean, foo: Foo)
+  object Bar {
+    implicit val barRing: Ring[Bar] = caseclass.ring
+  }
+
   case class Baz[A](a: A, b: Short, c: A)
+  object Baz {
+    implicit def bazRing[A: Ring]: Ring[Baz[A]] = caseclass.ring
+  }
 
   property("Foo is a Semigroup") = semigroupLaws[Foo]
   property("Foo is a Monoid") = monoidLaws[Foo]
@@ -32,4 +42,14 @@ object CaseClassMacrosTest extends Properties("Case class macros") {
   property("Baz[Int] is a Monoid") = monoidLaws[Baz[Int]]
   property("Baz[Int] is a Group") = groupLaws[Baz[Int]]
   property("Baz[Int] is a Ring") = ringLaws[Baz[Int]]
+
+  //
+  // importing the case class macros does not break wrappers:
+  property("importing caseclass._ doesn't break Max") = forAll { (x: Int, y: Int) =>
+    Semigroup.plus(Max(x), Max(y)) == Max(x.max(y))
+  }
+
+  property("importing caseclass._ doesn't break Last") = forAll { (x: Int, y: Int) =>
+    Semigroup.plus(Last(x), Last(y)) == Last(y)
+  }
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/macros/CaseClassMacrosTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/macros/CaseClassMacrosTest.scala
@@ -45,11 +45,15 @@ object CaseClassMacrosTest extends Properties("Case class macros") {
 
   //
   // importing the case class macros does not break wrappers:
-  property("importing caseclass._ doesn't break Max") = forAll { (x: Int, y: Int) =>
-    Semigroup.plus(Max(x), Max(y)) == Max(x.max(y))
-  }
+  {
+    import caseclass._
 
-  property("importing caseclass._ doesn't break Last") = forAll { (x: Int, y: Int) =>
-    Semigroup.plus(Last(x), Last(y)) == Last(y)
+    property("importing caseclass._ doesn't break Max") = forAll { (x: Int, y: Int) =>
+      Semigroup.plus(Max(x), Max(y)) == Max(x.max(y))
+    }
+
+    property("importing caseclass._ doesn't break Last") = forAll { (x: Int, y: Int) =>
+      Semigroup.plus(Last(x), Last(y)) == Last(y)
+    }
   }
 }


### PR DESCRIPTION
This is interestingly, not source compatible (since it removes implicit) but it is binary compatible.

This will likely be a small migration for people using it, but I think it is the right direction.

Notice the tests I added failed if we didn't remove the implicit. We got burned at Stripe on this.

cc @ianoc @travisbrown @MansurAshraf what do you think?