### PR TITLE
use builder in SetMonoid

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Monoid.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Monoid.scala
@@ -172,11 +172,11 @@ class SetMonoid[T] extends Monoid[Set[T]] {
   override def sumOption(items: TraversableOnce[Set[T]]): Option[Set[T]] =
     if (items.isEmpty) None
     else {
-      val mutable = scala.collection.mutable.Set[T]()
+      val builder = Set.newBuilder[T]
       items.foreach { s =>
-        mutable ++= s
+        builder ++= s
       }
-      Some(mutable.toSet)
+      Some(builder.result())
     }
 }
 


### PR DESCRIPTION
Our benchmark shows that `var` of an immutable `Set` is ~50% faster than `mutable.Set` and `.toSet` later.
https://github.com/spotify/scio/issues/1183#issuecomment-410022235