### PR TITLE
Saturated bloomfilter size

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ See [Algebird's page on the Scaladex](https://index.scala-lang.org/twitter/algeb
 - [Scio](https://github.com/spotify/scio)
 - [Packetloop](https://www.packetloop.com) (see [this tweet](https://twitter.com/cloudjunky/status/355073917720858626))
 - Ebay uses Algebird for machine learning: [ScalaDays talk](http://www.slideshare.net/VitalyGordon/scalable-and-flexible-machine-learning-with-scala-linkedin)
-- [Apple (FEAR Team)](https://news.ycombinator.com/item?id=16969118)
 
 Other projects built with Algebird, as compiled by the Scaladex: [![Scaladex Dependents](https://index.scala-lang.org/count.svg?q=dependencies:twitter/algebird*&subject=scaladex:&color=blue&style=flat-square)](https://index.scala-lang.org/search?q=dependencies:twitter/algebird-core)
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -157,13 +157,16 @@ object BloomFilter {
      * This is \hat{S}^{-1}(t) in the cardinality estimation paper used above.
      */
     def sInverse(t: Int): Double =
-      scala.math.log1p(-t.toDouble / width) / (numHashes * scala.math.log1p(-1.0 / width))
+      if (numBits == width) 0.0
+      else
+        scala.math.log(1 - t.toDouble / width) / (numHashes * scala.math.log1p(-1.0 / width))
 
     // Variable names correspond to those used in the paper.
     val t = numBits
     val n = sInverse(t).round.toInt
     // Take the min and max because the probability formula assumes
     // nl <= sInverse(t - 1) and sInverse(t + 1) <= nr
+
     val nl =
       scala.math.min(sInverse(t - 1).floor, (1 - approximationWidth) * n).toInt
     val nr =

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -354,7 +354,6 @@ class BloomFilterTest extends WordSpec with Matchers {
         val items = (1 until exactCardinality).map { _.toString }
         val bf = bfMonoid.create(items: _*)
         val size = bf.size
-
         assert(size ~ exactCardinality)
         assert(size.min <= size.estimate)
         assert(size.max >= size.estimate)
@@ -408,23 +407,16 @@ class BloomFilterTest extends WordSpec with Matchers {
 
       assert(index >= 0)
     }
+  }
 
-    "return his size event if it's saturated" in {
+  "BloomFilter method `size`" should {
+
+    "return the appropriate size when it's saturated " in {
       val bfMonoid = BloomFilterMonoid[String](5, 13)
-      val strings = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).map(_.toString)
+      val strings = List(8, 9, 8, 10, 1, 8, 11, 12, 13, 14, 15, 67, 18981, 1122, 86787).map(_.toString)
       val bf = bfMonoid.create(strings: _*)
-
-      assert(bf.size.min > 0)
+      assert(bf.size.isZero)
     }
-
-    "return a max approximate size if it's saturated" in {
-      val bfMonoid = BloomFilterMonoid[String](5, 13)
-      val strings = List(8, 9, 8, 10, 1, 8, 11, 7, 7, 1).map(_.toString)
-      val bf = bfMonoid.create(strings: _*)
-      // even it's seems big. This assert fail..
-      assert(bf.size.max < strings.length * 100)
-    }
-
   }
 
   "BloomFilter method `checkAndAdd`" should {

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -2,9 +2,9 @@ package com.twitter.algebird
 
 import java.io.{ByteArrayOutputStream, ObjectOutputStream}
 
-import org.scalacheck.Prop._
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{Arbitrary, Gen, Properties}
 import org.scalatest.{Matchers, WordSpec}
+import org.scalacheck.Prop._
 
 object BloomFilterTestUtils {
   def toSparse[A](bf: BF[A]): BFSparse[A] = bf match {
@@ -29,8 +29,8 @@ object BloomFilterTestUtils {
 
 class BloomFilterLaws extends CheckProperties {
 
-  import BloomFilterTestUtils._
   import com.twitter.algebird.BaseProperties._
+  import BloomFilterTestUtils._
 
   val NUM_HASHES = 6
   val WIDTH = 32
@@ -155,7 +155,7 @@ class BFHashIndices extends CheckProperties {
   }
 
   /**
-   * This is the version of the BFHash as of before the "negative values fix"
+   *   This is the version of the BFHash as of before the "negative values fix"
    */
   case class NegativeBFHash(numHashes: Int, width: Int) {
     val size = numHashes
@@ -264,12 +264,10 @@ class BloomFilterCardinality[T: Gen: Hash128] extends ApproximateProperty {
   def inputGenerator(set: Set[T]) = Gen.const(())
 
   def exactResult(s: Set[T], u: Unit) = s.size
-
   def approximateResult(bf: BF[T], u: Unit) = bf.size
 }
 
 class BloomFilterProperties extends ApproximateProperties("BloomFilter") {
-
   import ApproximateProperty.toProp
 
   for (falsePositiveRate <- List(0.1, 0.01, 0.001)) {
@@ -353,9 +351,7 @@ class BloomFilterTest extends WordSpec with Matchers {
     "approximate cardinality" in {
       val bfMonoid = BloomFilterMonoid[String](10, 100000)
       Seq(10, 100, 1000, 10000).foreach { exactCardinality =>
-        val items = (1 until exactCardinality).map {
-          _.toString
-        }
+        val items = (1 until exactCardinality).map { _.toString }
         val bf = bfMonoid.create(items: _*)
         val size = bf.size
 
@@ -412,6 +408,7 @@ class BloomFilterTest extends WordSpec with Matchers {
 
       assert(index >= 0)
     }
+
     "return his size event if it's saturated" in {
       val bfMonoid = BloomFilterMonoid[String](5, 13)
       val strings = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).map(_.toString)


### PR DESCRIPTION
I reproduce the error from issue #632 

1. The error from the initial issue is reproduced with the test : 
```scala
    "return his size event if it's saturated" in {
      val bfMonoid = BloomFilterMonoid[String](5, 13)
      val strings = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).map(_.toString)
      val bf = bfMonoid.create(strings: _*)

      assert(bf.size.min > 0)
    }
```
throws : 
```
[info] - should return his size event if it's saturated *** FAILED ***
[info]   java.lang.IllegalArgumentException: requirement failed
```

Due to, I think , https://github.com/twitter/algebird/issues/632#issuecomment-416946292 we discuss before.

2. This is not the only error I found, seem like a saturated bloomfilter also provided a huge  max approximation for a given input. But not throw an exception

Coming from the comment (L.135 to 138 ) in Bloomfilter file :
```scala
/*
   * approximationWidth defines an interval around the maximum-likelihood cardinality
   * estimate. Namely, the approximation returned is of the form
   * (min, estimate, max) =
   *   ((1 - approxWidth) * estimate, estimate, (1 + approxWidth) * estimate)
   */
```

But there is a problem between the result from the : 

```scala
    "return a max approximate size if it's saturated" in {
      val bfMonoid = BloomFilterMonoid[String](5, 13)
      val strings = List(8, 9, 8, 10, 1, 8, 11, 7, 7, 1).map(_.toString)
      val bf = bfMonoid.create(strings: _*)
      // even it's seems big. This assert fail..
      assert(bf.size.max < strings.length * 100)
    }
```
which return : 
```
[info] - should return a max approximate size if it's saturated *** FAILED ***
[info]   2147483647 was not less than 1000 (BloomFilterTest.scala:459)
```
**2147483647** is a particular number because it's the maximum 32 bits integer you can have.