### PR TITLE
Bump spark version to 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ matrix:
       script: sbt ++$TRAVIS_SCALA_VERSION clean test mimaReportBinaryIssues
       #script: ./sbt ++$TRAVIS_SCALA_VERSION clean test
 
-    - scala: 2.11.11
+    - scala: 2.11.12
       script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport mimaReportBinaryIssues
       #script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport
       after_success:
         - bash <(curl -s https://codecov.io/bash)
 
-    - scala: 2.12.6
+    - scala: 2.12.7
       jdk: oraclejdk8
       script: sbt "++$TRAVIS_SCALA_VERSION clean" "++$TRAVIS_SCALA_VERSION test" "scalafmt::test" "test:scalafmt::test" "++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "++$TRAVIS_SCALA_VERSION docs/makeMicrosite"
       #script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "++$TRAVIS_SCALA_VERSION docs/makeMicrosite"

--- a/algebird-spark/src/main/scala/com/twitter/algebird/spark/AlgebirdRDD.scala
+++ b/algebird-spark/src/main/scala/com/twitter/algebird/spark/AlgebirdRDD.scala
@@ -1,9 +1,10 @@
 package com.twitter.algebird
 
 import com.twitter.algebird._
-import org.apache.spark.rdd.{ RDD, PairRDDFunctions }
+import org.apache.spark.rdd.{PairRDDFunctions, RDD}
 import org.apache.spark.Partitioner
 import scala.reflect.ClassTag
+
 /**
  * import com.twitter.algebird.spark.ToAlgebird
  * to get the enrichment to do:
@@ -12,6 +13,7 @@ import scala.reflect.ClassTag
  * This adds methods to Spark RDDs to use Algebird
  */
 class AlgebirdRDD[T](val rdd: RDD[T]) extends AnyVal {
+
   /**
    * Apply an Aggregator to return a single value for the whole RDD.
    * If the RDD is empty, None is returned
@@ -20,14 +22,17 @@ class AlgebirdRDD[T](val rdd: RDD[T]) extends AnyVal {
    */
   def aggregateOption[B: ClassTag, C](agg: Aggregator[T, B, C]): Option[C] = {
     val pr = rdd.mapPartitions({ data =>
-      if (data.isEmpty) Iterator.empty else {
+      if (data.isEmpty) Iterator.empty
+      else {
         val b = agg.prepare(data.next)
         Iterator(agg.appendAll(b, data))
       }
     }, preservesPartitioning = true)
     pr.repartition(1)
       .mapPartitions(pr => Iterator(agg.semigroup.sumOption(pr)))
-      .collect.head.map(agg.present)
+      .collect
+      .head
+      .map(agg.present)
   }
 
   /**
@@ -35,22 +40,25 @@ class AlgebirdRDD[T](val rdd: RDD[T]) extends AnyVal {
    * requires a commutative Semigroup. To generalize to non-commutative, we need a sorted partition for
    * T.
    */
-  def aggregate[B: ClassTag, C](agg: Aggregator[T, B, C]): C = (aggregateOption[B, C](agg), agg.semigroup) match {
-    case (Some(c), _) => c
-    case (None, m: Monoid[B]) => agg.present(m.zero)
-    case (None, _) => None.get // no such element
-  }
+  def aggregate[B: ClassTag, C](agg: Aggregator[T, B, C]): C =
+    (aggregateOption[B, C](agg), agg.semigroup) match {
+      case (Some(c), _)         => c
+      case (None, m: Monoid[B]) => agg.present(m.zero)
+      case (None, _)            => None.get // no such element
+    }
 
   /**
    * Apply an Aggregator to the values for each key.
    * requires a commutative Semigroup. To generalize to non-commutative, we need a sorted partition for
    * T.
    */
-  def aggregateByKey[K: ClassTag, V1, U: ClassTag, V2](
-    agg: Aggregator[V1, U, V2])(implicit ev: T <:< (K, V1), ordK: Priority[Ordering[K], DummyImplicit]): RDD[(K, V2)] =
+  def aggregateByKey[K: ClassTag, V1, U: ClassTag, V2](agg: Aggregator[V1, U, V2])(
+      implicit ev: T <:< (K, V1),
+      ordK: Priority[Ordering[K], DummyImplicit]): RDD[(K, V2)] =
     aggregateByKey(Partitioner.defaultPartitioner(rdd), agg)
 
-  private def toPair[K: ClassTag, V: ClassTag](kv: RDD[(K, V)])(implicit ordK: Priority[Ordering[K], DummyImplicit]) =
+  private def toPair[K: ClassTag, V: ClassTag](kv: RDD[(K, V)])(
+      implicit ordK: Priority[Ordering[K], DummyImplicit]) =
     new PairRDDFunctions(kv)(implicitly, implicitly, ordK.getPreferred.orNull)
 
   /**
@@ -58,9 +66,9 @@ class AlgebirdRDD[T](val rdd: RDD[T]) extends AnyVal {
    * requires a commutative Semigroup. To generalize to non-commutative, we need a sorted partition for
    * T.
    */
-  def aggregateByKey[K: ClassTag, V1, U: ClassTag, V2](
-    part: Partitioner,
-    agg: Aggregator[V1, U, V2])(implicit ev: T <:< (K, V1), ordK: Priority[Ordering[K], DummyImplicit]): RDD[(K, V2)] = {
+  def aggregateByKey[K: ClassTag, V1, U: ClassTag, V2](part: Partitioner, agg: Aggregator[V1, U, V2])(
+      implicit ev: T <:< (K, V1),
+      ordK: Priority[Ordering[K], DummyImplicit]): RDD[(K, V2)] = {
     /*
      * This mapValues implementation allows us to avoid needing the V1 ClassTag, which would
      * be required to use the implementation in PairRDDFunctions
@@ -69,8 +77,9 @@ class AlgebirdRDD[T](val rdd: RDD[T]) extends AnyVal {
       it.map { case (k, v) => (k, agg.prepare(v)) }
     }, preservesPartitioning = true)
 
-    toPair(toPair(prepared)
-      .reduceByKey(part, agg.reduce(_, _)))
+    toPair(
+      toPair(prepared)
+        .reduceByKey(part, agg.reduce(_, _)))
       .mapValues(agg.present)
   }
 
@@ -81,7 +90,8 @@ class AlgebirdRDD[T](val rdd: RDD[T]) extends AnyVal {
    * requires a commutative Semigroup. To generalize to non-commutative, we need a sorted partition for
    * T.
    */
-  def sumByKey[K: ClassTag, V: ClassTag: Semigroup](implicit ev: T <:< (K, V), ord: Priority[Ordering[K], DummyImplicit]): RDD[(K, V)] =
+  def sumByKey[K: ClassTag, V: ClassTag: Semigroup](implicit ev: T <:< (K, V),
+                                                    ord: Priority[Ordering[K], DummyImplicit]): RDD[(K, V)] =
     sumByKey(Partitioner.defaultPartitioner(rdd))
 
   /**
@@ -91,7 +101,7 @@ class AlgebirdRDD[T](val rdd: RDD[T]) extends AnyVal {
    * Unfortunately we need to use a different name than sumByKey in scala 2.11
    */
   def sumByKey[K: ClassTag, V: ClassTag: Semigroup](
-    part: Partitioner)(implicit ev: T <:< (K, V), ord: Priority[Ordering[K], DummyImplicit]): RDD[(K, V)] =
+      part: Partitioner)(implicit ev: T <:< (K, V), ord: Priority[Ordering[K], DummyImplicit]): RDD[(K, V)] =
     toPair(keyed).reduceByKey(part, implicitly[Semigroup[V]].plus _)
 
   /**
@@ -108,15 +118,17 @@ class AlgebirdRDD[T](val rdd: RDD[T]) extends AnyVal {
    * T.
    */
   def sumOption(implicit sg: Semigroup[T], ct: ClassTag[T]): Option[T] = {
-    val partialReduce: RDD[T] = rdd.mapPartitions(
-      { itT => sg.sumOption(itT).toIterator },
-      preservesPartitioning = true)
+    val partialReduce: RDD[T] = rdd.mapPartitions({ itT =>
+      sg.sumOption(itT).toIterator
+    }, preservesPartitioning = true)
 
     // my reading of the docs is that we do want a shuffle at this stage to
     // to make sure the upstream work is done in parallel.
-    val results = partialReduce.repartition(1).mapPartitions({ it =>
-      Iterator(sg.sumOption(it))
-    }, preservesPartitioning = true)
+    val results = partialReduce
+      .repartition(1)
+      .mapPartitions({ it =>
+        Iterator(sg.sumOption(it))
+      }, preservesPartitioning = true)
       .collect
 
     assert(results.size == 1, s"Should only be 1 item: ${results.toList}")

--- a/algebird-spark/src/main/scala/com/twitter/algebird/spark/package.scala
+++ b/algebird-spark/src/main/scala/com/twitter/algebird/spark/package.scala
@@ -1,6 +1,5 @@
 package com.twitter.algebird
 
-import com.twitter.algebird._
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import scala.reflect.ClassTag
@@ -10,6 +9,7 @@ import scala.reflect.ClassTag
  * import com.twitter.algebird.spark._
  */
 package object spark {
+
   /**
    * spark exposes an Aggregator type, so this is here to avoid shadowing
    */

--- a/algebird-spark/src/test/scala/com/twitter/algebird/spark/AlgebirdRDDTests.scala
+++ b/algebird-spark/src/test/scala/com/twitter/algebird/spark/AlgebirdRDDTests.scala
@@ -1,6 +1,6 @@
 package com.twitter.algebird.spark
 
-import com.twitter.algebird.{ MapAlgebra, Semigroup, Monoid, Min }
+import com.twitter.algebird.{MapAlgebra, Min, Monoid, Semigroup}
 import org.apache.spark._
 import org.apache.spark.rdd._
 import org.scalatest._
@@ -14,6 +14,7 @@ package test {
     def sum[T: Monoid: ClassTag](r: RDD[T]) = r.algebird.sum
   }
 }
+
 /**
  * This test almost always times out on travis.
  * Leaving at least a compilation test of using with spark
@@ -43,8 +44,8 @@ class AlgebirdRDDTest extends FunSuite with BeforeAndAfter {
   implicit def optEq[V](implicit eq: Equiv[V]): Equiv[Option[V]] = Equiv.fromFunction[Option[V]] { (o1, o2) =>
     (o1, o2) match {
       case (Some(v1), Some(v2)) => eq.equiv(v1, v2)
-      case (None, None) => true
-      case _ => false
+      case (None, None)         => true
+      case _                    => false
     }
   }
 
@@ -55,7 +56,8 @@ class AlgebirdRDDTest extends FunSuite with BeforeAndAfter {
     assertEq(sc.makeRDD(s).algebird.aggregate(agg), agg(s))
   }
 
-  def aggregateByKey[K: ClassTag, T: ClassTag, U: ClassTag, V: Equiv](s: Seq[(K, T)], agg: AlgebirdAggregator[T, U, V]) {
+  def aggregateByKey[K: ClassTag, T: ClassTag, U: ClassTag, V: Equiv](s: Seq[(K, T)],
+                                                                      agg: AlgebirdAggregator[T, U, V]) {
     val resMap = sc.makeRDD(s).algebird.aggregateByKey[K, T, U, V](agg).collect.toMap
     implicit val sg = agg.semigroup
     val algMap = MapAlgebra.sumByKey(s.map { case (k, t) => k -> agg.prepare(t) }).mapValues(agg.present)

--- a/sbt
+++ b/sbt
@@ -2,60 +2,64 @@
 #
 # A more capable sbt runner, coincidentally also called sbt.
 # Author: Paul Phillips <paulp@improving.org>
+# https://github.com/paulp/sbt-extras
 
-# todo - make this dynamic
-declare -r sbt_release_version="0.13.13"
-declare -r sbt_unreleased_version="0.13.13"
+set -o pipefail
+
+declare -r sbt_release_version="0.13.17"
+declare -r sbt_unreleased_version="0.13.17"
+
+declare -r latest_213="2.13.0-M5"
+declare -r latest_212="2.12.7"
+declare -r latest_211="2.11.12"
+declare -r latest_210="2.10.7"
+declare -r latest_29="2.9.3"
+declare -r latest_28="2.8.2"
+
 declare -r buildProps="project/build.properties"
 
-declare sbt_jar sbt_dir sbt_create sbt_version
-declare scala_version sbt_explicit_version
-declare verbose noshare batch trace_level log_level
-declare sbt_saved_stty debugUs
+declare -r sbt_launch_ivy_release_repo="http://repo.typesafe.com/typesafe/ivy-releases"
+declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy-snapshots"
+declare -r sbt_launch_mvn_release_repo="http://repo.scala-sbt.org/scalasbt/maven-releases"
+declare -r sbt_launch_mvn_snapshot_repo="http://repo.scala-sbt.org/scalasbt/maven-snapshots"
+
+declare -r default_jvm_opts_common="-Xms512m -Xss2m"
+declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
+
+declare sbt_jar sbt_dir sbt_create sbt_version sbt_script sbt_new
+declare sbt_explicit_version
+declare verbose noshare batch trace_level
+declare debugUs
+
+declare java_cmd="java"
+declare sbt_launch_dir="$HOME/.sbt/launchers"
+declare sbt_launch_repo
+
+# pull -J and -D options to give to java.
+declare -a java_args scalac_args sbt_commands residual_args
+
+# args to jvm/sbt via files or environment variables
+declare -a extra_jvm_opts extra_sbt_opts
 
 echoerr () { echo >&2 "$@"; }
 vlog ()    { [[ -n "$verbose" ]] && echoerr "$@"; }
+die ()     { echo "Aborting: $@" ; exit 1; }
 
-# spaces are possible, e.g. sbt.version = 0.13.0
-build_props_sbt () {
-  [[ -r "$buildProps" ]] && \
-    grep '^sbt\.version' "$buildProps" | tr '=\r' ' ' | awk '{ print $2; }'
-}
+setTrapExit () {
+  # save stty and trap exit, to ensure echo is re-enabled if we are interrupted.
+  export SBT_STTY="$(stty -g 2>/dev/null)"
 
-update_build_props_sbt () {
-  local ver="$1"
-  local old="$(build_props_sbt)"
-
-  [[ -r "$buildProps" ]] && [[ "$ver" != "$old" ]] && {
-    perl -pi -e "s/^sbt\.version\b.*\$/sbt.version=${ver}/" "$buildProps"
-    grep -q '^sbt.version[ =]' "$buildProps" || printf "\nsbt.version=%s\n" "$ver" >> "$buildProps"
-
-    vlog "!!!"
-    vlog "!!! Updated file $buildProps setting sbt.version to: $ver"
-    vlog "!!! Previous value was: $old"
-    vlog "!!!"
+  # restore stty settings (echo in particular)
+  onSbtRunnerExit() {
+    [ -t 0 ] || return
+    vlog ""
+    vlog "restoring stty: $SBT_STTY"
+    stty "$SBT_STTY"
   }
-}
 
-set_sbt_version () {
-  sbt_version="${sbt_explicit_version:-$(build_props_sbt)}"
-  [[ -n "$sbt_version" ]] || sbt_version=$sbt_release_version
-  export sbt_version
+  vlog "saving stty: $SBT_STTY"
+  trap onSbtRunnerExit EXIT
 }
-
-# restore stty settings (echo in particular)
-onSbtRunnerExit() {
-  [[ -n "$sbt_saved_stty" ]] || return
-  vlog ""
-  vlog "restoring stty: $sbt_saved_stty"
-  stty "$sbt_saved_stty"
-  unset sbt_saved_stty
-}
-
-# save stty and trap exit, to ensure echo is reenabled if we are interrupted.
-trap onSbtRunnerExit EXIT
-sbt_saved_stty="$(stty -g 2>/dev/null)"
-vlog "Saved stty: $sbt_saved_stty"
 
 # this seems to cover the bases on OSX, and someone will
 # have to tell me about the others.
@@ -71,21 +75,8 @@ get_script_path () {
   fi
 }
 
-die() {
-  echo "Aborting: $@"
-  exit 1
-}
-
-make_url () {
-  version="$1"
-
-  case "$version" in
-        0.7.*) echo "http://simple-build-tool.googlecode.com/files/sbt-launch-0.7.7.jar" ;;
-      0.10.* ) echo "$sbt_launch_repo/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
-    0.11.[12]) echo "$sbt_launch_repo/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
-            *) echo "$sbt_launch_repo/org.scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
-  esac
-}
+declare -r script_path="$(get_script_path "$BASH_SOURCE")"
+declare -r script_name="${script_path##*/}"
 
 init_default_option_file () {
   local overriding_var="${!1}"
@@ -99,60 +90,61 @@ init_default_option_file () {
   echo "$default_file"
 }
 
-declare -r cms_opts="-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
-declare -r jit_opts="-XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation"
-declare -r default_jvm_opts_common="-Xms512m -Xmx1536m -Xss2m $jit_opts $cms_opts"
-declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
-declare -r latest_28="2.8.2"
-declare -r latest_29="2.9.3"
-declare -r latest_210="2.10.5"
-declare -r latest_211="2.11.7"
-
-declare -r script_path="$(get_script_path "$BASH_SOURCE")"
-declare -r script_name="${script_path##*/}"
-
-# some non-read-onlies set with defaults
-declare java_cmd="java"
 declare sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
 declare jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
-declare sbt_launch_repo="http://repo.typesafe.com/typesafe/ivy-releases"
 
-# pull -J and -D options to give to java.
-declare -a residual_args
-declare -a java_args
-declare -a scalac_args
-declare -a sbt_commands
-
-# args to jvm/sbt via files or environment variables
-declare -a extra_jvm_opts extra_sbt_opts
-
-addJava () {
-  vlog "[addJava] arg = '$1'"
-  java_args+=("$1")
+build_props_sbt () {
+  [[ -r "$buildProps" ]] && \
+    grep '^sbt\.version' "$buildProps" | tr '=\r' ' ' | awk '{ print $2; }'
 }
-addSbt () {
-  vlog "[addSbt] arg = '$1'"
-  sbt_commands+=("$1")
+
+set_sbt_version () {
+  sbt_version="${sbt_explicit_version:-$(build_props_sbt)}"
+  [[ -n "$sbt_version" ]] || sbt_version=$sbt_release_version
+  export sbt_version
 }
+
+url_base () {
+  local version="$1"
+
+  case "$version" in
+        0.7.*) echo "http://simple-build-tool.googlecode.com" ;;
+      0.10.* ) echo "$sbt_launch_ivy_release_repo" ;;
+    0.11.[12]) echo "$sbt_launch_ivy_release_repo" ;;
+    0.*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]) # ie "*-yyyymmdd-hhMMss"
+               echo "$sbt_launch_ivy_snapshot_repo" ;;
+          0.*) echo "$sbt_launch_ivy_release_repo" ;;
+    *-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]) # ie "*-yyyymmdd-hhMMss"
+               echo "$sbt_launch_mvn_snapshot_repo" ;;
+            *) echo "$sbt_launch_mvn_release_repo" ;;
+  esac
+}
+
+make_url () {
+  local version="$1"
+
+  local base="${sbt_launch_repo:-$(url_base "$version")}"
+
+  case "$version" in
+        0.7.*) echo "$base/files/sbt-launch-0.7.7.jar" ;;
+      0.10.* ) echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
+    0.11.[12]) echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
+          0.*) echo "$base/org.scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
+            *) echo "$base/org/scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
+  esac
+}
+
+addJava ()     { vlog "[addJava] arg = '$1'"   ;     java_args+=("$1"); }
+addSbt ()      { vlog "[addSbt] arg = '$1'"    ;  sbt_commands+=("$1"); }
+addScalac ()   { vlog "[addScalac] arg = '$1'" ;   scalac_args+=("$1"); }
+addResidual () { vlog "[residual] arg = '$1'"  ; residual_args+=("$1"); }
+
+addResolver () { addSbt "set resolvers += $1"; }
+addDebugger () { addJava "-Xdebug" ; addJava "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"; }
 setThisBuild () {
   vlog "[addBuild] args = '$@'"
   local key="$1" && shift
   addSbt "set $key in ThisBuild := $@"
-}
-addScalac () {
-  vlog "[addScalac] arg = '$1'"
-  scalac_args+=("$1")
-}
-addResidual () {
-  vlog "[residual] arg = '$1'"
-  residual_args+=("$1")
-}
-addResolver () {
-  addSbt "set resolvers += $1"
-}
-addDebugger () {
-  addJava "-Xdebug"
-  addJava "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"
 }
 setScalaVersion () {
   [[ "$1" == *"-SNAPSHOT" ]] && addResolver 'Resolver.sonatypeRepo("snapshots")'
@@ -160,36 +152,51 @@ setScalaVersion () {
 }
 setJavaHome () {
   java_cmd="$1/bin/java"
-  setThisBuild javaHome "Some(file(\"$1\"))"
+  setThisBuild javaHome "_root_.scala.Some(file(\"$1\"))"
   export JAVA_HOME="$1"
   export JDK_HOME="$1"
   export PATH="$JAVA_HOME/bin:$PATH"
 }
-setJavaHomeQuietly () {
-  addSbt warn
-  setJavaHome "$1"
-  addSbt info
+
+getJavaVersion() {
+  local str=$("$1" -version 2>&1 | grep -E -e '(java|openjdk) version' | awk '{ print $3 }' | tr -d '"')
+
+  # java -version on java8 says 1.8.x
+  # but on 9 and 10 it's 9.x.y and 10.x.y.
+  if [[ "$str" =~ ^1\.([0-9]+)\..*$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  elif [[ "$str" =~ ^([0-9]+)\..*$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  elif [[ -n "$str" ]]; then
+    echoerr "Can't parse java version from: $str"
+  fi
 }
 
-# if set, use JDK_HOME/JAVA_HOME over java found in path
-if [[ -e "$JDK_HOME/lib/tools.jar" ]]; then
-  setJavaHomeQuietly "$JDK_HOME"
-elif [[ -e "$JAVA_HOME/bin/java" ]]; then
-  setJavaHomeQuietly "$JAVA_HOME"
-fi
+checkJava() {
+  # Warn if there is a Java version mismatch between PATH and JAVA_HOME/JDK_HOME
 
-# directory to store sbt launchers
-declare sbt_launch_dir="$HOME/.sbt/launchers"
-[[ -d "$sbt_launch_dir" ]] || mkdir -p "$sbt_launch_dir"
-[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$(mktemp -d -t sbt_extras_launchers.XXXXXX)"
+  [[ -n "$JAVA_HOME" && -e "$JAVA_HOME/bin/java"     ]] && java="$JAVA_HOME/bin/java"
+  [[ -n "$JDK_HOME"  && -e "$JDK_HOME/lib/tools.jar" ]] && java="$JDK_HOME/bin/java"
+
+  if [[ -n "$java" ]]; then
+    pathJavaVersion=$(getJavaVersion java)
+    homeJavaVersion=$(getJavaVersion "$java")
+    if [[ "$pathJavaVersion" != "$homeJavaVersion" ]]; then
+      echoerr "Warning: Java version mismatch between PATH and JAVA_HOME/JDK_HOME, sbt will use the one in PATH"
+      echoerr "  Either: fix your PATH, remove JAVA_HOME/JDK_HOME or use -java-home"
+      echoerr "  java version from PATH:               $pathJavaVersion"
+      echoerr "  java version from JAVA_HOME/JDK_HOME: $homeJavaVersion"
+    fi
+  fi
+}
 
 java_version () {
-  local version=$("$java_cmd" -version 2>&1 | grep -E -e '(java|openjdk) version' | awk '{ print $3 }' | tr -d \")
+  local version=$(getJavaVersion "$java_cmd")
   vlog "Detected Java version: $version"
-  echo "${version:2:1}"
+  echo "$version"
 }
 
-# MaxPermSize critical on pre-8 jvms but incurs noisy warning on 8+
+# MaxPermSize critical on pre-8 JVMs but incurs noisy warning on 8+
 default_jvm_opts () {
   local v="$(java_version)"
   if [[ $v -ge 8 ]]; then
@@ -222,16 +229,23 @@ execRunner () {
     vlog ""
   }
 
-  [[ -n "$batch" ]] && exec </dev/null
-  exec "$@"
+  setTrapExit
+
+  if [[ -n "$batch" ]]; then
+    "$@" < /dev/null
+  else
+    "$@"
+  fi
 }
 
-jar_url () {
-  make_url "$1"
-}
+jar_url ()  { make_url "$1"; }
+
+is_cygwin () [[ "$(uname -a)" == "CYGWIN"* ]]
 
 jar_file () {
-  echo "$sbt_launch_dir/$1/sbt-launch.jar"
+  is_cygwin \
+  && echo "$(cygpath -w $sbt_launch_dir/"$1"/sbt-launch.jar)" \
+  || echo "$sbt_launch_dir/$1/sbt-launch.jar"
 }
 
 download_url () {
@@ -243,33 +257,43 @@ download_url () {
   echoerr "    To  $jar"
 
   mkdir -p "${jar%/*}" && {
-    if which curl >/dev/null; then
+    if command -v curl > /dev/null 2>&1; then
       curl --fail --silent --location "$url" --output "$jar"
-    elif which wget >/dev/null; then
-      wget --quiet -O "$jar" "$url"
+    elif command -v wget > /dev/null 2>&1; then
+      wget -q -O "$jar" "$url"
     fi
   } && [[ -r "$jar" ]]
 }
 
 acquire_sbt_jar () {
-  sbt_url="$(jar_url "$sbt_version")"
-  sbt_jar="$(jar_file "$sbt_version")"
-
-  [[ -r "$sbt_jar" ]] || download_url "$sbt_url" "$sbt_jar"
+  {
+    sbt_jar="$(jar_file "$sbt_version")"
+    [[ -r "$sbt_jar" ]]
+  } || {
+    sbt_jar="$HOME/.ivy2/local/org.scala-sbt/sbt-launch/$sbt_version/jars/sbt-launch.jar"
+    [[ -r "$sbt_jar" ]]
+  } || {
+    sbt_jar="$(jar_file "$sbt_version")"
+    download_url "$(make_url "$sbt_version")" "$sbt_jar"
+  }
 }
 
 usage () {
+  set_sbt_version
   cat <<EOM
 Usage: $script_name [options]
+
 Note that options which are passed along to sbt begin with -- whereas
 options to this runner use a single dash. Any sbt command can be scheduled
 to run first by prefixing the command with --, so --warn, --error and so on
 are not special.
+
 Output filtering: if there is a file in the home directory called .sbtignore
 and this is not an interactive sbt session, the file is treated as a list of
 bash regular expressions. Output lines which match any regex are not echoed.
 One can see exactly which lines would have been suppressed by starting this
 runner with the -x option.
+
   -h | -help         print this message
   -v                 verbose operation (this runner is chattier)
   -d, -w, -q         aliases for --debug, --warn, --error (q means quiet)
@@ -286,23 +310,30 @@ runner with the -x option.
   -jvm-debug <port>  Turn on JVM debugging, open at the given port.
   -batch             Disable interactive mode
   -prompt <expr>     Set the sbt prompt; in expr, 's' is the State and 'e' is Extracted
+  -script <file>     Run the specified file as a scala script
+
   # sbt version (default: sbt.version from $buildProps if present, otherwise $sbt_release_version)
   -sbt-force-latest         force the use of the latest release of sbt: $sbt_release_version
   -sbt-version  <version>   use the specified version of sbt (default: $sbt_release_version)
   -sbt-dev                  use the latest pre-release version of sbt: $sbt_unreleased_version
   -sbt-jar      <path>      use the specified jar as the sbt launcher
-  -sbt-launch-dir <path>    directory to hold sbt launchers (default: ~/.sbt/launchers)
-  -sbt-launch-repo <url>    repo url for downloading sbt launcher jar (default: $sbt_launch_repo)
+  -sbt-launch-dir <path>    directory to hold sbt launchers (default: $sbt_launch_dir)
+  -sbt-launch-repo <url>    repo url for downloading sbt launcher jar (default: $(url_base "$sbt_version"))
+
   # scala version (default: as chosen by sbt)
   -28                       use $latest_28
   -29                       use $latest_29
   -210                      use $latest_210
   -211                      use $latest_211
+  -212                      use $latest_212
+  -213                      use $latest_213
   -scala-home <path>        use the scala build at the specified directory
   -scala-version <version>  use the specified version of scala
   -binary-version <version> use the specified scala version when searching for dependencies
+
   # java version (default: java from PATH, currently $(java -version 2>&1 | grep version))
   -java-home <path>         alternate JAVA_HOME
+
   # passing options to the jvm - note it does NOT use JAVA_OPTS due to pollution
   # The default set is used if JVM_OPTS is unset and no -jvm-opts file is found
   <default>        $(default_jvm_opts)
@@ -312,6 +343,7 @@ runner with the -x option.
   -jvm-opts <path> file containing jvm args (if not given, .jvmopts in project root is used if present)
   -Dkey=val        pass -Dkey=val directly to the jvm
   -J-X             pass option -X directly to the jvm (-J is stripped)
+
   # passing options to sbt, OR to this runner
   SBT_OPTS         environment variable holding either the sbt args directly, or
                    the reference to a file containing sbt args if given path is prepended by '@' (e.g. '@/etc/sbtopts')
@@ -321,8 +353,7 @@ runner with the -x option.
 EOM
 }
 
-process_args ()
-{
+process_args () {
   require_arg () {
     local type="$1"
     local opt="$2"
@@ -334,11 +365,11 @@ process_args ()
   }
   while [[ $# -gt 0 ]]; do
     case "$1" in
-          -h|-help) usage; exit 1 ;;
+          -h|-help) usage; exit 0 ;;
                 -v) verbose=true && shift ;;
-                -d) addSbt "--debug" && addSbt debug && shift ;;
-                -w) addSbt "--warn"  && addSbt warn  && shift ;;
-                -q) addSbt "--error" && addSbt error && shift ;;
+                -d) addSbt "--debug" && shift ;;
+                -w) addSbt "--warn"  && shift ;;
+                -q) addSbt "--error" && shift ;;
                 -x) debugUs=true && shift ;;
             -trace) require_arg integer "$1" "$2" && trace_level="$2" && shift 2 ;;
               -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
@@ -347,10 +378,11 @@ process_args ()
          -sbt-boot) require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;
           -sbt-dir) require_arg path "$1" "$2" && sbt_dir="$2" && shift 2 ;;
         -debug-inc) addJava "-Dxsbt.inc.debug=true" && shift ;;
-          -offline) addSbt "set offline := true" && shift ;;
+          -offline) addSbt "set offline in Global := true" && shift ;;
         -jvm-debug) require_arg port "$1" "$2" && addDebugger "$2" && shift 2 ;;
             -batch) batch=true && shift ;;
            -prompt) require_arg "expr" "$1" "$2" && setThisBuild shellPrompt "(s => { val e = Project.extract(s) ; $2 })" && shift 2 ;;
+           -script) require_arg file "$1" "$2" && sbt_script="$2" && addJava "-Dsbt.main.class=sbt.ScriptMain" && shift 2 ;;
 
        -sbt-create) sbt_create=true && shift ;;
           -sbt-jar) require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
@@ -361,7 +393,7 @@ process_args ()
   -sbt-launch-repo) require_arg path "$1" "$2" && sbt_launch_repo="$2" && shift 2 ;;
     -scala-version) require_arg version "$1" "$2" && setScalaVersion "$2" && shift 2 ;;
    -binary-version) require_arg version "$1" "$2" && setThisBuild scalaBinaryVersion "\"$2\"" && shift 2 ;;
-       -scala-home) require_arg path "$1" "$2" && setThisBuild scalaHome "Some(file(\"$2\"))" && shift 2 ;;
+       -scala-home) require_arg path "$1" "$2" && setThisBuild scalaHome "_root_.scala.Some(file(\"$2\"))" && shift 2 ;;
         -java-home) require_arg path "$1" "$2" && setJavaHome "$2" && shift 2 ;;
          -sbt-opts) require_arg path "$1" "$2" && sbt_opts_file="$2" && shift 2 ;;
          -jvm-opts) require_arg path "$1" "$2" && jvm_opts_file="$2" && shift 2 ;;
@@ -373,10 +405,9 @@ process_args ()
                -29) setScalaVersion "$latest_29" && shift ;;
               -210) setScalaVersion "$latest_210" && shift ;;
               -211) setScalaVersion "$latest_211" && shift ;;
-
-           --debug) addSbt debug && addResidual "$1" && shift ;;
-            --warn) addSbt warn  && addResidual "$1" && shift ;;
-           --error) addSbt error && addResidual "$1" && shift ;;
+              -212) setScalaVersion "$latest_212" && shift ;;
+              -213) setScalaVersion "$latest_213" && shift ;;
+               new) sbt_new=true && : ${sbt_explicit_version:=$sbt_release_version} && addResidual "$1" && shift ;;
                  *) addResidual "$1" && shift ;;
     esac
   done
@@ -387,8 +418,10 @@ process_args "$@"
 
 # skip #-styled comments and blank lines
 readConfigFile() {
-  while read line; do
-    [[ $line =~ ^# ]] || [[ -z $line ]] || echo "$line"
+  local end=false
+  until $end; do
+    read || end=true
+    [[ $REPLY =~ ^# ]] || [[ -z $REPLY ]] || echo "$REPLY"
   done < "$1"
 }
 
@@ -413,6 +446,8 @@ argumentCount=$#
 # set sbt version
 set_sbt_version
 
+checkJava
+
 # only exists in 0.12+
 setTraceLevel() {
   case "$sbt_version" in
@@ -424,30 +459,36 @@ setTraceLevel() {
 # set scalacOptions if we were given any -S opts
 [[ ${#scalac_args[@]} -eq 0 ]] || addSbt "set scalacOptions in ThisBuild += \"${scalac_args[@]}\""
 
-# Update build.properties on disk to set explicit version - sbt gives us no choice
-[[ -n "$sbt_explicit_version" ]] && update_build_props_sbt "$sbt_explicit_version"
+[[ -n "$sbt_explicit_version" && -z "$sbt_new" ]] && addJava "-Dsbt.version=$sbt_explicit_version"
 vlog "Detected sbt version $sbt_version"
 
-[[ -n "$scala_version" ]] && vlog "Overriding scala version to $scala_version"
+if [[ -n "$sbt_script" ]]; then
+  residual_args=( $sbt_script ${residual_args[@]} )
+else
+  # no args - alert them there's stuff in here
+  (( argumentCount > 0 )) || {
+    vlog "Starting $script_name: invoke with -help for other options"
+    residual_args=( shell )
+  }
+fi
 
-# no args - alert them there's stuff in here
-(( argumentCount > 0 )) || {
-  vlog "Starting $script_name: invoke with -help for other options"
-  residual_args=( shell )
-}
-
-# verify this is an sbt dir or -create was given
-[[ -r ./build.sbt || -d ./project || -n "$sbt_create" ]] || {
+# verify this is an sbt dir, -create was given or user attempts to run a scala script
+[[ -r ./build.sbt || -d ./project || -n "$sbt_create" || -n "$sbt_script" || -n "$sbt_new" ]] || {
   cat <<EOM
 $(pwd) doesn't appear to be an sbt project.
 If you want to start sbt anyway, run:
   $0 -sbt-create
+
 EOM
   exit 1
 }
 
 # pick up completion if present; todo
 [[ -r .sbt_completion.sh ]] && source .sbt_completion.sh
+
+# directory to store sbt launchers
+[[ -d "$sbt_launch_dir" ]] || mkdir -p "$sbt_launch_dir"
+[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$(mktemp -d -t sbt_extras_launchers.XXXXXX)"
 
 # no jar? download it.
 [[ -r "$sbt_jar" ]] || acquire_sbt_jar || {
@@ -510,8 +551,8 @@ mainFiltered () {
 
   echoLine () {
     local line="$1"
-    local line1="$(echo "$line" | sed -r 's/\r\x1BM\x1B\[2K//g')"       # This strips the OverwriteLine code.
-    local line2="$(echo "$line1" | sed -r 's/\x1B\[[0-9;]*[JKmsu]//g')" # This strips all codes - we test regexes against this.
+    local line1="$(echo "$line" | sed 's/\r\x1BM\x1B\[2K//g')"       # This strips the OverwriteLine code.
+    local line2="$(echo "$line1" | sed 's/\x1B\[[0-9;]*[JKmsu]//g')" # This strips all codes - we test regexes against this.
 
     if [[ $line2 =~ $excludeRegex ]]; then
       [[ -n $debugUs ]] && echo "[X] $line1"


### PR DESCRIPTION
Hey, 

to support `algerbird-spark` #669 module on scala 2.12.x, we upgrade spark dependency to 2.4.0.

also, we need to disable `-opt:l:inline` and `-opt-inline-from:com.twitter.algebird.**` to workround issue https://github.com/scala/bug/issues/11247.

also, upgrade sbt script as the side effect. 