### PR TITLE
More benchmarks for creating bloom filters

### DIFF
--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterCreateBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterCreateBenchmark.scala
@@ -37,4 +37,22 @@ class BloomFilterCreateBenchmark {
     val bf = bfMonoid.create(bloomFilterState.randomStrings: _*)
     bf
   }
+
+  @Benchmark
+  def createBloomFilterUsingFold(bloomFilterState: BloomFilterState): BF[String] = {
+    val bfMonoid = BloomFilter[String](bloomFilterState.nbrOfElements, bloomFilterState.falsePositiveRate)
+    val bf = bloomFilterState.randomStrings.foldLeft(bfMonoid.zero) {
+      case (filter, string) => filter + string
+    }
+    bf
+  }
+
+  @Benchmark
+  def createBloomFilterAggregator(bloomFilterState: BloomFilterState): BF[String] = {
+    val bfMonoid = BloomFilter[String](bloomFilterState.nbrOfElements, bloomFilterState.falsePositiveRate)
+    val bfAggregator = BloomFilterAggregator(bfMonoid)
+
+    val bf = bloomFilterState.randomStrings.aggregate(bfAggregator.monoid.zero)(_ + _, _ ++ _)
+    bf
+  }
 }


### PR DESCRIPTION
In some use cases in [Scio](https://github.com/spotify/scio) we create large Bloom filters with around 5 ~ 50M entries in some batch data pipelines. We were using BloomFilterAggregator API for most of our uses cases, and it felt like a good idea to bench mark the aggregator for comparison.