### PR TITLE
Update Ruby version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - export PATH=${PATH}:./vendor/bundle
 
 install:
-  - rvm use 2.2.5 --install --fuzzy
+  - rvm use 2.6.1 --install --fuzzy
   - gem update --system
   - gem install sass
   - gem install jekyll -v 3.2.1


### PR DESCRIPTION
The builds via travis are failing because of an outdated ruby version which is no longer supported.
updating to the latest version passes the builds.