### PR TITLE
Remove most of the unused warns

### DIFF
--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/AsyncSummerBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/AsyncSummerBenchmark.scala
@@ -113,7 +113,7 @@ object AsyncSummerBenchmark {
         Counter("tuplesOut")
       )
 
-      val inputData: IndexedSeq[(Long, HLL)] = (0L until numInputItems).map { inputKey =>
+      val inputData: IndexedSeq[(Long, HLL)] = (0L until numInputItems).map { _ =>
         val pos = rnd.nextInt(10)
         val k = if (pos < 8) { // 80% chance of hitting a heavy hitter
           heavyKeysIndexedSeq(rnd.nextInt(heavyKeysIndexedSeq.size))

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterDistanceBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/BloomFilterDistanceBenchmark.scala
@@ -20,8 +20,8 @@ object BloomFilterDistanceBenchmark {
       val bs = LongBitSet.empty(width)
       bs += hashes(item)
       BFInstance(hashes, bs.toBitSetNoCopy, width)
-    case bfs @ BFSparse(hashes, bitset, width)   => bfs.dense
-    case bfi @ BFInstance(hashes, bitset, width) => bfi
+    case bfs @ BFSparse(_, _, _)   => bfs.dense
+    case bfi @ BFInstance(_, _, _) => bfi
   }
 
   @State(Scope.Benchmark)

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/CMSBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/CMSBenchmark.scala
@@ -50,7 +50,7 @@ object CMSBenchmark {
       stringMonoid = CMS.monoid[String](eps, delta, Seed)
 
       val bitsPerChar = 16
-      largeStrings = (1 to size).map(i => nextString(MaxBits / bitsPerChar)).toVector
+      largeStrings = (1 to size).map(_ => nextString(MaxBits / bitsPerChar)).toVector
       largeBigInts = largeStrings.map(s => BigInt(s.getBytes))
       largeBigDecimals = largeStrings.map(s => {
         val md = (s.head % 256) - 128

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/CMSHashingBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/CMSHashingBenchmark.scala
@@ -1,6 +1,7 @@
 package com.twitter.algebird.benchmark
 
 import org.openjdk.jmh.annotations._
+import com.twitter.algebird.CMSHasher
 
 /**
  * Benchmarks the hashing algorithms used by Count-Min sketch for CMS[BigInt].
@@ -75,13 +76,7 @@ class CMSHashingBenchmark {
   import CMSHashingBenchmark._
 
   private def murmurHashScala(a: Int, b: Int, width: Int)(x: BigInt) = {
-    val hash: Int = scala.util.hashing.MurmurHash3.arrayHash(x.toByteArray, a)
-    val h = {
-      // We only want positive integers for the subsequent modulo.  This method mimics Java's Hashtable
-      // implementation.  The Java code uses `0x7FFFFFFF` for the bit-wise AND, which is equal to Int.MaxValue.
-      val positiveHash = hash & Int.MaxValue
-      positiveHash % width
-    }
+    val h = CMSHasher.hashBytes(a, b, width)(x.toByteArray)
     assert(h >= 0, "hash must not be negative")
     h
   }

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/TopCMSBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/TopCMSBenchmark.scala
@@ -51,7 +51,7 @@ object TopCMSBenchmark {
       cmsStringMonoid = TopPctCMS.monoid[String](eps, delta, Seed, pct)
 
       val bitsPerChar = 16
-      largeStrings = (1 to size).map(i => nextString(MaxBits / bitsPerChar)).toVector
+      largeStrings = (1 to size).map(_ => nextString(MaxBits / bitsPerChar)).toVector
       largeBigInts = largeStrings.map(s => BigInt(s.getBytes))
       largeBigDecimals = largeStrings.map(s => {
         val md = (s.head % 256) - 128

--- a/algebird-core/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/AdaptiveVector.scala
@@ -73,7 +73,7 @@ object AdaptiveVector {
 
   def toVector[V](v: AdaptiveVector[V]): Vector[V] =
     v match {
-      case DenseVector(is, sv, _) => is
+      case DenseVector(is, _, _)  => is
       case SparseVector(m, v, sz) => toVector(m, v, sz)
     }
 
@@ -96,7 +96,7 @@ object AdaptiveVector {
         // they have the same sparse value
         val maxSize = Ordering[Int].max(left.size, right.size)
         (left, right) match {
-          case (DenseVector(lv, ls, ld), DenseVector(rv, rs, rd)) =>
+          case (DenseVector(lv, ls, _), DenseVector(rv, _, _)) =>
             val vec = Semigroup.plus[IndexedSeq[V]](lv, rv) match {
               case v: Vector[_] => v.asInstanceOf[Vector[V]]
               case notV         => Vector(notV: _*)

--- a/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -178,14 +178,14 @@ object Aggregator extends java.io.Serializable {
   /**
    * Take the first (left most in reduce order) item found
    */
-  def head[T]: Aggregator[T, T, T] = fromReduce[T] { (l, r) =>
+  def head[T]: Aggregator[T, T, T] = fromReduce[T] { (l, _) =>
     l
   }
 
   /**
    * Take the last (right most in reduce order) item found
    */
-  def last[T]: Aggregator[T, T, T] = fromReduce[T] { (l, r) =>
+  def last[T]: Aggregator[T, T, T] = fromReduce[T] { (_, r) =>
     r
   }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -455,8 +455,8 @@ case class BFItem[A](item: A, hashes: BFHash[A], width: Int) extends BF[A] {
 
   def ++(other: BF[A]): BF[A] =
     other match {
-      case _ @BFZero(_, _)            => this
-      case _ @BFItem(otherItem, _, _) => toSparse + otherItem
+      case BFZero(_, _)            => this
+      case BFItem(otherItem, _, _) => toSparse + otherItem
       case _                          => other + item
     }
 
@@ -504,8 +504,8 @@ case class BFSparse[A](hashes: BFHash[A], bits: CBitSet, width: Int) extends BF[
     require(this.numHashes == other.numHashes)
 
     other match {
-      case _ @BFZero(_, _)       => this
-      case _ @BFItem(item, _, _) => this + item
+      case BFZero(_, _)       => this
+      case BFItem(item, _, _) => this + item
       case bf @ BFSparse(_, otherBits, _) => {
         // assume same hashes used
 
@@ -576,7 +576,7 @@ case class BFInstance[A](hashes: BFHash[A], bits: BitSet, width: Int) extends BF
       case BFSparse(_, otherBits, _) =>
         // assume same hashes used
         BFInstance(hashes, bits | (new RichCBitSet(otherBits)).toBitSet(width), width)
-      case _ @BFInstance(_, otherBits, _) => {
+      case BFInstance(_, otherBits, _) => {
         // assume same hashes used
         BFInstance(hashes, bits ++ otherBits, width)
       }

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -400,9 +400,9 @@ sealed abstract class BF[A] extends java.io.Serializable {
     (this, that) match {
       // Comparing with empty filter should give number
       // of bits in other set
-      case (x: BFZero[A], y: BFZero[A]) => 0
-      case (x: BFZero[A], y: BF[A])     => y.numBits
-      case (x: BF[A], y: BFZero[A])     => x.numBits
+      case (_: BFZero[A], _: BFZero[A]) => 0
+      case (_: BFZero[A], y: BF[A])     => y.numBits
+      case (x: BF[A], _: BFZero[A])     => x.numBits
 
       // Special case for Sparse vs. Sparse
       case (x: BFSparse[A], y: BFSparse[A]) => x.bits.xorCardinality(y.bits)
@@ -455,9 +455,9 @@ case class BFItem[A](item: A, hashes: BFHash[A], width: Int) extends BF[A] {
 
   def ++(other: BF[A]): BF[A] =
     other match {
-      case bf @ BFZero(_, _)            => this
-      case bf @ BFItem(otherItem, _, _) => toSparse + otherItem
-      case _                            => other + item
+      case _ @BFZero(_, _)            => this
+      case _ @BFItem(otherItem, _, _) => toSparse + otherItem
+      case _                          => other + item
     }
 
   def +(other: A) = this ++ BFItem(other, hashes, width)
@@ -504,8 +504,8 @@ case class BFSparse[A](hashes: BFHash[A], bits: CBitSet, width: Int) extends BF[
     require(this.numHashes == other.numHashes)
 
     other match {
-      case bf @ BFZero(_, _)       => this
-      case bf @ BFItem(item, _, _) => this + item
+      case _ @BFZero(_, _)       => this
+      case _ @BFItem(item, _, _) => this + item
       case bf @ BFSparse(_, otherBits, _) => {
         // assume same hashes used
 
@@ -576,7 +576,7 @@ case class BFInstance[A](hashes: BFHash[A], bits: BitSet, width: Int) extends BF
       case BFSparse(_, otherBits, _) =>
         // assume same hashes used
         BFInstance(hashes, bits | (new RichCBitSet(otherBits)).toBitSet(width), width)
-      case bf @ BFInstance(_, otherBits, _) => {
+      case _ @BFInstance(_, otherBits, _) => {
         // assume same hashes used
         BFInstance(hashes, bits ++ otherBits, width)
       }

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -457,7 +457,7 @@ case class BFItem[A](item: A, hashes: BFHash[A], width: Int) extends BF[A] {
     other match {
       case BFZero(_, _)            => this
       case BFItem(otherItem, _, _) => toSparse + otherItem
-      case _                          => other + item
+      case _                       => other + item
     }
 
   def +(other: A) = this ++ BFItem(other, hashes, width)

--- a/algebird-core/src/main/scala/com/twitter/algebird/CMSHasher.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CMSHasher.scala
@@ -116,6 +116,7 @@ object CMSHasher {
    * @return Slot assigned to item `x` in the vector of size `width`, where `x in [0, width)`.
    */
   private[algebird] def hashBytes(a: Int, b: Int, width: Int)(x: Array[Byte]): Int = {
+    val _ = b // suppressing unused `b`
     val hash: Int = scala.util.hashing.MurmurHash3.arrayHash(x, a)
     // We only want positive integers for the subsequent modulo.  This method mimics Java's Hashtable
     // implementation.  The Java code uses `0x7FFFFFFF` for the bit-wise AND, which is equal to Int.MaxValue.

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -180,7 +180,7 @@ class CMSSummation[K](params: CMSParams[K]) {
         ()
       case CMSItem(item, count, _) =>
         insert(item, count)
-      case SparseCMS(table, count, _) =>
+      case SparseCMS(table, _, _) =>
         table.foreach {
           case (item, c) =>
             insert(item, c)
@@ -605,7 +605,7 @@ case class CMSItem[K](item: K, override val totalCount: Long, override val param
 
   override def ++(other: CMS[K]): CMS[K] =
     other match {
-      case other: CMSZero[_] => this
+      case _: CMSZero[_] => this
       case other: CMSItem[K] =>
         CMSInstance[K](params) + (item, totalCount) + (other.item, other.totalCount)
       case _ => other + item
@@ -642,7 +642,7 @@ case class SparseCMS[K](
 
   override def ++(other: CMS[K]): CMS[K] =
     other match {
-      case other: CMSZero[_]   => this
+      case _: CMSZero[_]       => this
       case other: CMSItem[K]   => this + (other.item, other.totalCount)
       case other: SparseCMS[K] =>
         // This SparseCMS's maxExactCount is used, so ++ is not communitive
@@ -699,7 +699,7 @@ case class CMSInstance[K](
 
   def ++(other: CMS[K]): CMS[K] =
     other match {
-      case other: CMSZero[_] => this
+      case _: CMSZero[_]     => this
       case other: CMSItem[K] => this + other.item
       case other: SparseCMS[K] =>
         other.exactCountTable.foldLeft(this) {
@@ -934,7 +934,7 @@ case class TopCMSItem[K](item: K, override val cms: CMS[K], params: TopCMSParams
   override def +(x: K, count: Long): TopCMS[K] = toCMSInstance + (x, count)
 
   override def ++(other: TopCMS[K]): TopCMS[K] = other match {
-    case other: TopCMSZero[_]     => this
+    case _: TopCMSZero[_]         => this
     case other: TopCMSItem[K]     => toCMSInstance + other.item
     case other: TopCMSInstance[K] => other + item
   }
@@ -969,7 +969,7 @@ case class TopCMSInstance[K](override val cms: CMS[K], hhs: HeavyHitters[K], par
   }
 
   override def ++(other: TopCMS[K]): TopCMS[K] = other match {
-    case other: TopCMSZero[_] => this
+    case _: TopCMSZero[_]     => this
     case other: TopCMSItem[K] => this + other.item
     case other: TopCMSInstance[K] =>
       val newCms = cms ++ other.cms

--- a/algebird-core/src/main/scala/com/twitter/algebird/First.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/First.scala
@@ -30,7 +30,10 @@ case class First[@specialized(Int, Long, Float, Double) +T](get: T) {
    *
    * @param r ignored instance of `First[U]`
    */
-  def +[U >: T](r: First[U]): First[T] = this
+  def +[U >: T](r: First[U]): First[T] = {
+    val _ = r //suppressing unused `r`
+    this
+  }
 }
 
 /**

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -426,7 +426,7 @@ case class SparseHLL(bits: Int, maxRhow: Map[Int, Max[Byte]]) extends HLL {
         val iter: Iterator[(Int, Max[Byte])] = maxRhow.iterator
 
         while (iter.hasNext) {
-          val (idx, maxB) = iter.next
+          val (idx, _) = iter.next
           val existing: Byte = newContents(idx)
           val other: Byte = maxRhow(idx).get
 
@@ -614,7 +614,7 @@ class HyperLogLogMonoid(val bits: Int) extends Monoid[HLL] with BoundedSemilatti
       .map { x =>
         jRhoW(hash(x), bits)
       }
-      .groupBy { case (j, rhow) => j }
+      .groupBy { case (j, _) => j }
       .map { case (j, iter) => (j, Max(iter.maxBy(_._2)._2)) }
     if (allMaxRhow.size * 16 <= size) {
       SparseHLL(bits, allMaxRhow)

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLogSeries.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLogSeries.scala
@@ -84,7 +84,7 @@ case class HLLSeries(bits: Int, rows: Vector[Map[Int, Long]]) {
    * @return New HLLSeries only including RhoWs for values seen at or after the given timestamp
    */
   def since(threshold: Long): HLLSeries =
-    HLLSeries(bits, rows.map { _.filter { case (j, ts) => ts >= threshold } })
+    HLLSeries(bits, rows.map { _.filter { case (_, ts) => ts >= threshold } })
 
   def toHLL: HLL = {
     val monoid = new HyperLogLogMonoid(bits)
@@ -92,7 +92,7 @@ case class HLLSeries(bits: Int, rows: Vector[Map[Int, Long]]) {
     else {
       monoid.sum(rows.iterator.zipWithIndex.map {
         case (map, i) =>
-          SparseHLL(bits, map.mapValues { ts =>
+          SparseHLL(bits, map.mapValues { _ =>
             Max((i + 1).toByte)
           })
       })

--- a/algebird-core/src/main/scala/com/twitter/algebird/Interval.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Interval.scala
@@ -133,8 +133,8 @@ object Interval extends java.io.Serializable {
         !succ.next(l).exists(succ.ordering.lt(_, u))
       case Intersection(ExclusiveLower(l), InclusiveUpper(u)) =>
         !succ.next(l).exists(succ.ordering.lteq(_, u))
-      case InclusiveLower(l) => false // we at least have l
-      case InclusiveUpper(u) => false //false // we at least have u
+      case InclusiveLower(_) => false // we at least have l
+      case InclusiveUpper(_) => false //false // we at least have u
       case ExclusiveLower(l) =>
         succ.next(l).isEmpty
       case ExclusiveUpper(u) =>
@@ -150,7 +150,7 @@ object Interval extends java.io.Serializable {
     def boundedLeast(implicit succ: Successible[T]): Option[T] = intr match {
       case Empty()                => None
       case Universe()             => None
-      case u: Upper[_]            => None
+      case _: Upper[_]            => None
       case i @ Intersection(_, _) => i.least
       case l: Lower[_]            => l.least
     }
@@ -165,7 +165,7 @@ object Interval extends java.io.Serializable {
       intr match {
         case Empty()                => None
         case Universe()             => None
-        case l: Lower[_]            => None
+        case _: Lower[_]            => None
         case i @ Intersection(_, _) => i.greatest
         case u: Upper[_]            => u.greatest
       }
@@ -229,9 +229,9 @@ case class InclusiveLower[T](lower: T) extends Interval[T] with Lower[T] {
   def intersect(that: Interval[T])(implicit ordering: Ordering[T]): Interval[T] = that match {
     case Universe() => this
     case Empty()    => that
-    case ub @ InclusiveUpper(upper) =>
+    case ub @ InclusiveUpper(_) =>
       if (intersects(ub)) Intersection(this, ub) else Empty()
-    case ub @ ExclusiveUpper(upper) =>
+    case ub @ ExclusiveUpper(_) =>
       if (intersects(ub)) Intersection(this, ub) else Empty()
     case InclusiveLower(thatlb) =>
       if (ordering.gt(lower, thatlb)) this else that
@@ -254,9 +254,9 @@ case class ExclusiveLower[T](lower: T) extends Interval[T] with Lower[T] {
   def intersect(that: Interval[T])(implicit ordering: Ordering[T]): Interval[T] = that match {
     case Universe() => this
     case Empty()    => that
-    case ub @ InclusiveUpper(upper) =>
+    case ub @ InclusiveUpper(_) =>
       if (intersects(ub)) Intersection(this, ub) else Empty()
-    case ub @ ExclusiveUpper(upper) =>
+    case ub @ ExclusiveUpper(_) =>
       if (intersects(ub)) Intersection(this, ub) else Empty()
     case InclusiveLower(thatlb) =>
       if (ordering.gteq(lower, thatlb)) this else that
@@ -283,9 +283,9 @@ case class InclusiveUpper[T](upper: T) extends Interval[T] with Upper[T] {
   def intersect(that: Interval[T])(implicit ordering: Ordering[T]): Interval[T] = that match {
     case Universe() => this
     case Empty()    => that
-    case lb @ InclusiveLower(lower) =>
+    case lb @ InclusiveLower(_) =>
       if (lb.intersects(this)) Intersection(lb, this) else Empty()
-    case lb @ ExclusiveLower(lower) =>
+    case lb @ ExclusiveLower(_) =>
       if (lb.intersects(this)) Intersection(lb, this) else Empty()
     case InclusiveUpper(thatub) =>
       if (ordering.lt(upper, thatub)) this else that
@@ -304,9 +304,9 @@ case class ExclusiveUpper[T](upper: T) extends Interval[T] with Upper[T] {
   def intersect(that: Interval[T])(implicit ordering: Ordering[T]): Interval[T] = that match {
     case Universe() => this
     case Empty()    => that
-    case lb @ InclusiveLower(lower) =>
+    case lb @ InclusiveLower(_) =>
       if (lb.intersects(this)) Intersection(lb, this) else Empty()
-    case lb @ ExclusiveLower(lower) =>
+    case lb @ ExclusiveLower(_) =>
       if (lb.intersects(this)) Intersection(lb, this) else Empty()
     case InclusiveUpper(thatub) =>
       if (ordering.lteq(upper, thatub)) this else that

--- a/algebird-core/src/main/scala/com/twitter/algebird/MapAlgebra.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/MapAlgebra.scala
@@ -57,8 +57,8 @@ abstract class GenericMapMonoid[K, V, M <: ScMap[K, V]](implicit val semigroup: 
       // Mutable maps create new copies of the underlying data on add so don't use the
       // handleImmutable method.
       // Cannot have a None so 'get' is safe here.
-      case mmap: MMap[_, _] => sumOption(Seq(big, small)).get
-      case _                => handleImmutable(big, small, bigOnLeft)
+      case _: MMap[_, _] => sumOption(Seq(big, small)).get
+      case _             => handleImmutable(big, small, bigOnLeft)
     }
   }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/MinHasher.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/MinHasher.scala
@@ -73,7 +73,7 @@ abstract class MinHasher[H](val numHashes: Int, val numBands: Int)(implicit n: N
   private val hashFunctions = {
     val r = new scala.util.Random(seed)
     val numHashFunctions = math.ceil(numBytes / 16.0).toInt
-    (1 to numHashFunctions).map { i =>
+    (1 to numHashFunctions).map { _ =>
       MurmurHash128(r.nextLong)
     }
   }
@@ -153,9 +153,7 @@ class MinHasher32(numHashes: Int, numBands: Int) extends MinHasher[Int](numHashe
   override protected def buildArray(fn: => Int): Array[Byte] = {
     val byteBuffer = ByteBuffer.allocate(numBytes)
     val writeBuffer = byteBuffer.asIntBuffer
-    1.to(numHashes).foreach { i =>
-      writeBuffer.put(fn)
-    }
+    1.to(numHashes).foreach(_ => writeBuffer.put(fn))
     byteBuffer.array
   }
 
@@ -172,9 +170,7 @@ class MinHasher32(numHashes: Int, numBands: Int) extends MinHasher[Int](numHashe
     val buffer = ByteBuffer.wrap(sig).asIntBuffer
     val mean = 1
       .to(numHashes)
-      .map { i =>
-        buffer.get.toLong
-      }
+      .map(_ => buffer.get.toLong)
       .sum / numHashes
     (2L << 31) / (mean.toLong + (2L << 30))
   }
@@ -194,9 +190,7 @@ class MinHasher16(numHashes: Int, numBands: Int) extends MinHasher[Char](numHash
   override protected def buildArray(fn: => Char): Array[Byte] = {
     val byteBuffer = ByteBuffer.allocate(numBytes)
     val writeBuffer = byteBuffer.asCharBuffer
-    1.to(numHashes).foreach { i =>
-      writeBuffer.put(fn)
-    }
+    1.to(numHashes).foreach(_ => writeBuffer.put(fn))
     byteBuffer.array
   }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/QTree.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/QTree.scala
@@ -430,7 +430,7 @@ class QTree[@specialized(Int, Long, Float, Double) A] private[algebird] (
    * A debug method that prints the QTree to standard out using print/println
    */
   def dump() {
-    for (i <- (20 to _level by -1))
+    for (_ <- (20 to _level by -1))
       print(" ")
     print(lowerBound + " - " + upperBound + ": " + _count)
     if (lowerChild.isDefined || upperChild.isDefined) {

--- a/algebird-core/src/main/scala/com/twitter/algebird/ResetAlgebra.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/ResetAlgebra.scala
@@ -37,6 +37,6 @@ class ResetStateMonoid[A](implicit monoid: Monoid[A]) extends Monoid[ResetState[
     (left, right) match {
       case (SetValue(l), SetValue(r))   => SetValue(monoid.plus(l, r))
       case (ResetValue(l), SetValue(r)) => ResetValue(monoid.plus(l, r))
-      case (_, ResetValue(r))           => right
+      case (_, ResetValue(_))           => right
     }
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/RightFolded2.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/RightFolded2.scala
@@ -66,7 +66,7 @@ class RightFolded2Monoid[In, Out, Acc](foldfn: (In, Out) => Out, accfn: (Out) =>
             val newAcc = grpAcc.plus(leftAcc, rightAcc)
             RightFoldedValue2(leftV, newAcc, rightRvals)
           } else {
-            val (newV, newRightAcc) = doFold(leftRvals, rightV, rightAcc)
+            val (_, newRightAcc) = doFold(leftRvals, rightV, rightAcc)
             // Now actually add the left value, with the right:
             val newAcc = grpAcc.plus(leftAcc, newRightAcc)
             RightFoldedValue2(leftV, newAcc, rightRvals)

--- a/algebird-core/src/main/scala/com/twitter/algebird/SGDMonoid.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SGDMonoid.scala
@@ -98,7 +98,7 @@ class SGDMonoid[Pos](
     (left, right) match {
       case (_, SGDZero)                 => left
       case (SGDPos(llps), SGDPos(rlps)) => SGDPos(llps ::: rlps)
-      case (rsw @ SGDWeights(c, w), SGDPos(p)) =>
+      case (rsw @ SGDWeights(_, _), SGDPos(p)) =>
         p.foldLeft(rsw) { (cntWeight, pos) =>
           newWeights(cntWeight, pos)
         }

--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -240,9 +240,9 @@ case class SketchMap[K, V](
  * An Aggregator for the SketchMap.
  * Can be created using SketchMap.aggregator
  */
-case class SketchMapAggregator[K, V](params: SketchMapParams[K], skmMonoid: SketchMapMonoid[K, V])(
-    implicit valueOrdering: Ordering[V],
-    valueMonoid: Monoid[V]
+case class SketchMapAggregator[K, V: Ordering: Monoid](
+    params: SketchMapParams[K],
+    skmMonoid: SketchMapMonoid[K, V]
 ) extends MonoidAggregator[(K, V), SketchMap[K, V], SketchMap[K, V]] {
   val monoid = skmMonoid
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/SpaceSaver.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SpaceSaver.scala
@@ -22,7 +22,7 @@ object SpaceSaver {
 
   private[algebird] val ordering =
     Ordering.by[(_, (Long, Long)), (Long, Long)] {
-      case (item, (count, err)) => (-count, err)
+      case (_, (count, err)) => (-count, err)
     }
 
   implicit def spaceSaverSemiGroup[T]: Semigroup[SpaceSaver[T]] =
@@ -161,7 +161,7 @@ sealed abstract class SpaceSaver[T] {
    */
   def mostFrequent(thres: Int): Seq[(T, Approximate[Long], Boolean)] =
     counters.iterator
-      .filter { case (item, (count, err)) => count >= thres }
+      .filter { case (_, (count, _)) => count >= thres }
       .toList
       .sorted(ordering)
       .map {

--- a/algebird-core/src/main/scala/com/twitter/algebird/Successible.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Successible.scala
@@ -82,8 +82,8 @@ object Successible {
       def compare(left: Option[T], right: Option[T]) =
         (left, right) match {
           case (Some(l), Some(r)) => ord.compare(l, r)
-          case (Some(l), None)    => -1
-          case (None, Some(r))    => 1
+          case (Some(_), None)    => -1
+          case (None, Some(_))    => 1
           case (None, None)       => 0
         }
     }

--- a/algebird-core/src/main/scala/com/twitter/algebird/monad/StateWithError.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/monad/StateWithError.scala
@@ -113,9 +113,7 @@ object StateWithError {
       Right((state, t))
     })
   def failure[S, F](f: F): StateWithError[S, F, Nothing] =
-    StateFn({ (state: S) =>
-      Left(f)
-    })
+    StateFn(_ => Left(f))
 
   /**
    * Use like fromEither[Int](Right("good"))

--- a/algebird-core/src/main/scala/com/twitter/algebird/monad/Trampoline.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/monad/Trampoline.scala
@@ -45,9 +45,7 @@ object Trampoline {
   val unit: Trampoline[Unit] = Done(())
   def apply[A](a: A): Trampoline[A] = Done(a)
   def lazyVal[A](a: => A): Trampoline[A] =
-    FlatMapped(unit, { (u: Unit) =>
-      Done(a)
-    })
+    FlatMapped(unit, (_: Unit) => Done(a))
 
   /**
    * Use this to call to another trampoline returning function
@@ -55,9 +53,7 @@ object Trampoline {
    * returning function
    */
   def call[A](layzee: => Trampoline[A]): Trampoline[A] =
-    FlatMapped(unit, { (u: Unit) =>
-      layzee
-    })
+    FlatMapped(unit, (_: Unit) => layzee)
   implicit val Monad: Monad[Trampoline] = new Monad[Trampoline] {
     def apply[A](a: A) = Done(a)
     def flatMap[A, B](start: Trampoline[A])(fn: A => Trampoline[B]) =

--- a/algebird-core/src/test/scala/com/twitter/algebird/AlgebraResolutionTest.scala
+++ b/algebird-core/src/test/scala/com/twitter/algebird/AlgebraResolutionTest.scala
@@ -15,7 +15,7 @@ class AlgebraResolutionTest extends FunSuite {
   }
   test("algebra.ring.AdditiveSemigroup") {
     implicit def fakeAdditiveSemigroup[T]: algebra.ring.AdditiveSemigroup[T] =
-      Semigroup.from[T] { (a, b) =>
+      Semigroup.from[T] { (a, _) =>
         a
       }
 
@@ -27,7 +27,7 @@ class AlgebraResolutionTest extends FunSuite {
   }
   test("algebra.ring.AdditiveMonoid") {
     implicit def fakeAdditiveMonoid[T]: algebra.ring.AdditiveMonoid[T] =
-      Monoid.from[T](null.asInstanceOf[T]) { (a, b) =>
+      Monoid.from[T](null.asInstanceOf[T]) { (a, _) =>
         a
       }
 

--- a/algebird-spark/src/main/scala/com/twitter/algebird/spark/AlgebirdRDD.scala
+++ b/algebird-spark/src/main/scala/com/twitter/algebird/spark/AlgebirdRDD.scala
@@ -1,6 +1,5 @@
 package com.twitter.algebird
 
-import com.twitter.algebird._
 import org.apache.spark.rdd.{PairRDDFunctions, RDD}
 import org.apache.spark.Partitioner
 import scala.reflect.ClassTag

--- a/algebird-test/src/main/scala/com/twitter/algebird/ApproximateProperty.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/ApproximateProperty.scala
@@ -59,7 +59,7 @@ object ApproximateProperty {
       }
 
   def toProp(a: ApproximateProperty, objectReps: Int, inputReps: Int, falsePositiveRate: Double): Prop =
-    Prop { params: Gen.Parameters =>
+    Prop { _: Gen.Parameters =>
       require(0 <= falsePositiveRate && falsePositiveRate <= 1)
 
       val list = successesAndProbabilities(a, objectReps, inputReps)

--- a/algebird-test/src/main/scala/com/twitter/algebird/PredecessibleLaws.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/PredecessibleLaws.scala
@@ -41,7 +41,7 @@ object PredecessibleLaws {
   def iteratePrevDecreases[T: Predecessible](t: T, size: Short): Boolean =
     Predecessible.iteratePrev(t).take(size.toInt).sliding(2).forall {
       case a :: b :: Nil => implicitly[Predecessible[T]].ordering.lt(b, a)
-      case a :: Nil      => true
+      case _ :: Nil      => true
       case s             => sys.error("should never happen: " + s)
     }
 

--- a/algebird-test/src/main/scala/com/twitter/algebird/SuccessibleLaws.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/SuccessibleLaws.scala
@@ -41,7 +41,7 @@ object SuccessibleLaws {
   def iterateNextIncreases[T: Successible](t: T, size: Short): Boolean =
     Successible.iterateNext(t).take(size.toInt).sliding(2).forall {
       case a :: b :: Nil => implicitly[Successible[T]].ordering.lt(a, b)
-      case a :: Nil      => true
+      case _ :: Nil      => true
       case s             => sys.error("should never happen: " + s)
     }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/BloomFilterTest.scala
@@ -22,8 +22,8 @@ object BloomFilterTestUtils {
       val bs = LongBitSet.empty(width)
       bs += hashes(item)
       BFInstance(hashes, bs.toBitSetNoCopy, width)
-    case bfs @ BFSparse(hashes, bitset, width)   => bfs.dense
-    case bfi @ BFInstance(hashes, bitset, width) => bfi
+    case bfs @ BFSparse(_, _, _)   => bfs.dense
+    case bfi @ BFInstance(_, _, _) => bfi
   }
 }
 
@@ -426,7 +426,7 @@ class BloomFilterTest extends WordSpec with Matchers {
               (entry, bfMonoid.create(entry))
             }
             .foldLeft((bfMonoid.zero, bfMonoid.zero)) {
-              case ((left, leftAlt), (entry, right)) =>
+              case ((left, leftAlt), (entry, _)) =>
                 val (newLeftAlt, contained) = leftAlt.checkAndAdd(entry)
                 left.contains(entry) shouldBe contained
                 (left + entry, newLeftAlt)

--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogSeriesTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogSeriesTest.scala
@@ -100,7 +100,7 @@ class HLLSeriesSinceProperty extends ApproximateProperty {
 
   // arbitrary timestamp
   def inputGenerator(timestampedData: Exact): Gen[Long] =
-    Gen.oneOf(timestampedData).map { case (value, timestamp) => timestamp }
+    Gen.oneOf(timestampedData).map { case (_, timestamp) => timestamp }
 
   def approximateResult(series: HLLSeries, timestamp: Long) =
     series.since(timestamp).toHLL.approximateSize

--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -301,7 +301,7 @@ class HyperLogLogTest extends WordSpec with Matchers {
   def aveErrorOf(bits: Int): Double = 1.04 / scala.math.sqrt(1 << bits)
 
   def testDownsize(dataSize: Int)(oldBits: Int, newBits: Int) {
-    val data = (0 until dataSize).map { i =>
+    val data = (0 until dataSize).map { _ =>
       r.nextLong
     }
     val exact = exactCount(data).toDouble
@@ -387,7 +387,7 @@ class HyperLogLogTest extends WordSpec with Matchers {
     "work as an Aggregator and return a HLL" in {
       List(5, 7, 8, 10).foreach(bits => {
         val aggregator = HyperLogLogAggregator(bits)
-        val data = (0 to 10000).map { i =>
+        val data = (0 to 10000).map { _ =>
           r.nextInt(1000)
         }
         val exact = exactCount(data).toDouble
@@ -401,7 +401,7 @@ class HyperLogLogTest extends WordSpec with Matchers {
     "work as an Aggregator and return size" in {
       List(5, 7, 8, 10).foreach(bits => {
         val aggregator = HyperLogLogAggregator.sizeAggregator(bits)
-        val data = (0 to 10000).map { i =>
+        val data = (0 to 10000).map { _ =>
           r.nextInt(1000)
         }
         val exact = exactCount(data).toDouble

--- a/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MinHasherTest.scala
@@ -36,22 +36,16 @@ class MinHasherSpec extends WordSpec with Matchers {
     val sharedFraction = 1 - uniqueFraction
     val unique1 = 1
       .to((s * uniqueFraction).toInt)
-      .map { i =>
-        math.random
-      }
+      .map(_ => math.random)
       .toSet
     val unique2 = 1
       .to((s * uniqueFraction).toInt)
-      .map { i =>
-        math.random
-      }
+      .map(_ => math.random)
       .toSet
 
     val shared = 1
       .to((s * sharedFraction).toInt)
-      .map { i =>
-        math.random
-      }
+      .map(_ => math.random)
       .toSet
     (unique1 ++ shared, unique2 ++ shared)
   }

--- a/algebird-test/src/test/scala/com/twitter/algebird/MonadInstanceLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/MonadInstanceLaws.scala
@@ -48,18 +48,16 @@ class MonadInstanceLaws extends CheckProperties {
 
   property("State behaves correctly") {
     forAll { (in: Int, head: Long, fns: List[(Int) => Either[String, (Int, Long)]]) =>
-      val mons = fns.map { StateWithError(_) }
+      val mons = fns.map(StateWithError(_))
       val init =
         StateWithError.const[Int, Long](head): StateWithError[Int, String, Long]
       val comp = mons.foldLeft(init) { (old, fn) =>
-        old.flatMap { x =>
-          fn
-        } // just bind
+        old.flatMap(_ => fn) // just bind
       }
-      comp(in) == (fns
+      comp(in) == fns
         .foldLeft(Right((in, head)): Either[String, (Int, Long)]) { (oldState, fn) =>
-          oldState.right.flatMap { case (s, v) => fn(s) }
-        })
+          oldState.right.flatMap { case (s, _) => fn(s) }
+        }
     }
   }
 
@@ -82,9 +80,7 @@ class MonadInstanceLaws extends CheckProperties {
       // Now apply them all:
       val bigReader =
         readers.foldLeft(Reader.const(()): Reader[MutableBox, Unit]) { (oldr, thisR) =>
-          oldr.flatMap { x =>
-            thisR
-          } // just sequence them
+          oldr.flatMap(_ => thisR) // just sequence them
         }
       // apply:
       bigReader(m1)

--- a/algebird-test/src/test/scala/com/twitter/algebird/QTreeTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/QTreeTest.scala
@@ -37,9 +37,7 @@ class QTreeLaws extends CheckProperties {
 
 class QTreeTest extends WordSpec with Matchers {
   def randomList(n: Long) =
-    (1L to n).map { i =>
-      math.random
-    }
+    (1L to n).map(_ => math.random)
 
   def buildQTree(k: Int, list: Seq[Double]) = {
     val qtSemigroup = new QTreeSemigroup[Double](k)

--- a/algebird-test/src/test/scala/com/twitter/algebird/SpaceSaverTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/SpaceSaverTest.scala
@@ -58,7 +58,7 @@ class SpaceSaverLaws extends CheckProperties {
         //We check that `fromBytes` doesn't yield exceptions
         fromBytes.isFailure || fromBytes.isSuccess
       } catch {
-        case oom: OutOfMemoryError =>
+        case _: OutOfMemoryError =>
           true // this happens if random data has a giant number in it
       }
     }
@@ -72,9 +72,7 @@ class SpaceSaverTest extends WordSpec with Matchers {
       val gen = Gen.frequency((1 to 100).map { x =>
         (x * x, x: Gen[Int])
       }: _*)
-      val items = (1 to 1000).map { x =>
-        gen.sample.get
-      }
+      val items = (1 to 1000).map(_ => gen.sample.get)
       val exactCounts = items.groupBy(identity).mapValues(_.size)
 
       // simulate a distributed system with 10 mappers and 1 reducer

--- a/algebird-test/src/test/scala/com/twitter/algebird/statistics/StatisticsTests.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/statistics/StatisticsTests.scala
@@ -25,7 +25,7 @@ class StatisticsTest extends WordSpec with Matchers {
   // the test framework garbles the exceptions :/
   lazy val statsMonoid = new StatisticsMonoid[Int]
   try {
-    for (i <- 1 to 2) statsMonoid.zero
+    for (_ <- 1 to 2) statsMonoid.zero
     for (i <- 1 to 3) statsMonoid.plus(i, i)
     for (i <- 1 to 3000) statsMonoid.sum(for (v <- 1 to i) yield v)
     for (i <- 1 to 2000) statsMonoid.sumOption(for (v <- 1 to i) yield v)

--- a/algebird-util/src/main/scala/com/twitter/algebird/util/summer/AsyncSummer.scala
+++ b/algebird-util/src/main/scala/com/twitter/algebird/util/summer/AsyncSummer.scala
@@ -28,13 +28,13 @@ trait AsyncSummer[T, +M <: Iterable[T]] { self =>
 
   def isFlushed: Boolean
   def cleanup: Future[Unit] = Future.Unit
-  def withCleanup(cleanup: () => Future[Unit]): AsyncSummer[T, M] = {
+  def withCleanup(cleanupFn: () => Future[Unit]): AsyncSummer[T, M] = {
     val oldSelf = self
     new AsyncSummerProxy[T, M] {
       override val self = oldSelf
       override def cleanup =
         oldSelf.cleanup.flatMap { _ =>
-          cleanup
+          cleanupFn()
         }
     }
   }

--- a/algebird-util/src/test/scala/com/twitter/algebird/util/TunnelMonoidProperties.scala
+++ b/algebird-util/src/test/scala/com/twitter/algebird/util/TunnelMonoidProperties.scala
@@ -21,14 +21,10 @@ import com.twitter.util.{Await, Future}
 import scala.util.Random
 
 object TunnelMonoidProperties {
-  def testTunnelMonoid[I, V](
+  def testTunnelMonoid[I: Monoid, V: Monoid](
       makeRandomInput: Int => I,
       makeTunnel: I => V,
       collapseFinalValues: (V, Seq[V], I) => Seq[Future[I]]
-  )(
-      implicit
-      monoid: Monoid[I],
-      superMonoid: Monoid[V]
   ) = {
     val r = new Random
     val numbers = (1 to 40).map { _ =>

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ def docsSourcesAndProjects(sv: String): (Boolean, Seq[ProjectReference]) =
 
 val sharedSettings = Seq(
   organization := "com.twitter",
-  scalaVersion := "2.12.9",
+  scalaVersion := "2.11.12",
   crossScalaVersions := Seq("2.10.6", "2.11.12", "2.12.9"),
   resolvers ++= Seq(
     Opts.resolver.sonatypeSnapshots,

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ def docsSourcesAndProjects(sv: String): (Boolean, Seq[ProjectReference]) =
 
 val sharedSettings = Seq(
   organization := "com.twitter",
-  scalaVersion := "2.11.12",
+  scalaVersion := "2.12.9",
   crossScalaVersions := Seq("2.10.6", "2.11.12", "2.12.9"),
   resolvers ++= Seq(
     Opts.resolver.sonatypeSnapshots,


### PR DESCRIPTION
Hi @johnynek so I tracked down most of them. We still have some unused implicits and case classes that should have non-implicit param list. Both of them break binary compatibility however fixing `case class` should be less problematic.