### PR TITLE
Use sonatype bundle release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,15 +106,10 @@ val sharedSettings = Seq(
     releaseStepCommandAndRemaining("+publishSigned"), // formerly publishArtifacts, here to deal with algebird-spark
     setNextVersion,
     commitNextVersion,
-    ReleaseStep(action = releaseStepCommand("sonatypeReleaseAll")),
+    ReleaseStep(action = releaseStepCommand("sonatypeBundleRelease")),
     pushChanges
   ),
-  publishTo := Some(
-    if (version.value.trim.endsWith("SNAPSHOT"))
-      Opts.resolver.sonatypeSnapshots
-    else
-      Opts.resolver.sonatypeStaging
-  ),
+  publishTo := sonatypePublishToBundle.value,
   scmInfo := Some(
     ScmInfo(
       url("https://github.com/twitter/algebird"),


### PR DESCRIPTION
Not sure if this is of interest, but with `sbt-sonatype >= 3.4` it's possible to release a bit faster by uploading the artifacts as a bundle.