### PR TITLE
Fix: case classes must have a non-implicit parameter list

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Max.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Max.scala
@@ -204,7 +204,7 @@ private[algebird] sealed abstract class LowPriorityMaxInstances {
  * [[Aggregator]] that selects the maximum instance of `T` in the
  * aggregated stream.
  */
-case class MaxAggregator[T](implicit ord: Ordering[T]) extends Aggregator[T, T, T] {
+case class MaxAggregator[T: Ordering]() extends Aggregator[T, T, T] {
   def prepare(v: T) = v
   val semigroup = Max.maxSemigroup[T]
   def present(v: T) = v

--- a/algebird-core/src/main/scala/com/twitter/algebird/Max.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Max.scala
@@ -204,7 +204,7 @@ private[algebird] sealed abstract class LowPriorityMaxInstances {
  * [[Aggregator]] that selects the maximum instance of `T` in the
  * aggregated stream.
  */
-case class MaxAggregator[T: Ordering]() extends Aggregator[T, T, T] {
+case class MaxAggregator[T]()(implicit val ord: Ordering[T]) extends Aggregator[T, T, T] {
   def prepare(v: T) = v
   val semigroup = Max.maxSemigroup[T]
   def present(v: T) = v

--- a/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
@@ -129,7 +129,7 @@ private[algebird] sealed abstract class MinInstances {
  * [[Aggregator]] that selects the minimum instance of `T` in the
  * aggregated stream.
  */
-case class MinAggregator[T: Ordering]() extends Aggregator[T, T, T] {
+case class MinAggregator[T]()(implicit val ord: Ordering[T]) extends Aggregator[T, T, T] {
   def prepare(v: T) = v
   val semigroup = Min.minSemigroup[T]
   def present(v: T) = v

--- a/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Min.scala
@@ -129,7 +129,7 @@ private[algebird] sealed abstract class MinInstances {
  * [[Aggregator]] that selects the minimum instance of `T` in the
  * aggregated stream.
  */
-case class MinAggregator[T](implicit ord: Ordering[T]) extends Aggregator[T, T, T] {
+case class MinAggregator[T: Ordering]() extends Aggregator[T, T, T] {
   def prepare(v: T) = v
   val semigroup = Min.minSemigroup[T]
   def present(v: T) = v

--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,8 @@ lazy val mimaSettings = Def.settings(
       .exclude[DirectMissingMethodProblem]("com.twitter.algebird.util.summer.HeavyHittersPercent.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("com.twitter.algebird.util.summer.BufferSize.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("com.twitter.algebird.util.summer.Compact.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("com.twitter.algebird.MinAggregator.ord"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("com.twitter.algebird.MaxAggregator.ord"),
     ProblemFilters.exclude[IncompatibleSignatureProblem]("com.twitter.algebird.MinHashSignature.*"),
     ProblemFilters.exclude[IncompatibleSignatureProblem]("com.twitter.algebird.MinHasher.*")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -197,8 +197,6 @@ lazy val mimaSettings = Def.settings(
       .exclude[DirectMissingMethodProblem]("com.twitter.algebird.util.summer.HeavyHittersPercent.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("com.twitter.algebird.util.summer.BufferSize.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("com.twitter.algebird.util.summer.Compact.apply"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("com.twitter.algebird.MinAggregator.ord"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("com.twitter.algebird.MaxAggregator.ord"),
     ProblemFilters.exclude[IncompatibleSignatureProblem]("com.twitter.algebird.MinHashSignature.*"),
     ProblemFilters.exclude[IncompatibleSignatureProblem]("com.twitter.algebird.MinHasher.*")
   )


### PR DESCRIPTION
This triggers mima with the same issue we have seen when updating mima to the last version.