### PR TITLE
Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,28 +5,38 @@ matrix:
     - name: checks
       scala: 2.11.12
       jdk: openjdk8
-      script: sbt ++$TRAVIS_SCALA_VERSION \
+      script: sbt \
         "; scalafmtCheckAll; scalafmtSbtCheck" \
         "; scalafixEnable; scalafix --check; test:scalafix --check"
 
     - scala: 2.11.12
       jdk: openjdk8
-      script: sbt ++$TRAVIS_SCALA_VERSION "; clean; coverage; test; coverageReport; mimaReportBinaryIssues"
+      script: sbt \
+        coverage \
+        "++$TRAVIS_SCALA_VERSION clean" \
+        "++$TRAVIS_SCALA_VERSION test" \
+        "++$TRAVIS_SCALA_VERSION coverageReport"
       after_success:
         - bash <(curl -s https://codecov.io/bash)
 
     - scala: 2.11.12
       jdk: openjdk11
-      script: sbt ++$TRAVIS_SCALA_VERSION "; clean; test"
+      script: sbt \
+        "++$TRAVIS_SCALA_VERSION clean" \
+        "++$TRAVIS_SCALA_VERSION test"
 
     - scala: 2.12.9
       jdk: openjdk8
-      script: sbt ++$TRAVIS_SCALA_VERSION "; clean; test; mimaReportBinaryIssues; docs/makeMicrosite"
-      #script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "++$TRAVIS_SCALA_VERSION docs/makeMicrosite"
+      script: sbt \
+        "++$TRAVIS_SCALA_VERSION clean" \
+        "++$TRAVIS_SCALA_VERSION test" \
+        "++$TRAVIS_SCALA_VERSION docs/makeMicrosite"
 
     - scala: 2.12.9
       jdk: openjdk11
-      script: sbt ++$TRAVIS_SCALA_VERSION "; clean; test"
+      script: sbt \
+        "++$TRAVIS_SCALA_VERSION clean" \
+        "++$TRAVIS_SCALA_VERSION test"
 
 before_install:
   - export PATH=${PATH}:./vendor/bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ matrix:
         coverage \
         "++$TRAVIS_SCALA_VERSION clean" \
         "++$TRAVIS_SCALA_VERSION test" \
-        "++$TRAVIS_SCALA_VERSION coverageReport"
+        "++$TRAVIS_SCALA_VERSION coverageReport" \
+        "++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
       after_success:
         - bash <(curl -s https://codecov.io/bash)
 
@@ -30,7 +31,8 @@ matrix:
       script: sbt \
         "++$TRAVIS_SCALA_VERSION clean" \
         "++$TRAVIS_SCALA_VERSION test" \
-        "++$TRAVIS_SCALA_VERSION docs/makeMicrosite"
+        "++$TRAVIS_SCALA_VERSION docs/makeMicrosite" \
+        "++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.12.9
       jdk: openjdk11
@@ -49,6 +51,7 @@ install:
 
 cache:
   directories:
+  - $HOME/.cache
   - $HOME/.sbt/boot/scala*
   - $HOME/.sbt/launchers
   - $HOME/.ivy2/cache


### PR DESCRIPTION
Apologies but I kinda broke the cross build in #720; I thought that aggregating the commands like `++SCALA_VERSION ;cmd; cmd` would work but it turns out that it doesn't as expected.

Also, since sbt 1.3.2 uses coursier, we need to add the dependencies path to the cache.