### PR TITLE
Add DecayingCMS[K] type.

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/DecayingCMS.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/DecayingCMS.scala
@@ -1,0 +1,689 @@
+package com.twitter.algebird
+
+import java.lang.Double.{compare => cmp}
+import java.lang.Math
+import java.util.Arrays.deepHashCode
+import scala.concurrent.duration.Duration
+import scala.util.Random
+
+/**
+ * DecayingCMS is a module to build count-min sketch instances whose
+ * counts decay exponentially.
+ *
+ * Similar to a Map[K, com.twitter.algebird.DecayedValue], each key is
+ * associated with a single count value that decays over time. Unlike
+ * a map, the decyaing CMS is an approximate count -- in exchange for
+ * the possibility of over-counting, we can bound its size in memory.
+ *
+ * The intended use case is for metrics or machine learning where
+ * exact values aren't needed.
+ *
+ * You can expect the keys with the biggest values to be fairly
+ * accurate but the very small values (rare keys or very old keys) to
+ * be lost in the noise. For both metrics and ML this should be fine:
+ * you can't learn too much from very rare values.
+ *
+ * We recommend depth of at least 5, and width of at least 100, but
+ * you should do some experiments to determine the smallest parameters
+ * that will work for your use case.
+ */
+final class DecayingCMS[K](
+    seed: Long,
+    val halfLife: Duration,
+    val depth: Int, // number of hashing functions
+    val width: Int, // number of table cells per hashing function
+    hasher: CMSHasher[K]
+) extends Serializable { module =>
+
+  override def toString: String =
+    s"DecayingCMS(seed=$seed, halfLife=$halfLife, depth=$depth, width=$width)"
+
+  @inline private def getNextLogScale(
+      logScale: Double,
+      oldTimeInHL: Double,
+      nowInHL: Double
+  ): Double =
+    if (nowInHL == oldTimeInHL) logScale else logScale + (nowInHL - oldTimeInHL) * log2
+
+  @inline private def getScale(logScale: Double, oldTimeInHL: Double, nowInHL: Double): Double = {
+    val logScale1 = getNextLogScale(logScale, oldTimeInHL, nowInHL)
+    Math.exp(-logScale1)
+  }
+
+  val empty: CMS =
+    new CMS(Array.fill(depth)(Vector.fill[Double](width)(0.0)), 0.0, Double.NegativeInfinity)
+
+
+  /**
+   * Represents a decaying scalar value at a particular point in time.
+   *
+   * The value decays according to halfLife. Another way to think
+   * about DoubleAt is that it represents a particular decay curve
+   * (and in particular, a point along that curve). Two DoubleAt
+   * values may be equivalent if they are two points on the same curve.
+   *
+   * The `timeToZero` and `timeToUnit` methods can be used to
+   * "normalize" DoubleAt values. If two DoubleAt values do not
+   * produce the same (approximate) Double values from these methods,
+   * they represent different curves.
+   */
+  class DoubleAt private[algebird] (val value: Double, val timeInHL: Double) extends Serializable {
+    lhs =>
+
+    // this is not public because it's not safe in general -- you need
+    // to run a function that is time-commutative.
+    private[algebird] def map(f: Double => Double): DoubleAt =
+      new DoubleAt(f(value), timeInHL)
+
+    // this is not public because it's not safe in general -- you need
+    // to run a function that is time-commutative.
+    private[algebird] def map2(rhs: DoubleAt)(f: (Double, Double) => Double): DoubleAt =
+      if (lhs.timeInHL < rhs.timeInHL) {
+        val x = lhs.scaledAt(rhs.timeInHL)
+        new DoubleAt(f(x, rhs.value), rhs.timeInHL)
+      } else if (lhs.timeInHL == rhs.timeInHL) {
+        new DoubleAt(f(lhs.value, rhs.value), rhs.timeInHL)
+      } else {
+        val y = rhs.scaledAt(lhs.timeInHL)
+        new DoubleAt(f(lhs.value, y), lhs.timeInHL)
+      }
+
+    def unary_- : DoubleAt = new DoubleAt(-value, timeInHL)
+    def abs: DoubleAt = new DoubleAt(Math.abs(value), timeInHL)
+    def *(n: Double): DoubleAt = new DoubleAt(value * n, timeInHL)
+
+    def +(rhs: DoubleAt): DoubleAt = map2(rhs)(_ + _)
+    def -(rhs: DoubleAt): DoubleAt = map2(rhs)(_ - _)
+    def min(rhs: DoubleAt): DoubleAt = map2(rhs)(Math.min)
+    def max(rhs: DoubleAt): DoubleAt = map2(rhs)(Math.max)
+
+    def /(rhs: DoubleAt): Double = map2(rhs)(_ / _).value
+
+    /**
+     * We consider two DoubleAt values equal not just if their
+     * elements are equal, but also if they represent the same value
+     * at different points of decay.
+     */
+    def compare(rhs: DoubleAt): Int = {
+      val vc = cmp(lhs.value, rhs.value)
+      val tc = cmp(lhs.timeInHL, rhs.timeInHL)
+      if (vc == tc) vc
+      else if (tc == 0) vc
+      else if (vc == 0) tc
+      else if (tc < 0) cmp(lhs.scaledAt(rhs.timeInHL), rhs.value)
+      else cmp(lhs.value, rhs.scaledAt(lhs.timeInHL))
+    }
+
+    /**
+     * Time when this value will reach the smallest double value
+     * bigger than zero, unless we are already at zero in which
+     * case we return the current time
+     */
+    def timeToZero: Double =
+      if (java.lang.Double.isNaN(value)) Double.NaN
+      else if (java.lang.Double.isInfinite(value)) Double.PositiveInfinity
+      else if (value == 0.0) timeInHL
+      else timeToUnit + DoubleAt.TimeFromUnitToZero
+
+    /**
+     * This is the scaled time when the current value will reach
+     * 1 (or -1 for negative values)
+     *
+     * This method is a way of collapsing a DoubleAt into a single
+     * value (the time in the past or future where its value would be
+     * 1, the unit value).
+     */
+    def timeToUnit: Double =
+      if (java.lang.Double.isNaN(value)) Double.NaN
+      else if (java.lang.Double.isInfinite(value)) Double.PositiveInfinity
+      else if (value == 0.0) Double.NegativeInfinity
+      else {
+        // solve for result:
+        //
+        //   1 = value * module.getScale(0.0, timeInHL, result)
+        //   1 = value * Math.exp(-getNextLogScale(0.0, timeInHL, result))
+        //   1 / value = Math.exp(-getNextLogScale(0.0, timeInHL, result))
+        //   log(1 / value) = -getNextLogScale(0.0, timeInHL, result)
+        //   -log(1 / value) = getNextLogScale(0.0, timeInHL, result)
+        //   log(value) = getNextLogScale(0.0, timeInHL, result)
+        //   log(value) = if (result == timeInHL) 0 else 0 + (result - timeInHL) * log2
+        //   log(value) = if (result == timeInHL) 0 else (result - timeInHL) * log2
+        //
+        //   log(value) = (result - timeInHL) * log2
+        //   log(value) / log2 = result - timeInHL
+        //   log(value) / log2 + timeInHL = result
+        Math.log(Math.abs(value)) / log2 + timeInHL
+      }
+
+    override def equals(that: Any): Boolean =
+      that match {
+        case d: DoubleAt => compare(d) == 0
+        case _           => false
+      }
+
+    override def hashCode: Int =
+      timeToUnit.##
+
+    override def toString: String =
+      s"DoubleAt($value, $timeInHL)"
+
+    def <(rhs: DoubleAt): Boolean = (lhs compare rhs) < 0
+    def <=(rhs: DoubleAt): Boolean = (lhs compare rhs) <= 0
+    def >(rhs: DoubleAt): Boolean = (lhs compare rhs) > 0
+    def >=(rhs: DoubleAt): Boolean = (lhs compare rhs) >= 0
+
+    def time: Long =
+      toTimestamp(timeInHL)
+
+    private def scaledAt(t: Double): Double =
+      if (value == 0.0) 0.0
+      else value * module.getScale(0.0, timeInHL, t)
+
+    def at(time: Long): Double =
+      if (value == 0.0) 0.0
+      else value * module.getScale(0.0, timeInHL, fromTimestamp(time))
+  }
+
+  object DoubleAt {
+    def apply(x: Double, t: Long): DoubleAt =
+      new DoubleAt(x, fromTimestamp(t))
+
+    val zero: DoubleAt =
+      new DoubleAt(0.0, Double.NegativeInfinity)
+
+    private val TimeFromUnitToZero: Double =
+      -Math.log(Double.MinPositiveValue) / log2
+  }
+
+  val totalCells: Int = depth * width
+
+  val halfLifeSecs: Double =
+    halfLife.toMillis.toDouble / 1000.0
+
+  // TODO: consider a smaller number?
+  // we are trading accuracy for possible performence
+  private[this] val maxLogScale: Double = 20.0
+
+  /**
+   * Allocate an empty array of row.
+   *
+   * The elements start as null. It's an important optimization _not_
+   * to allocate vectors here, since we're often building up cells
+   * mutably.
+   */
+  private def allocCells(): Array[Vector[Double]] =
+    new Array[Vector[Double]](depth)
+
+  def toTimestamp(t: Double): Long =
+    (t * halfLifeSecs * 1000.0).toLong
+
+  def fromTimestamp(t: Long): Double =
+    (t.toDouble / 1000.0) / halfLifeSecs
+
+  val hashFns: Array[K => Int] = {
+    val rng = new Random(seed)
+    def genPos(): Int =
+      rng.nextInt match {
+        case 0 => genPos()
+        case n => n & 0x7fffffff
+      }
+
+    (0 until depth).map { _ =>
+      val n = genPos()
+      (k: K) => hasher.hash(n, 0, width)(k)
+    }.toArray
+  }
+
+  private final val log2 = Math.log(2.0)
+
+  /**
+   * The idealized formula for the updating current value for a key
+   * (y0 -> y1) is given as:
+   *
+   *   delta = (t1 - t0) / halflife
+   *   y1 = y0 * 2^(-delta) + n
+   *
+   * However, we want to avoid having to rescale every single cell
+   * every time we update; i.e. a cell with a zero value should
+   * continue to have a zero value when n=0.
+   *
+   * Therefore, we introduce a change of variable to cell values (z)
+   * along with a scale factor (scale), and the following formula:
+   *
+   *   (1) zN = yN * scaleN
+   *
+   * Our constraint is expressed as:
+   *
+   *   (2) If n=0, z1 = z0
+   *
+   * In that case:
+   *
+   *   (3) If n=0, (y1 * scale1) = (y0 * scale0)
+   *   (4) Substituting for y1, (y0 * 2^(-delta) + 0) * scale1 = y0 * scale0
+   *   (5) 2^(-delta) * scale1 = scale0
+   *   (6) scale1 = scale0 * 2^(delta)
+   *
+   * Also, to express z1 in terms of z0, we say:
+   *
+   *   (7) z1 = y1 * scale1
+   *   (8) z1 = (y0 * 2^(-delta) + n) * scale1
+   *   (9) z1 = ((z0 / scale0) * 2^(-delta) + n) * scale1
+   *  (10) z1 / scale1 = (z0 / (scale1 * 2^(-delta))) * 2^(-delta) + n
+   *  (11) z1 / scale1 = z0 / scale1 + n
+   *  (12) z1 = z0 + n * scale1
+   *
+   * So, for cells where n=0, we just update scale0 to scale1, and for
+   * cells where n is non-zero, we update z1 in terms of z0 and
+   * scale1.
+   *
+   * If we convert scale to logscale, we have:
+   *
+   *  (13) logscale1 = logscale0 + delta * log(2)
+   *  (14) z1 = z0 + n * exp(logscale1)
+   *
+   * When logscale1 gets big, we start to distort z1. For example,
+   * exp(36) is close to 2^53. We can measure when n * exp(logscale1)
+   * gets big, and in those cases we can rescale all our cells (set
+   * each z to its corresponding y) and set the logscale to 0.
+   *
+   *  (15) y1 = z1 / scale1
+   *  (16) y1 = z1 / exp(logscale1)
+   *  (17) y1 = z1 * exp(-logscale1)
+   */
+  final class CMS(
+      val cells: Array[Vector[Double]],
+      val logScale: Double,
+      val timeInHL: Double
+  ) extends Serializable {
+
+    @inline private def scale: Double =
+      Math.exp(-logScale)
+
+    override def toString: String = {
+      val s = cells.iterator.map(_.toString).mkString("Array(", ", ", ")")
+      s"CMS($s, $logScale, $timeInHL)"
+    }
+
+    override def hashCode: Int =
+      deepHashCode(cells.asInstanceOf[Array[Object]]) * 59 +
+    logScale.## * 17 +
+    timeInHL.## * 37 +
+            19
+
+    // unfortunately we can't check the path-dependent type of this
+    // CMS, which we signal by using a type projection here.
+    override def equals(any: Any): Boolean =
+      any match {
+        case that: DecayingCMS[_]#CMS =>
+          this.logScale == that.logScale &&
+          this.timeInHL == that.timeInHL &&
+          this.cells.length == that.cells.length && {
+            var i = 0
+            while (i < depth) {
+              if (this.cells(i) != that.cells(i)) return false
+              i += 1
+            }
+            true
+          }
+        case _ =>
+          false
+      }
+
+    def lastUpdateTime: Long =
+      toTimestamp(timeInHL)
+
+    /**
+     * Provide lower and upper bounds on values returned for any
+     * possible key.
+     *
+     * The first value is a lower bound: even keys that have never
+     * been counted will return this value or greater. This will be
+     * zero unless the CMS is saturated.
+     *
+     * The second value is an upper bound: the key with the largest
+     * cardinality will not be reported as being larger than this
+     * value (though it might be reported as being smaller).
+     *
+     * Together these values indicate how saturated and skewed the CMS
+     * might be.
+     */
+    def range: (DoubleAt, DoubleAt) = {
+      var minMinimum = Double.PositiveInfinity
+      var minMaximum = Double.PositiveInfinity
+      var i = 0
+      while (i < cells.length) {
+        val it = cells(i).iterator
+        var localMax = it.next // we know it doesn't start empty
+        if (localMax < minMinimum) minMinimum = localMax
+        while (it.hasNext) {
+          val n = it.next
+          if (n > localMax) localMax = n
+          else if (n < minMinimum) minMinimum = n
+        }
+        if (localMax < minMaximum) minMaximum = localMax
+        i += 1
+      }
+
+      val s = scale
+      def sc(x: Double): DoubleAt =
+        new DoubleAt(if (x == 0.0) 0.0 else x * s, timeInHL)
+
+      (sc(minMinimum), sc(minMaximum))
+    }
+
+    /**
+     * Returns the square-root of the inner product of two decaying
+     * CMSs.
+     *
+     * We want the result to decay at the same rate as the CMS for
+     * this method to be valid. Taking the square root ensures that
+     * this is true. Without it, we would violate the following
+     * equality (assuming we had at() on a CMS):
+     *
+     *   x.innerProduct(y).at(t) = x.at(t).innerProduct(y.at(t))
+     *
+     * This is why we don't support innerProduct, only
+     * innerProductRoot.
+     */
+    def innerProductRoot(that: CMS): DoubleAt = {
+      var i = 0
+      var res = Double.PositiveInfinity
+      val t = Math.max(this.timeInHL, that.timeInHL)
+      val scale = this.getScale(t) * that.getScale(t)
+      while (i < depth) {
+        var sum = 0.0
+        val it0 = this.cells(i).iterator
+        val it1 = that.cells(i).iterator
+        while (it0.hasNext) {
+          val x = it0.next * it1.next
+          if (x != 0.0) sum += x
+        }
+        if (sum < res) res = sum
+        i += 1
+      }
+      val x = if (res != 0.0) Math.sqrt(res * scale) else 0.0
+      new DoubleAt(x, t)
+    }
+
+    def l2Norm: DoubleAt =
+      innerProductRoot(this)
+
+    def scale(x: Double): CMS =
+      if (java.lang.Double.isNaN(x)) {
+        throw new IllegalArgumentException(s"invalid scale: $x")
+      } else if (x < 0.0) {
+        throw new IllegalArgumentException(s"negative scale is not allowed: $x")
+      } else if (x == 0.0) {
+        module.empty
+      } else {
+        val s = logScale + Math.log(x)
+        val c = new CMS(cells, s, timeInHL)
+        if (s > maxLogScale) c.rescaleTo(timeInHL) else c
+      }
+
+    /**
+     * Get the total count of all items in the CMS.
+     *
+     * The total is the same as the l1Norm, since we don't allow
+     * negative values.
+     *
+     * Total is one of the few non-approximate statistics that
+     * DecayingCMS supports. We expect the total to be exact (except
+     * for floating-point error).
+     */
+    def total: DoubleAt = {
+      val n = cells(0).sum
+      val x = if (n == 0.0) 0.0 else scale * n
+      new DoubleAt(x, timeInHL)
+    }
+
+    def get(k: K): DoubleAt = {
+      var minValue = Double.PositiveInfinity
+      var didx = 0
+      while (didx < depth) {
+        val i = hashFns(didx)(k)
+        val inner = cells(didx)
+        val value = inner(i)
+        if (value < minValue) minValue = value
+        didx += 1
+      }
+      val x = if (minValue == 0.0) 0.0 else scale * minValue
+      new DoubleAt(x, timeInHL)
+    }
+
+    def getScale(t: Double): Double =
+      module.getScale(logScale, timeInHL, t)
+
+    private final def nextLogScale(t: Double): Double =
+      module.getNextLogScale(logScale, timeInHL, t)
+
+    def +(other: CMS): CMS = {
+      val x = this
+      val y = other
+      val timeInHL = Math.max(x.timeInHL, y.timeInHL)
+      val cms = new CMS(allocCells, 0.0, timeInHL)
+
+      val xscale = x.getScale(timeInHL)
+      val yscale = y.getScale(timeInHL)
+
+      // a zero count is zero, no matter, how big the scale is.
+      @inline def prod(x: Double, y: Double): Double =
+        if (x == 0.0) 0.0 else x * y
+
+      var i = 0
+      while (i < depth) {
+        val left = x.cells(i)
+        val right = y.cells(i)
+        var j = 0
+        val bldr = rowBuilder()
+        while (j < width) {
+          bldr += prod(left(j), xscale) + prod(right(j), yscale)
+          j += 1
+        }
+        cms.cells(i) = bldr.result
+        i += 1
+      }
+      cms
+    }
+
+    def add(t: Long, k: K, n: Double): CMS =
+      scaledAdd(fromTimestamp(t), k, n)
+
+    // TODO: we could allocate a mutable scratch pad, write all the
+    // values into it, and then build a CMS out of it. if items is
+    // very small, this would be less efficient than what we're doing
+    // now. probably the "ideal" solution would be determine how many
+    // items there are. if we have fewer than ~width items, this
+    // approach is fine. for more, a scratch pad would be better
+    // (assuming we wrote that code).
+    //
+    // alternately, you could map items into (zero + item) and then
+    // use the monoid's sum to boil it down.
+    //
+    // we only use this in testing currently so the current code is
+    // fine until we rely on it in production. any change here should
+    // probably include benchmarks justifying the design.
+    def bulkAdd(items: Iterable[(Long, K, Double)]): CMS =
+      items.foldLeft(this) { case (c, (t, k, v)) => c.add(t, k, v) }
+
+    private[algebird] def scaledAdd(ts1: Double, k: K, n: Double): CMS =
+      if (n < 0.0) {
+        val t = toTimestamp(ts1)
+        throw new IllegalArgumentException(
+          s"we can only add non-negative numbers to a CMS, got $n for key: $k at time: $t"
+        )
+      } else if (n == 0.0) {
+        this
+      } else {
+        val logScale1 = nextLogScale(ts1)
+        if (logScale1 > maxLogScale) {
+          rescaleTo(ts1).scaledAdd(ts1, k, n)
+        } else {
+          val increment = n * Math.exp(logScale1)
+          val cells1 = allocCells()
+          var didx = 0
+          while (didx < depth) {
+            val cell = cells(didx)
+            val w = hashFns(didx)(k)
+            cells1(didx) = cell.updated(w, cell(w) + increment)
+            didx += 1
+          }
+          new CMS(cells1, logScale1, ts1)
+        }
+      }
+
+    // Set the scale back to 0.0
+    // input time is in half-lives
+    private[algebird] def rescaleTo(ts: Double): CMS = {
+      val logScale1 = nextLogScale(ts)
+      val expL = Math.exp(-logScale1)
+      if (expL == 0.0) {
+        new CMS(monoid.zero.cells, 0.0, ts)
+      } else {
+        val cms = new CMS(allocCells, 0.0, ts)
+        var i = 0
+        while (i < depth) {
+          val ci = cells(i)
+          cms.cells(i) = ci.map(_ * expL)
+          i += 1
+        }
+        cms
+      }
+    }
+  }
+
+  private def rowBuilder() = {
+    val bldr = Vector.newBuilder[Double]
+    bldr.sizeHint(width)
+    bldr
+  }
+
+  object CMS {
+
+    implicit val monoidForCMS: Monoid[CMS] =
+      new Monoid[CMS] {
+
+        def zero: CMS = module.empty
+
+        def plus(x: CMS, y: CMS): CMS =
+          x + y
+
+        /**
+         * Turn a flat array into an array of vectors.
+         */
+        private def scratchToCells(scratch: Array[Double]): Array[Vector[Double]] = {
+          val cells = new Array[Vector[Double]](depth)
+          var i = 0
+          while (i < depth) {
+            var j = i * width
+            val limit = j + width
+            val bldr = rowBuilder()
+            while (j < limit) {
+              bldr += scratch(j)
+              j += 1
+            }
+            cells(i) = bldr.result
+            i += 1
+          }
+          cells
+        }
+
+        /**
+         * This method sums the first `num` items in `arr`.
+         */
+        private def innerSum(arr: Array[CMS], num: Int): CMS =
+          if (num == 0) zero
+          else if (num == 1) arr(0)
+          else if (num == 2) plus(arr(0), arr(1))
+          else {
+            // start with zero
+            val scratch: Array[Double] = new Array(totalCells)
+
+            val latestTimeInHL: Double =
+              arr.iterator.take(num).map(cms => cms.timeInHL).max
+
+            var i = 0
+            while (i < num) {
+              val cms = arr(i)
+              val scale = cms.getScale(latestTimeInHL)
+              var j = 0
+              while (j < depth) {
+                val row = cms.cells(j)
+                val stride = j * width
+                var k = 0
+                while (k < width) {
+                  val n = row(k)
+                  if (n > 0.0) {
+                    scratch(stride + k) += scale * n
+                  }
+                  k += 1
+                }
+                j += 1
+              }
+              i += 1
+            }
+
+            val cells = scratchToCells(scratch)
+
+            new CMS(cells, 0.0, latestTimeInHL)
+          }
+
+        override def sumOption(xs: TraversableOnce[CMS]): Option[CMS] = {
+
+          val it: Iterator[CMS] = xs.toIterator
+          val ChunkSize = 1000
+
+          // the idea here is that we read up to 1000 CMS values into
+          // a fixed array, crunch them down to a single CMS, store it
+          // in the first array index, read up to 999 more CMS values
+          // in, crunch them down, and so on.
+          var i = 0
+          val arr = new Array[CMS](ChunkSize)
+          while (it.hasNext) {
+            while (it.hasNext && i < ChunkSize) {
+              arr(i) = it.next
+              i += 1
+            }
+            if (i > 1) {
+              arr(0) = innerSum(arr, i)
+            }
+            i = 1
+          }
+          if (i == 0) None else Some(arr(0))
+        }
+      }
+  }
+
+  val monoid: Monoid[CMS] = CMS.monoidForCMS
+}
+
+object DecayingCMS {
+
+  /**
+   * Construct a DecayingCMS module.
+   *
+   * The seed is used to initialize the hash families used by the
+   * count-min sketch. Using the same seed will always produce the
+   * same hash family.
+   *
+   * Half-life determines the rate at which values in the CMS decay.
+   * If a key was counted once at time t, by time (t + halfLife), the
+   * value for that key will be 0.5. After enough half lives the value
+   * will decay to zero.
+   *
+   * The size of the CMS in bytes is O(depth * width).
+   *
+   * Width controls the relative error due to over-counting
+   * (approximately 1/width). For 1% error, use width=100, for 0.1%
+   * error, use width=1000, etc.
+   *
+   * Depth controls the probability the error bounds are broken and
+   * that probability scales with exp(-alpha * depth) so, a small depth
+   * (e.g. 5-10) is fine. Each update requires O(depth) work so you
+   * want to keep this as small as possible.
+   */
+  def apply[K](seed: Long, halfLife: Duration, depth: Int, width: Int)(
+      implicit hasher: CMSHasher[K]
+  ): DecayingCMS[K] =
+    new DecayingCMS(seed, halfLife, depth, width, hasher)
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/DecayingCMS.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/DecayingCMS.scala
@@ -53,7 +53,6 @@ final class DecayingCMS[K](
   val empty: CMS =
     new CMS(Array.fill(depth)(Vector.fill[Double](width)(0.0)), 0.0, Double.NegativeInfinity)
 
-
   /**
    * Represents a decaying scalar value at a particular point in time.
    *
@@ -167,10 +166,10 @@ final class DecayingCMS[K](
     override def toString: String =
       s"DoubleAt($value, $timeInHL)"
 
-    def <(rhs: DoubleAt): Boolean = (lhs compare rhs) < 0
-    def <=(rhs: DoubleAt): Boolean = (lhs compare rhs) <= 0
-    def >(rhs: DoubleAt): Boolean = (lhs compare rhs) > 0
-    def >=(rhs: DoubleAt): Boolean = (lhs compare rhs) >= 0
+    def <(rhs: DoubleAt): Boolean = (lhs.compare(rhs)) < 0
+    def <=(rhs: DoubleAt): Boolean = (lhs.compare(rhs)) <= 0
+    def >(rhs: DoubleAt): Boolean = (lhs.compare(rhs)) > 0
+    def >=(rhs: DoubleAt): Boolean = (lhs.compare(rhs)) >= 0
 
     def time: Long =
       toTimestamp(timeInHL)
@@ -306,9 +305,9 @@ final class DecayingCMS[K](
 
     override def hashCode: Int =
       deepHashCode(cells.asInstanceOf[Array[Object]]) * 59 +
-    logScale.## * 17 +
-    timeInHL.## * 37 +
-            19
+        logScale.## * 17 +
+        timeInHL.## * 37 +
+        19
 
     // unfortunately we can't check the path-dependent type of this
     // CMS, which we signal by using a type projection here.
@@ -316,8 +315,8 @@ final class DecayingCMS[K](
       any match {
         case that: DecayingCMS[_]#CMS =>
           this.logScale == that.logScale &&
-          this.timeInHL == that.timeInHL &&
-          this.cells.length == that.cells.length && {
+            this.timeInHL == that.timeInHL &&
+            this.cells.length == that.cells.length && {
             var i = 0
             while (i < depth) {
               if (this.cells(i) != that.cells(i)) return false

--- a/algebird-test/src/test/scala/com/twitter/algebird/DecayingCMSTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/DecayingCMSTest.scala
@@ -1,0 +1,434 @@
+package com.twitter.algebird
+
+import org.scalacheck.{Arbitrary, Gen, Prop}
+import scala.concurrent.duration.{Duration, MINUTES, HOURS, DAYS}
+
+import Prop.{forAllNoShrink => forAll}
+
+class DecayingCMSProperties extends CheckProperties {
+
+  val eps = 1e-6
+
+  def close(a: Double, b: Double): Boolean =
+    if (a == b) {
+      true
+    } else {
+      val (aa, ab) = (Math.abs(a), Math.abs(b))
+      if (aa < eps && ab < eps) true
+      else if (aa < ab) (b / a) < 1.0 + eps
+      else (a / b) < 1.0 + eps
+    }
+
+  def fuzzyEq[K](module: DecayingCMS[K])(cms0: module.CMS, cms1: module.CMS): Boolean = {
+    val t = cms0.timeInHL max cms1.timeInHL
+    val (x0, x1) =
+      if (t == Double.NegativeInfinity) (cms0, cms1)
+      else (cms0.rescaleTo(t), cms1.rescaleTo(t))
+
+    (0 until module.depth).forall { d =>
+      (0 until module.width).forall { w =>
+        close(x0.cells(d)(w), x1.cells(d)(w))
+      }
+    }
+  }
+
+  def genModule[K: CMSHasher]: Gen[DecayingCMS[K]] =
+    for {
+      seed <- Gen.choose(1L, Long.MaxValue)
+      hl <- genDuration
+      d <- Gen.choose(1, 5)
+      w <- Gen.choose(1, 12)
+    } yield DecayingCMS[K](seed, hl, d, w)
+
+  def genBigModule[K: CMSHasher]: Gen[DecayingCMS[K]] =
+    for {
+      seed <- Gen.choose(1L, Long.MaxValue)
+      hl <- genDuration
+      d <- Gen.const(6)
+      w <- Gen.choose(100, 200)
+    } yield DecayingCMS[K](seed, hl, d, w)
+
+  implicit def arbitraryModule[K: CMSHasher]: Arbitrary[DecayingCMS[K]] =
+    Arbitrary(genModule)
+
+  def genCms[K](
+      module: DecayingCMS[K],
+      genk: Gen[K],
+      gent: Gen[Long],
+      genv: Gen[Double]
+  ): Gen[module.CMS] = {
+
+    val genEmpty = Gen.const(module.monoid.zero)
+    val genItem = Gen.zip(gent, genk, genv)
+
+    def genSeq(cms0: module.CMS): Gen[module.CMS] =
+      Gen.listOf(genItem).map { items =>
+        items.foldLeft(cms0) {
+          case (cms, (t, k, n)) =>
+            cms.add(t, k, n)
+        }
+      }
+
+    val terminalGens: Gen[module.CMS] = genEmpty
+
+    def gen(depth: Int): Gen[module.CMS] =
+      if (depth <= 0) terminalGens
+      else {
+        val recur = Gen.lzy(gen(depth - 1))
+        Gen.frequency(
+          1 -> genEmpty,
+          7 -> recur.flatMap(genSeq(_)),
+          2 -> Gen.zip(recur, recur).map { case (g0, g1) => module.monoid.plus(g0, g1) },
+          1 -> Gen.listOf(recur).map(module.monoid.sum(_))
+        )
+      }
+
+    gen(2)
+  }
+
+  val genDuration: Gen[Duration] =
+    Gen.oneOf(Duration(1, HOURS), Duration(1, DAYS), Duration(10, MINUTES), Duration(7, DAYS))
+
+  implicit val arbitraryDuration: Arbitrary[Duration] =
+    Arbitrary(genDuration)
+
+  val stdKey: Gen[String] =
+    Gen.listOfN(2, Gen.choose('a', 'm')).map(_.mkString)
+
+  val stdVal: Gen[Double] =
+    Gen.choose(0.0, 100.0)
+
+  val stdItem: Gen[(String, Double)] =
+    Gen.zip(stdKey, stdVal)
+
+  val stdItems: Gen[List[(String, Double)]] =
+    Gen.listOf(stdItem)
+
+  def genTimestamp[K](module: DecayingCMS[K]): Gen[Long] =
+    //Gen.choose(0L, module.halfLifeSecs.toLong * 1000L * 10L)
+    Gen.choose(0L, module.halfLifeSecs.toLong * 10L)
+
+  def genDoubleAt[K](module: DecayingCMS[K]): Gen[module.DoubleAt] =
+    Gen.zip(genTimestamp(module), stdVal).map { case (t, x) => module.DoubleAt(x, t) }
+
+  def genItem(module: DecayingCMS[String]): Gen[(Long, String, Double)] =
+    Gen.zip(genTimestamp(module), stdKey, stdVal)
+
+  def genItems(module: DecayingCMS[String]): Gen[List[(Long, String, Double)]] =
+    Gen.listOf(genItem(module))
+
+  def genValues(module: DecayingCMS[String]): Gen[List[(Long, Double)]] =
+    Gen.listOf(Gen.zip(genTimestamp(module), stdVal))
+
+  property("basic") {
+    val gk = Gen.identifier
+    val gt = Gen.choose(-30610206238000L, 32503698000000L)
+    val gn = Gen.choose(0, 0xffff).map(_.toDouble)
+    val gm = genModule[String]
+    forAll(gk, gt, gn, gm) { (key: String, t: Long, n: Double, module: DecayingCMS[String]) =>
+      val cms0 = module.monoid.zero
+      val cms = cms0.add(t, key, n)
+      val got = cms.get(key).at(t)
+      Prop(got == n) :| s"$got == $n"
+    }
+  }
+
+  property("sum(xs) = xs.foldLeft(zero)(plus)") {
+    forAll { (module: DecayingCMS[String]) =>
+      val g = genCms(module, stdKey, genTimestamp(module), stdVal)
+      forAll(Gen.listOf(g)) { xs =>
+        val left = module.monoid.sum(xs)
+        val right = xs.foldLeft(module.monoid.zero)(module.monoid.plus)
+        Prop(fuzzyEq(module)(left, right)) :| s"$left was not equal to $right"
+      }
+    }
+  }
+
+  property("all rows should sum to the same value") {
+    forAll { (module: DecayingCMS[String]) =>
+      val g = genCms(module, stdKey, genTimestamp(module), stdVal)
+      forAll(g) { cms =>
+        val sum0 = cms.cells(0).sum
+        cms.cells.foldLeft(Prop(true)) { (res, row) =>
+          val sum = row.sum
+          res && (Prop(close(sum, sum0)) :| s"close($sum, $sum0)")
+        }
+      }
+    }
+  }
+
+  property("round-tripping timestamps works") {
+    forAll { (module: DecayingCMS[String]) =>
+      val n = module.halfLifeSecs * 1000.0
+      forAll(Gen.choose(-n, n)) { x =>
+        val t = module.toTimestamp(x)
+        val y = module.fromTimestamp(t)
+        Prop(close(x, y)) :| s"close($x, $y)"
+      }
+    }
+  }
+
+  property("total works reliably") {
+    forAll { (module: DecayingCMS[String]) =>
+      val g = genCms(module, stdKey, genTimestamp(module), stdVal)
+      forAll(g, genItems(module)) { (cms0, items) =>
+        val time = cms0.timeInHL
+        val cms1 = items.foldLeft(cms0) {
+          case (c, (_, k, v)) =>
+            c.scaledAdd(time, k, v)
+        }
+        val got = cms1.total.value
+        val expected = cms0.total.value + items.map(_._3).sum
+        Prop(close(got, expected)) :| s"close($got, $expected) with cms1=$cms1"
+      }
+    }
+  }
+
+  def timeCommutativeBinop(op: String)(f: (Double, Double) => Double): Unit =
+    property(s"DoubleAt operations are time-commutative with $op") {
+      forAll { (module: DecayingCMS[String]) =>
+        val g = genDoubleAt(module)
+        forAll(g, g, genTimestamp(module)) { (x, y, t) =>
+          val lhs = x.map2(y)(f).at(t)
+          val rhs = f(x.at(t), y.at(t))
+          Prop(close(lhs, rhs)) :| s"close($lhs, $rhs)"
+        }
+      }
+    }
+
+  def timeCommutativeUnop(op: String)(f: Double => Double): Unit =
+    property(s"DoubleAt operations are time-commutative with $op") {
+      forAll { (module: DecayingCMS[String]) =>
+        val g = genDoubleAt(module)
+        forAll(g, genTimestamp(module)) { (x, t) =>
+          val lhs = x.map(f).at(t)
+          val rhs = f(x.at(t))
+          Prop(close(lhs, rhs)) :| s"close($lhs, $rhs)"
+        }
+      }
+    }
+
+  // this idea here is that for a given operation (e.g. +) we want:
+  //
+  //   (x + y).at(t) = x(t) + y(t)
+  //
+  timeCommutativeBinop("+")(_ + _)
+  timeCommutativeBinop("-")(_ - _)
+  timeCommutativeBinop("min")(_ min _)
+  timeCommutativeBinop("max")(_ max _)
+
+  timeCommutativeUnop("abs")(_.abs)
+  timeCommutativeUnop("unary -")(-_)
+  timeCommutativeUnop("*2")(_ * 2.0)
+
+  property("division is scale-independent") {
+    forAll { (module: DecayingCMS[String]) =>
+      val g = genDoubleAt(module)
+      forAll(g, g, genTimestamp(module)) { (x, y, t) =>
+        if (y.at(t) != 0) {
+          val lhs = (y * (x / y)).at(t)
+          val rhs = x.at(t)
+          Prop(close(lhs, rhs)) :| s"close($lhs, $rhs)"
+        } else {
+          Prop(true)
+        }
+      }
+    }
+  }
+
+  property("timeToZero") {
+    forAll { (module: DecayingCMS[String]) =>
+      val g = genDoubleAt(module)
+      forAll(g) { x =>
+        val t = x.timeToZero
+        if (java.lang.Double.isFinite(t)) {
+          Prop(x.at(module.toTimestamp(t - 100.0)) != 0.0) &&
+          Prop(x.at(module.toTimestamp(t + 100.0)) == 0.0)
+        } else {
+          Prop(true)
+        }
+      }
+    }
+  }
+
+  property("timeToUnit") {
+    forAll { (module: DecayingCMS[String]) =>
+      val g = genDoubleAt(module)
+      forAll(g) { x =>
+        val timeInHL = x.timeToUnit
+        if (java.lang.Double.isFinite(timeInHL)) {
+          val time = module.toTimestamp(timeInHL)
+          val x0 = Math.abs(x.at(time - 100L))
+          val x1 = Math.abs(x.at(time))
+          val x2 = Math.abs(x.at(time + 100L))
+          val p0 = Prop(x0 > 1.0) :| s"$x0 > 1.0"
+          val p1 = Prop(close(x1, 1.0)) :| s"$x1 == 1.0"
+          val p2 = Prop(x2 < 1.0) :| s"$x2 < 1.0"
+          p0 && p1 && p2
+        } else {
+          Prop(true)
+        }
+      }
+    }
+  }
+
+  property("((x compare y) = n) = ((x.at(t) compare y.at(t)) = n)") {
+    forAll { (module: DecayingCMS[String]) =>
+      val g = genDoubleAt(module)
+      forAll(g, g, genTimestamp(module)) { (x, y, t) =>
+        val got = x.compare(y)
+        val expected = x.at(t) compare y.at(t)
+        Prop(got == expected)
+      }
+    }
+  }
+
+  property("range works reliably") {
+    forAll { (module: DecayingCMS[String]) =>
+      val g = genCms(module, stdKey, genTimestamp(module), stdVal)
+      forAll(g, genItems(module)) { (cms0, items) =>
+        val cms1 = cms0.bulkAdd(items)
+        val (minAt, maxAt) = cms1.range
+        val (xmin, xmax) = (minAt.value, maxAt.value)
+        items.iterator.map(_._2).foldLeft(Prop(true)) { (res, k) =>
+          val x = cms1.get(k).value
+          res &&
+            (Prop(xmin <= x) :| s"$xmin <= $x was false for key $k") &&
+            (Prop(x <= xmax) :| s"$x <= $xmax was false for key $k")
+        }
+      }
+    }
+  }
+
+  property("innerProductRoot(x, 0) = 0") {
+    forAll { (module: DecayingCMS[String]) =>
+      val g = genCms(module, stdKey, genTimestamp(module), stdVal)
+      forAll(g) { cms =>
+        val got = cms.innerProductRoot(module.empty)
+        Prop(got.value == 0.0) :| s"got $got expected 0"
+      }
+    }
+  }
+
+  property("innerProductRoot(x, x) = x for singleton x") {
+    forAll { (module: DecayingCMS[String]) =>
+      forAll(genItem(module)) {
+        case (t, k, v) =>
+          val cms0 = module.empty.add(t, k, v)
+          val got = cms0.l2Norm.at(t)
+          val expected = v
+          Prop(close(got, expected)) :| s"got $got, expected $expected"
+      }
+    }
+  }
+
+  property("innerProductRoot triangle inequality") {
+    // the triangle inequality is only approximately true. for a
+    // saturated CMS, it will stop being true. since normally we
+    // generate very small CMS structures, we choose to use a bigger
+    // module just for this test.
+    forAll(genBigModule[String]) { module =>
+      val g = genCms(module, stdKey, genTimestamp(module), stdVal)
+      forAll(g, g) { (x, y) =>
+        // abs(x + y) <= abs(x) + abs(y)
+        val lhs = ((x + y).l2Norm).timeToUnit
+        val rhs = (x.l2Norm + y.l2Norm).timeToUnit
+        Prop(lhs <= rhs || close(lhs, rhs))
+      }
+    }
+  }
+
+  property("(a + b) + c ~= a + (b + c) and a + b ~= b + a and a + zero = a") {
+    forAll { (module: DecayingCMS[String]) =>
+      val g = genCms(module, stdKey, genTimestamp(module), stdVal)
+      forAll(g, g, g) { (a, b, c) =>
+        import module.monoid.plus
+        val p0 = {
+          val left = plus(plus(a, b), c)
+          val right = plus(a, plus(b, c))
+          Prop(fuzzyEq(module)(left, right)) :| s"associate: $left was not equal to $right"
+        }
+
+        val p1 = {
+          val left = plus(a, b)
+          val right = plus(b, a)
+          Prop(fuzzyEq(module)(left, right)) :| s"commute: $left was not equal to $right"
+        }
+
+        val p2 = {
+          val left = plus(a, module.monoid.zero)
+          Prop(fuzzyEq(module)(left, a)) :| s"a + zero = a: $left was not equal to $a"
+        }
+
+        p0 && p1 && p2
+      }
+    }
+  }
+
+  property("fixed key ~ decayedvalue") {
+
+    def makeModule(halfLife: Duration): DecayingCMS[String] = {
+      val seed = "FIXED".hashCode.toLong
+      DecayingCMS[String](seed, halfLife, depth = 2, width = 3)
+    }
+
+    val genTestCase: Gen[(DecayingCMS[String], String, List[(Long, Double)])] =
+      for {
+        halfLife <- genDuration
+        module = makeModule(halfLife)
+        key <- stdKey
+        values <- genValues(module)
+      } yield (module, key, values)
+
+    def law(testCase: (DecayingCMS[String], String, List[(Long, Double)])): Prop = {
+
+      val (module, key, inputs0) = testCase
+      val halfLife = module.halfLife
+      val inputs = inputs0.sorted
+      val halfLifeSecs = halfLife.toSeconds.toDouble
+
+      if (inputs.nonEmpty) {
+
+        val tlast = inputs.last._1
+
+        val dvm = new DecayedValueMonoid(0.0)
+        val dv = dvm.sum(inputs.map {
+          case (t, n) =>
+            DecayedValue.build(n, (t.toDouble / 1000.0), halfLifeSecs)
+        })
+        val expected = dvm.valueAsOf(dv, halfLifeSecs, (tlast.toDouble / 1000.0))
+
+        val cms0 = module.monoid.zero
+        val cmss = inputs.map { case (t, n) => cms0.add(t, key, n) }
+        val cms = module.monoid.sum(cmss)
+
+        val got = cms.get(key).at(tlast)
+
+        Prop(close(got, expected)) :| s"$got is not close to $expected"
+      } else {
+        Prop(true)
+      }
+    }
+
+    forAll(genTestCase)(law _)
+
+    val regressions =
+      List(
+        (
+          "",
+          List((-7634593159529L, 1.0), (-10628114330964L, 0.0)),
+          Duration(1, HOURS)
+        ),
+        (
+          "",
+          List((29617281175711L, 65534.0), (29614132054038L, 255.0)),
+          Duration(7, DAYS)
+        )
+      )
+
+    regressions.foldLeft(Prop(true)) {
+      case (res, (k, items, hl)) =>
+        res && law((makeModule(hl), k, items))
+    }
+  }
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/DecayingCMSTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/DecayingCMSTest.scala
@@ -7,7 +7,11 @@ import Prop.{forAllNoShrink => forAll}
 
 class DecayingCMSProperties extends CheckProperties {
 
-  val eps = 1e-6
+  // uncomment to stress test (scalatest default is 10)
+  // override val generatorDrivenConfig =
+  //   PropertyCheckConfiguration(minSuccessful = 1000)
+
+  val eps = 1e-5
 
   def close(a: Double, b: Double): Boolean =
     if (a == b) {
@@ -105,7 +109,6 @@ class DecayingCMSProperties extends CheckProperties {
     Gen.listOf(stdItem)
 
   def genTimestamp[K](module: DecayingCMS[K]): Gen[Long] =
-    //Gen.choose(0L, module.halfLifeSecs.toLong * 1000L * 10L)
     Gen.choose(0L, module.halfLifeSecs.toLong * 10L)
 
   def genDoubleAt[K](module: DecayingCMS[K]): Gen[module.DoubleAt] =

--- a/build.sbt
+++ b/build.sbt
@@ -267,8 +267,7 @@ lazy val algebirdCore = module("core").settings(
 lazy val algebirdTest = module("test")
   .settings(
     testOptions in Test ++= Seq(
-      Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "4"),
-      Tests.Argument(TestFrameworks.ScalaCheck, "-minSuccessfulTests", "10000")),
+      Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "4")),
     crossScalaVersions += "2.13.1",
     libraryDependencies ++=
       Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -266,8 +266,7 @@ lazy val algebirdCore = module("core").settings(
 
 lazy val algebirdTest = module("test")
   .settings(
-    testOptions in Test ++= Seq(
-      Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "4")),
+    testOptions in Test ++= Seq(Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "4")),
     crossScalaVersions += "2.13.1",
     libraryDependencies ++=
       Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -266,7 +266,9 @@ lazy val algebirdCore = module("core").settings(
 
 lazy val algebirdTest = module("test")
   .settings(
-    testOptions in Test ++= Seq(Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "4")),
+    testOptions in Test ++= Seq(
+      Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "4"),
+      Tests.Argument(TestFrameworks.ScalaCheck, "-minSuccessfulTests", "10000")),
     crossScalaVersions += "2.13.1",
     libraryDependencies ++=
       Seq(


### PR DESCRIPTION
This type represents a count-min sketch whose values decay over time
according to a provided half-life.

It uses a module-style approach, where the half-life, width, depth,
and other parameters are set in a module. The actual CMS values are
path-dependent types on the DecayingCMS[K] module value. This means
that we don't have to carry around or serialize anything besides the
count-min values themselves, and also means we can be sure that CMS
values to be combined are aligned.

It's a slightly different pattern that people may be used to, but I
think it works much better for this kind of thing. (I could imagine
creating a non-decaying variant with a similar design, but that's
outside the scope of this PR.)

cc @johnynek 