### PR TITLE
Remove implicit from MomentsGroup and other cleanups

### DIFF
--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/HLLBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/HLLBenchmark.scala
@@ -2,7 +2,6 @@ package com.twitter.algebird
 package benchmark
 
 import scala.util.Random
-import com.twitter.bijection._
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
@@ -47,10 +46,9 @@ object HllBenchmark {
 
       val rng = new Random(3)
 
-      val byteEncoder = implicitly[Injection[Long, Array[Byte]]]
       def setSize = rng.nextInt(10) + 1 // 1 -> 10
       def hll(elements: Set[Long]): HLL =
-        hllMonoid.batchCreate(elements)(byteEncoder)
+        hllMonoid.sum(elements.map(hllMonoid.toHLL[Long](_)))
 
       val inputIntermediate = (0L until numElements).map { _ =>
         val setElements = (0 until setSize).map(_ => rng.nextInt(1000).toLong).toSet

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/HLLPresentBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/HLLPresentBenchmark.scala
@@ -1,13 +1,10 @@
 package com.twitter.algebird.benchmark
 
 import com.twitter.algebird.{DenseHLL, HLL, HyperLogLogMonoid, SparseHLL}
-import com.twitter.bijection._
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
 object HLLPresentBenchmark {
-  implicit val byteEncoder = implicitly[Injection[Long, Array[Byte]]]
-
   @State(Scope.Benchmark)
   class HLLPresentState {
 
@@ -27,7 +24,7 @@ object HLLPresentBenchmark {
       val r = new scala.util.Random(12345L)
       data = (0 until numHLL).map { _ =>
         val input = (0 until max).map(_ => r.nextLong).toSet
-        hllMonoid.batchCreate(input)(byteEncoder.toFunction)
+        hllMonoid.sum(input.map(hllMonoid.toHLL(_)))
       }.toIndexedSeq
     }
   }

--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/HllBatchCreateBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/HllBatchCreateBenchmark.scala
@@ -2,11 +2,8 @@ package com.twitter.algebird.benchmark
 
 import org.openjdk.jmh.annotations._
 import com.twitter.algebird.HyperLogLogMonoid
-import com.twitter.bijection._
 
 object HllBatchCreateBenchmark {
-  val byteEncoder = implicitly[Injection[Long, Array[Byte]]]
-  val byteEncoderFn = byteEncoder.toFunction
 
   @State(Scope.Benchmark)
   class HLLState {
@@ -35,5 +32,5 @@ class HllBatchCreateBenchmark {
 
   @Benchmark
   def timeBatchCreate(state: HLLState) =
-    state.hllMonoid.batchCreate(state.set)(byteEncoderFn)
+    state.hllMonoid.sum(state.set.iterator.map(state.hllMonoid.toHLL(_)))
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala
@@ -150,17 +150,17 @@ object AveragedGroup extends Group[AveragedValue] with CommutativeGroup[Averaged
     else {
       var count = 0L
       var average = 0.0
-      iter.iterator.foreach {
-        case AveragedValue(c, v) =>
-          average = getCombinedMean(count, average, c, v)
-          count += c
+      val it = iter.toIterator
+      while (it.hasNext) {
+        val av = it.next()
+        average = getCombinedMean(count, average, av.count, av.value)
+        count += av.count
       }
       Some(AveragedValue(count, average))
     }
 
   /**
-   * @inheritdoc
-   * @see [[AveragedValue.+]] for the implementation
+   * combine two AveragedValue instances
    */
   override def plus(l: AveragedValue, r: AveragedValue): AveragedValue = {
     val n = l.count

--- a/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/BloomFilter.scala
@@ -147,7 +147,7 @@ object BloomFilter {
   ): Approximate[Long] = {
     assert(0 <= approximationWidth && approximationWidth < 1, "approximationWidth must lie in [0, 1)")
 
-    /**
+    /*
      * s(n) is the expected number of bits that have been set to true after
      * n elements have been inserted into the Bloom filter.
      * This is \hat{S}(n) in the cardinality estimation paper used above.
@@ -155,7 +155,7 @@ object BloomFilter {
     def s(n: Int): Double =
       width * (1 - scala.math.pow(1 - 1.0 / width, numHashes * n))
 
-    /**
+    /*
      * sInverse(t) is the maximum likelihood value for the number of elements
      * that have been inserted into the Bloom filter when it has t bits set to true.
      * This is \hat{S}^{-1}(t) in the cardinality estimation paper used above.

--- a/algebird-core/src/main/scala/com/twitter/algebird/CMSHasher.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CMSHasher.scala
@@ -10,7 +10,7 @@ package com.twitter.algebird
  * count.  Algebird ships with several such implicits for commonly used types `K` such as `Long` and `BigInt`.
  *
  * If your type `K` is not supported out of the box, you have two options: 1) You provide a "translation" function to
- * convert items of your (unsupported) type `K` to a supported type such as [[Double]], and then use the `contramap`
+ * convert items of your (unsupported) type `K` to a supported type such as Double, and then use the `contramap`
  * function of [[CMSHasher]] to create the required `CMSHasher[K]` for your type (see the documentation of `contramap`
  * for an example); 2) You implement a `CMSHasher[K]` from scratch, using the existing CMSHasher implementations as a
  * starting point.
@@ -31,7 +31,7 @@ trait CMSHasher[K] extends java.io.Serializable {
    * def hash(a: Int, b: Int, width: Int)(x: L): CMSHasher[L] = CMSHasher[K].hash(a, b, width)(f(x))
    * }}}
    */
-  def on[L](f: L => K) = new CMSHasher[L] {
+  def on[L](f: L => K): CMSHasher[L] = new CMSHasher[L] {
     override def hash(a: Int, b: Int, width: Int)(x: L): Int =
       self.hash(a, b, width)(f(x))
   }
@@ -59,7 +59,7 @@ trait CMSHasher[K] extends java.io.Serializable {
    * implicit val cmsHasherDouble: CMSHasher[Double] = CMSHasherArrayByte.contramap((d: Double) => f(d))
    * }}}
    */
-  def contramap[L](f: L => K) = on(f)
+  def contramap[L](f: L => K): CMSHasher[L] = on(f)
 
 }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/CorrelationMonoid.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CorrelationMonoid.scala
@@ -157,7 +157,7 @@ object CorrelationMonoid extends Monoid[Correlation] {
 
       while (iter.hasNext) {
 
-        /**
+        /*
          * This is tested by monoidLaws to match plus
          * we do this loop here to avoid allocating
          * between each pair of Correlations

--- a/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/CountMinSketch.scala
@@ -60,7 +60,7 @@ import scala.collection.compat._
  * @author Edwin Chen
  */
 /**
- * Monoid for adding [[CMS]] sketches.
+ * Monoid for adding CMS sketches.
  *
  * =Usage=
  *
@@ -73,7 +73,7 @@ import scala.collection.compat._
  * Algebird ships with several such implicits for commonly used types such as `Long` and `BigInt`.
  *
  * If your type `K` is not supported out of the box, you have two options: 1) You provide a "translation" function to
- * convert items of your (unsupported) type `K` to a supported type such as [[Double]], and then use the `contramap`
+ * convert items of your (unsupported) type `K` to a supported type such as Double, and then use the `contramap`
  * function of [[CMSHasher]] to create the required `CMSHasher[K]` for your type (see the documentation of [[CMSHasher]]
  * for an example); 2) You implement a `CMSHasher[K]` from scratch, using the existing CMSHasher implementations as a
  * starting point.
@@ -225,7 +225,7 @@ class CMSSummation[K](params: CMSParams[K]) {
 }
 
 /**
- * An Aggregator for [[CMS]].  Can be created using [[CMS.aggregator]].
+ * An Aggregator for [[CMS]].  Can be created using CMS.aggregator.
  */
 case class CMSAggregator[K](cmsMonoid: CMSMonoid[K]) extends MonoidAggregator[K, CMS[K], CMS[K]] {
   override val monoid: CMSMonoid[K] = cmsMonoid
@@ -1149,7 +1149,7 @@ case class HeavyHitter[K](item: K, count: Long) extends java.io.Serializable
  * Algebird ships with several such implicits for commonly used types such as `Long` and `BigInt`.
  *
  * If your type `K` is not supported out of the box, you have two options: 1) You provide a "translation" function to
- * convert items of your (unsupported) type `K` to a supported type such as [[Double]], and then use the `contramap`
+ * convert items of your (unsupported) type `K` to a supported type such as Double, and then use the `contramap`
  * function of [[CMSHasher]] to create the required `CMSHasher[K]` for your type (see the documentation of [[CMSHasher]]
  * for an example); 2) You implement a `CMSHasher[K]` from scratch, using the existing CMSHasher implementations as a
  * starting point.

--- a/algebird-core/src/main/scala/com/twitter/algebird/Group.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Group.scala
@@ -87,10 +87,16 @@ class OptionGroup[T](implicit group: Group[T]) extends OptionMonoid[T] with Grou
  * negate is defined as the negation of each element of the array.
  */
 class ArrayGroup[T: ClassTag](implicit grp: Group[T]) extends ArrayMonoid[T]() with Group[Array[T]] {
-  override def negate(g: Array[T]): Array[T] =
-    g.map {
-      grp.negate(_)
-    }.toArray
+  override def negate(g: Array[T]): Array[T] = {
+    val res = new Array[T](g.length)
+    var idx = 0
+    while (idx < res.length) {
+      res(idx) = grp.negate(g(idx))
+      idx = idx + 1
+    }
+
+    res
+  }
 }
 
 class FromAlgebraGroup[T](m: AGroup[T]) extends FromAlgebraMonoid(m) with Group[T] {

--- a/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala
@@ -737,7 +737,8 @@ abstract class SetSizeAggregatorBase[A](hllBits: Int, maxSetSize: Int)
 
 case class SetSizeAggregator[A](hllBits: Int, maxSetSize: Int = 10)(implicit toBytes: A => Array[Byte])
     extends SetSizeAggregatorBase[A](hllBits, maxSetSize) {
-  override def convert(set: Set[A]): HLL = leftSemigroup.batchCreate(set.map(toBytes))
+  override def convert(set: Set[A]): HLL =
+    leftSemigroup.sum(set.iterator.map(a => leftSemigroup.toHLL(toBytes(a))))
 }
 
 /**

--- a/algebird-core/src/main/scala/com/twitter/algebird/Interval.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Interval.scala
@@ -58,7 +58,7 @@ object Interval extends java.io.Serializable {
    * [[leftOpenRightClosed]] can retain the type information of the
    * returned interval. The compiler doesn't know anything about
    * ordering, so without [[MaybeEmpty]] the only valid return type
-   * is [[Interval[T]]].
+   * is Interval[T].
    */
   sealed abstract class MaybeEmpty[T, NonEmpty[t] <: Interval[t]] {
     def isEmpty: Boolean

--- a/algebird-core/src/main/scala/com/twitter/algebird/MomentsGroup.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/MomentsGroup.scala
@@ -153,7 +153,7 @@ class MomentsMonoid extends Monoid[Moments] with CommutativeMonoid[Moments] {
 
       while (iter.hasNext) {
 
-        /**
+        /*
          * Unfortunately we copy the code in plus, but we do
          * it to avoid allocating a new Moments on every item
          * in the loop. the Monoid laws test that sum

--- a/algebird-core/src/main/scala/com/twitter/algebird/MomentsGroup.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/MomentsGroup.scala
@@ -207,7 +207,7 @@ class MomentsMonoid extends Monoid[Moments] with CommutativeMonoid[Moments] {
  * but (a - a) + b in general isn't associative: it won't equal a - (a - b)
  * which it should.
  */
-@deprecated("use MomentsMonoid, this isn't lawful for negative counts", "0.13.8")
+@deprecated("use Moments.momentsMonoid, this isn't lawful for negative counts", "0.13.8")
 object MomentsGroup extends MomentsMonoid with Group[Moments] with CommutativeGroup[Moments] {
 
   override def negate(a: Moments): Moments =

--- a/algebird-core/src/main/scala/com/twitter/algebird/Operators.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Operators.scala
@@ -16,23 +16,36 @@ limitations under the License.
 package com.twitter.algebird
 
 object Operators {
-  implicit def toPlus[T: Semigroup](t: T): PlusOp[T] = new PlusOp(t)
-  implicit def toMinus[T: Group](t: T): MinusOp[T] = new MinusOp(t)
-  implicit def toTimes[T: Ring](t: T): TimesOp[T] = new TimesOp(t)
+  @deprecated("use Operators.Ops", "0.13.8")
+  def toPlus[T: Semigroup](t: T): PlusOp[T] = new PlusOp(t)
+  @deprecated("use Operators.Ops", "0.13.8")
+  def toMinus[T: Group](t: T): MinusOp[T] = new MinusOp(t)
+  @deprecated("use Operators.Ops", "0.13.8")
+  def toTimes[T: Ring](t: T): TimesOp[T] = new TimesOp(t)
+
   implicit def toRichTraversableFromIterator[T](t: Iterator[T]): RichTraversable[T] =
     new RichTraversable(t)
   implicit def toRichTraversable[T](t: Traversable[T]): RichTraversable[T] =
     new RichTraversable(t)
+
+  implicit class Ops[A](private val a: A) extends AnyVal {
+    def +(other: A)(implicit sg: Semigroup[A]): A = sg.plus(a, other)
+    def -(other: A)(implicit g: Group[A]): A = g.minus(a, other)
+    def *(other: A)(implicit r: Ring[A]): A = r.times(a, other)
+  }
 }
 
+@deprecated("use Operators.Ops", "0.13.8")
 class PlusOp[T: Semigroup](t: T) {
   def +(other: T): T = implicitly[Semigroup[T]].plus(t, other)
 }
 
+@deprecated("use Operators.Ops", "0.13.8")
 class MinusOp[T: Group](t: T) {
   def -(other: T): T = implicitly[Group[T]].minus(t, other)
 }
 
+@deprecated("use Operators.Ops", "0.13.8")
 class TimesOp[T: Ring](t: T) {
   def *(other: T): T = implicitly[Ring[T]].times(t, other)
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -85,7 +85,10 @@ object IntRing extends Ring[Int] {
   override def times(l: Int, r: Int): Int = l * r
   override def sum(t: TraversableOnce[Int]): Int = {
     var sum = 0
-    t.foreach(sum += _)
+    val iter = t.toIterator
+    while (iter.hasNext) {
+      sum += iter.next()
+    }
     sum
   }
   override def sumOption(t: TraversableOnce[Int]): Option[Int] =
@@ -102,7 +105,10 @@ object ShortRing extends Ring[Short] {
   override def times(l: Short, r: Short): Short = (l * r).toShort
   override def sum(t: TraversableOnce[Short]): Short = {
     var sum = 0
-    t.foreach(sum += _)
+    val iter = t.toIterator
+    while (iter.hasNext) {
+      sum += iter.next()
+    }
     sum.toShort
   }
   override def sumOption(t: TraversableOnce[Short]): Option[Short] =
@@ -119,7 +125,10 @@ object LongRing extends Ring[Long] {
   override def times(l: Long, r: Long): Long = l * r
   override def sum(t: TraversableOnce[Long]): Long = {
     var sum = 0L
-    t.foreach(sum += _)
+    val iter = t.toIterator
+    while (iter.hasNext) {
+      sum += iter.next()
+    }
     sum
   }
   override def sumOption(t: TraversableOnce[Long]): Option[Long] =
@@ -134,6 +143,19 @@ object FloatRing extends Ring[Float] {
   override def plus(l: Float, r: Float): Float = l + r
   override def minus(l: Float, r: Float): Float = l - r
   override def times(l: Float, r: Float): Float = l * r
+  override def sum(t: TraversableOnce[Float]): Float = {
+    var sum = 0.0f
+    val iter = t.toIterator
+    while (iter.hasNext) {
+      sum += iter.next()
+    }
+
+    sum
+  }
+
+  override def sumOption(t: TraversableOnce[Float]): Option[Float] =
+    if (t.isEmpty) None
+    else Some(sum(t))
 }
 
 object DoubleRing extends Ring[Double] {
@@ -143,6 +165,19 @@ object DoubleRing extends Ring[Double] {
   override def plus(l: Double, r: Double): Double = l + r
   override def minus(l: Double, r: Double): Double = l - r
   override def times(l: Double, r: Double): Double = l * r
+  override def sum(t: TraversableOnce[Double]): Double = {
+    var sum = 0.0
+    val iter = t.toIterator
+    while (iter.hasNext) {
+      sum += iter.next()
+    }
+
+    sum
+  }
+
+  override def sumOption(t: TraversableOnce[Double]): Option[Double] =
+    if (t.isEmpty) None
+    else Some(sum(t))
 }
 
 object BooleanRing extends Ring[Boolean] {

--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -143,19 +143,19 @@ object FloatRing extends Ring[Float] {
   override def plus(l: Float, r: Float): Float = l + r
   override def minus(l: Float, r: Float): Float = l - r
   override def times(l: Float, r: Float): Float = l * r
-  override def sum(t: TraversableOnce[Float]): Float = {
-    var sum = 0.0f
-    val iter = t.toIterator
-    while (iter.hasNext) {
-      sum += iter.next()
-    }
-
-    sum
-  }
 
   override def sumOption(t: TraversableOnce[Float]): Option[Float] =
     if (t.isEmpty) None
-    else Some(sum(t))
+    else
+      Some {
+        var sum = 0.0
+        val iter = t.toIterator
+        while (iter.hasNext) {
+          sum += iter.next().toDouble
+        }
+
+        sum.toFloat
+      }
 }
 
 object DoubleRing extends Ring[Double] {
@@ -165,19 +165,19 @@ object DoubleRing extends Ring[Double] {
   override def plus(l: Double, r: Double): Double = l + r
   override def minus(l: Double, r: Double): Double = l - r
   override def times(l: Double, r: Double): Double = l * r
-  override def sum(t: TraversableOnce[Double]): Double = {
-    var sum = 0.0
-    val iter = t.toIterator
-    while (iter.hasNext) {
-      sum += iter.next()
-    }
-
-    sum
-  }
 
   override def sumOption(t: TraversableOnce[Double]): Option[Double] =
     if (t.isEmpty) None
-    else Some(sum(t))
+    else
+      Some {
+        var sum = 0.0
+        val iter = t.toIterator
+        while (iter.hasNext) {
+          sum += iter.next()
+        }
+
+        sum
+      }
 }
 
 object BooleanRing extends Ring[Boolean] {

--- a/algebird-test/src/main/scala/com/twitter/algebird/MonadLaws.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/MonadLaws.scala
@@ -88,7 +88,7 @@ object MonadLaws {
     forAll((t: T, fn: T => M[U]) => Equiv[M[U]].equiv(t.pure[M].flatMap(fn), fn(t)))
 
   def rightIdentity[M[_], T](implicit monad: Monad[M], arb: Arbitrary[M[T]], equiv: Equiv[M[T]]) =
-    forAll((mt: M[T]) => Equiv[M[T]].equiv(mt.flatMap(_.pure[M]), mt))
+    forAll((mt: M[T]) => equiv.equiv(mt.flatMap(_.pure[M]), mt))
 
   def associative[M[_], T, U, V](implicit
       monad: Monad[M],
@@ -97,7 +97,7 @@ object MonadLaws {
       fn2: Arbitrary[U => M[V]],
       equiv: Equiv[M[V]]
   ) = forAll { (mt: M[T], f1: T => M[U], f2: U => M[V]) =>
-    Equiv[M[V]].equiv(mt.flatMap(f1).flatMap(f2), mt.flatMap(t => f1(t).flatMap(f2)))
+    equiv.equiv(mt.flatMap(f1).flatMap(f2), mt.flatMap(t => f1(t).flatMap(f2)))
   }
 
   def monadLaws[M[_], T, U, R](implicit
@@ -106,11 +106,13 @@ object MonadLaws {
       equivT: Equiv[M[T]],
       equivU: Equiv[M[U]],
       equivR: Equiv[M[R]],
-      fn1: Arbitrary[(T) => M[U]],
+      fn1: Arbitrary[T => M[U]],
       arbr: Arbitrary[M[R]],
       fn2: Arbitrary[U => M[R]],
       arbu: Arbitrary[U]
   ) =
+    // TODO: equivT and equivU are unused, only equivR is used
+    // but it would break binary compatibility to remove them
     associative[M, T, U, R] && rightIdentity[M, R] && leftIdentity[M, U, R]
 
   implicit def indexedSeqA[T](implicit arbl: Arbitrary[List[T]]): Arbitrary[IndexedSeq[T]] =

--- a/algebird-test/src/test/scala/com/twitter/algebird/CorrelationLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/CorrelationLaws.scala
@@ -75,7 +75,9 @@ class CorrelationLaws extends CheckProperties {
   property("the swap method on moments works as you'd think") {
     forAll { l: List[(Double, Double)] =>
       val swapped = CorrelationAggregator(l).swap
-      val reversedInput = CorrelationAggregator.composePrepare[(Double, Double)] { case (x, y) => (y, x) }(l)
+      val fn: ((Double, Double)) => (Double, Double) = { tup => tup.swap }
+
+      val reversedInput = CorrelationAggregator.composePrepare[(Double, Double)](fn)(l)
       corrApproxEq(swapped, reversedInput)
     }
   }

--- a/algebird-test/src/test/scala/com/twitter/algebird/DecayedVectorProperties.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/DecayedVectorProperties.scala
@@ -23,8 +23,8 @@ class DecayedVectorProperties extends CheckProperties {
 
   implicit val mpint: Arbitrary[DecayedVector[({ type x[a] = Map[Int, a] })#x]] = Arbitrary {
     for {
-      t <- Gen.choose(1e-5, 200.0) // Not too high so as to avoid numerical issues
-      m <- Arbitrary.arbitrary[Map[Int, Double]]
+      t <- Gen.choose(1e-4, 200.0) // Not too high so as to avoid numerical issues
+      m <- Gen.mapOf(Gen.zip(Gen.choose(0, 100), Gen.choose(-1e5, 1e5)))
     } yield DecayedVector.forMap(m, t)
   }
 
@@ -33,8 +33,13 @@ class DecayedVectorProperties extends CheckProperties {
       a: DecayedVector[({ type x[a] = Map[Int, a] })#x],
       b: DecayedVector[({ type x[a] = Map[Int, a] })#x]
   ) = {
-    def beCloseTo(a: Double, b: Double, eps: Double = 1e-6) =
-      a == b || (math.abs(a - b) / math.abs(a)) < eps || (a.isInfinite && b.isInfinite) || a.isNaN || b.isNaN
+
+    def beCloseTo(a: Double, b: Double, eps: Double = 1e-5) =
+      a == b ||
+        ((2.0 * math.abs(a - b)) / (math.abs(a) + math.abs(b))) < eps ||
+        (a.isInfinite && b.isInfinite) ||
+        (a.isNaN && b.isNaN)
+
     val mapsAreClose = (a.vector.keySet ++ b.vector.keySet).forall { key =>
       (a.vector.get(key), b.vector.get(key)) match {
         case (Some(aVal), Some(bVal)) => beCloseTo(aVal, bVal)
@@ -47,7 +52,7 @@ class DecayedVectorProperties extends CheckProperties {
     mapsAreClose && timesAreClose
   }
 
-  property("DecayedVector[Map[Int, _]] is a monoid") {
+  property("DecayedVector[Map[Int, *]] is a monoid") {
     implicit val equiv = Equiv.fromFunction(decayedMapEqFn)
     monoidLaws[DecayedVector[({ type x[a] = Map[Int, a] })#x]]
   }

--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -362,7 +362,10 @@ class HyperLogLogTest extends AnyWordSpec with Matchers {
       val partialSums = data.foldLeft(IndexedSeq(mon.zero)) { (seq, value) =>
         seq :+ (seq.last + mon.create(value))
       }
-      (1 to 200).map(n => assert(partialSums(n) == mon.batchCreate(data.slice(0, n))))
+      (1 to 200).map { n =>
+        val bc = mon.sum(data.slice(0, n).map(mon.toHLL(_)))
+        assert(partialSums(n) == bc)
+      }
     }
 
     "work as an Aggregator and return a HLL" in {

--- a/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/HyperLogLogTest.scala
@@ -164,7 +164,7 @@ class HLLIntersectionProperty[T: Hash128: Gen](bits: Int, numHlls: Int) extends 
  * SetSizeAggregator should work as an aggregator and return
  * approximate size when > maxSetSize
  */
-abstract class SetSizeAggregatorProperty[T](bits: Int) extends ApproximateProperty {
+abstract class SetSizeAggregatorProperty[T] extends ApproximateProperty {
   type Exact = Set[T]
   type Approx = Long
 
@@ -178,7 +178,7 @@ abstract class SetSizeAggregatorProperty[T](bits: Int) extends ApproximateProper
   def exactResult(set: Set[T], i: Unit) = set.size
 }
 
-abstract class SmallSetSizeAggregatorProperty[T: Gen](bits: Int) extends SetSizeAggregatorProperty[T](bits) {
+abstract class SmallSetSizeAggregatorProperty[T: Gen] extends SetSizeAggregatorProperty[T] {
   def exactGenerator: Gen[Set[T]] =
     for {
       size <- Gen.choose(maxSetSize + 1, maxSetSize * 2)
@@ -189,7 +189,7 @@ abstract class SmallSetSizeAggregatorProperty[T: Gen](bits: Int) extends SetSize
     Approximate.exact(aggResult.toDouble)
 }
 
-abstract class LargeSetSizeAggregatorProperty[T: Gen](bits: Int) extends SetSizeAggregatorProperty[T](bits) {
+abstract class LargeSetSizeAggregatorProperty[T: Gen](bits: Int) extends SetSizeAggregatorProperty[T] {
   def exactGenerator: Gen[Set[T]] =
     for {
       size <- Gen.choose(1, maxSetSize)
@@ -203,7 +203,7 @@ abstract class LargeSetSizeAggregatorProperty[T: Gen](bits: Int) extends SetSize
 }
 
 class SmallBytesSetSizeAggregatorProperty[T <% Array[Byte]: Gen](bits: Int)
-    extends SmallSetSizeAggregatorProperty[T](bits) {
+    extends SmallSetSizeAggregatorProperty[T] {
   def makeApproximate(s: Set[T]): Long =
     SetSizeAggregator[T](bits, maxSetSize).apply(s)
 }
@@ -215,7 +215,7 @@ class LargeBytesSetSizeAggregatorProperty[T <% Array[Byte]: Gen](bits: Int)
 }
 
 class SmallSetSizeHashAggregatorProperty[T: Hash128: Gen](bits: Int)
-    extends SmallSetSizeAggregatorProperty[T](bits) {
+    extends SmallSetSizeAggregatorProperty[T] {
   def makeApproximate(s: Set[T]): Long =
     SetSizeHashAggregator[T](bits, maxSetSize).apply(s)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -203,12 +203,12 @@ lazy val mimaSettings = Def.settings(
  * This returns the previous jar we released that is compatible with
  * the current.
  */
-val noBinaryCompatCheck = Set[String]("benchmark", "caliper", "generic", "spark")
+val noBinaryCompatCheck = Set[String]("benchmark", "caliper", "spark")
 
 def previousVersion(subProj: String) =
   Some(subProj)
     .filterNot(noBinaryCompatCheck.contains)
-    .map(s => "com.twitter" %% ("algebird-" + s) % "0.13.5")
+    .map(s => "com.twitter" %% ("algebird-" + s) % "0.13.7")
 
 lazy val algebird = Project(id = "algebird", base = file("."))
   .settings(sharedSettings)


### PR DESCRIPTION
While working on #829 @eigenvariable discovered that our tests were too weak for Moments and it is not really a group.

This PR is binary compatible, but removes the implicit label (which only breaks source compatibility and only for users unsafely using Moments as a Group).

Note: the code is not *totally* wrong and were were testing the laws, but we were not hitting the corner case that violates the law. The fact that it is nearly lawful (e.g. you don't ever have negative counts, it seems to be lawful) and the fact that we don't want to do a binary break is the reason why we are leaving the code.

I did two other kinds of changes:

1. implement sumOption for Moments and Correlation to speed up aggregations of big lists
2. remove some warnings that I could without breaking binary compatibility

@regadas and @eigenvariable could you take a look?