### PR TITLE
Setup automated releases from GitHub Actions CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+on:
+  push:
+    branches: [develop]
+    tags: ["*"]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-gpg@v2
+      - name: Publish ${{ github.ref }}
+        run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import ReleaseTransformations._
 import algebird._
 import com.typesafe.tools.mima.core._
 import pl.project13.scala.sbt.JmhPlugin
@@ -34,6 +33,9 @@ def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
 
 def isScala212x(scalaVersion: String) = scalaBinaryVersion(scalaVersion) == "2.12"
 def isScala213x(scalaVersion: String) = scalaBinaryVersion(scalaVersion) == "2.13"
+
+noPublishSettings
+crossScalaVersions := Nil
 
 val sharedSettings = Seq(
   organization := "com.twitter",
@@ -73,35 +75,7 @@ val sharedSettings = Seq(
     "com.novocode" % "junit-interface" % "0.11" % Test
   ),
   // Publishing options:
-  releaseCrossBuild := true,
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  releaseVersionBump := sbtrelease.Version.Bump.Minor, // need to tweak based on mima results
-  publishMavenStyle := true,
-  publishArtifact in Test := false,
   pomIncludeRepository := { x => false },
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean,
-    releaseStepCommandAndRemaining("+test"), // formerly runTest, here to deal with algebird-spark
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    releaseStepCommandAndRemaining(
-      "+publishSigned"
-    ), // formerly publishArtifacts, here to deal with algebird-spark
-    ReleaseStep(action = releaseStepCommand("sonatypeBundleRelease")),
-    setNextVersion,
-    commitNextVersion,
-    pushChanges
-  ),
-  publishTo := sonatypePublishToBundle.value,
-  scmInfo := Some(
-    ScmInfo(
-      url("https://github.com/twitter/algebird"),
-      "scm:git@github.com:twitter/algebird.git"
-    )
-  ),
   pomExtra := (<url>https://github.com/twitter/algebird</url>
     <licenses>
       <license>
@@ -138,6 +112,7 @@ val sharedSettings = Seq(
 ) ++ mimaSettings
 
 lazy val noPublishSettings = Seq(
+  publish / skip := true,
   publish := {},
   publishLocal := {},
   test := {},

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,6 @@ resolvers ++= Seq(
 
 addSbtPlugin("com.47deg" % "sbt-microsites" % "1.2.1")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.0")
@@ -16,3 +15,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.20")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.13.8-SNAPSHOT"


### PR DESCRIPTION
Previously, releases were done from a local computer with the
sbt-release plugin. Now, releases happen automatically from GitHub
Actions. Every merge into master should trigger a SNAPSHOT release
and every git tag push should trigger a stable Sonatype release.

For more details, see https://github.com/olafurpg/sbt-ci-release