### PR TITLE
Enable release drafter workflow to help write changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## Pull Requests
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit adds a CI workflow that updates a draft for the changelog of
the next GitHub release. Here is an example release that's been created
with release drafter https://github.com/scalameta/mdoc/releases/tag/v2.2.6
It's not necessary to publish the release as the "github-actions" user,
you can copy-paste the draft into a new release if you prefer. The
draft is helpful just to get a quick overview of what has changed
since the last release.