### PR TITLE
Use Kahan summation for Float and Double

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -151,16 +151,16 @@ object FloatRing extends Ring[Float] {
     else
       Some {
         val iter = t.toIterator
-        var sum = iter.next().toDouble
-        var c = 0.0
+        var sum = iter.next()
+        var c = 0.0f
         while (iter.hasNext) {
-          val y = iter.next().toDouble - c
+          val y = iter.next() - c
           val t = sum + y
           c = (t - sum) - y
           sum = t
         }
 
-        sum.toFloat
+        sum
       }
 }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -151,16 +151,16 @@ object FloatRing extends Ring[Float] {
     else
       Some {
         val iter = t.toIterator
-        var sum = iter.next()
-        var c = 0.0f
+        var sum = iter.next().toDouble
+        var c = 0.0
         while (iter.hasNext) {
-          val y = iter.next() - c
+          val y = iter.next().toDouble - c
           val t = sum + y
           c = (t - sum) - y
           sum = t
         }
 
-        sum
+        sum.toFloat
       }
 }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -144,14 +144,20 @@ object FloatRing extends Ring[Float] {
   override def minus(l: Float, r: Float): Float = l - r
   override def times(l: Float, r: Float): Float = l * r
 
+  // see: https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+  // for this algorithm
   override def sumOption(t: TraversableOnce[Float]): Option[Float] =
     if (t.isEmpty) None
     else
       Some {
-        var sum = 0.0
         val iter = t.toIterator
+        var sum = iter.next().toDouble
+        var c = 0.0
         while (iter.hasNext) {
-          sum += iter.next().toDouble
+          val y = iter.next().toDouble - c
+          val t = sum + y
+          c = (t - sum) - y
+          sum = t
         }
 
         sum.toFloat
@@ -166,14 +172,20 @@ object DoubleRing extends Ring[Double] {
   override def minus(l: Double, r: Double): Double = l - r
   override def times(l: Double, r: Double): Double = l * r
 
+  // see: https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+  // for this algorithm
   override def sumOption(t: TraversableOnce[Double]): Option[Double] =
     if (t.isEmpty) None
     else
       Some {
-        var sum = 0.0
         val iter = t.toIterator
+        var sum = iter.next()
+        var c = 0.0
         while (iter.hasNext) {
-          sum += iter.next()
+          val y = iter.next() - c
+          val t = sum + y
+          c = (t - sum) - y
+          sum = t
         }
 
         sum

--- a/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
@@ -22,8 +22,8 @@ import org.scalacheck.Prop
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
-  Unit tests to highlight specific examples of the properties we guarantee.
-  */
+ *  Unit tests to highlight specific examples of the properties we guarantee.
+ */
 class AggregatorTests extends AnyFunSuite {
   test("Kahan summation mitigates Double error accumulation") {
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
@@ -89,7 +89,11 @@ class AggregatorLaws extends CheckProperties {
   def checkNumericSum[T: Arbitrary](implicit num: Numeric[T]): Prop =
     forAll { in: List[T] =>
       val aggregator = Aggregator.numericSum[T]
-      aggregator(in) == in.map(num.toDouble).sum
+      val ares = aggregator(in)
+      val sres = in.map(num.toDouble).sum
+      (sres == ares) || {
+        (sres - ares).abs / (sres.abs + ares.abs) < 1e-5
+      }
     }
   property("Aggregator.numericSum is correct for Ints")(checkNumericSum[Int])
   property("Aggregator.numericSum is correct for Longs") {


### PR DESCRIPTION
see: https://en.wikipedia.org/wiki/Kahan_summation_algorithm

@sritchie reminded me of this recently, which I had seen years ago but forgotten when we implemented this code.

This improves the accuracy of long sums, which will make the results different, but floating point is already not associative or commutative, so I think this is an acceptable risk.

I had to change the tests a bit because scalas `.sum` does not use this kind of approach and it results in larger error.

Thanks Sam!