### PR TITLE
Tests for #880, PR review suggestions

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -151,16 +151,16 @@ object FloatRing extends Ring[Float] {
     else
       Some {
         val iter = t.toIterator
-        var sum = iter.next().toDouble
-        var c = 0.0
+        var sum = iter.next()
+        var c = 0.0f
         while (iter.hasNext) {
-          val y = iter.next().toDouble - c
+          val y = iter.next() - c
           val t = sum + y
           c = (t - sum) - y
           sum = t
         }
 
-        sum.toFloat
+        sum
       }
 }
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Ring.scala
@@ -151,16 +151,16 @@ object FloatRing extends Ring[Float] {
     else
       Some {
         val iter = t.toIterator
-        var sum = iter.next()
-        var c = 0.0f
+        var sum = iter.next().toDouble
+        var c = 0.0
         while (iter.hasNext) {
-          val y = iter.next() - c
+          val y = iter.next().toDouble - c
           val t = sum + y
           c = (t - sum) - y
           sum = t
         }
 
-        sum
+        sum.toFloat
       }
 }
 

--- a/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/AggregatorLaws.scala
@@ -22,8 +22,8 @@ import org.scalacheck.Prop
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
-  Unit tests to highlight specific examples of the properties we guarantee.
-  */
+ *  Unit tests to highlight specific examples of the properties we guarantee.
+ */
 class AggregatorTests extends AnyFunSuite {
   test("Kahan summation mitigates Double error accumulation") {
 


### PR DESCRIPTION
My suggested tests for the Kahan summation PR @johnynek wrote up in #848.

@johnynek, I also backed off the `toDouble`, `toFloat`. I would have expected, based on this, that the tests would fail by turning all of the intermediates into doubles!

```scala
scala> val input = Stream.continually(0.01f).take(1000).map(implicitly[Numeric[Float]].toDouble(_))
input: scala.collection.immutable.Stream[Double] = Stream(0.009999999776482582, ?)

scala> input.map(implicitly[Numeric[Float]].toDouble(_)).take(5).toList
res3: List[Double] = List(0.009999999776482582, 0.009999999776482582, 0.009999999776482582, 0.009999999776482582, 0.009999999776482582)
```

But it turns out that the `toFloat` at the end "fixes" these errors. I added a third test to make this more clear.