### PR TITLE
expose maximum number of items and ordering in PQ

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/mutable/PriorityQueueMonoid.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/mutable/PriorityQueueMonoid.scala
@@ -29,7 +29,7 @@ class PriorityQueueMonoid[K](max: Int)(implicit ord: Ordering[K]) extends Monoid
   def maximumItems: Int = max
   def ordering: Ordering[K] = ord
   private[this] val revOrd: Ordering[K] = ord.reverse
-  
+
   require(max > 0, s"PriorityQueueMonoid requires keeping at least 1 item, invalid max=$max")
   // Java throws if you try to make a queue size 0
   protected val MINQUEUESIZE = 1


### PR DESCRIPTION
If you have a PriorityQueue monoid, there is no reason to hide the ordering and the maximum number of items. Both of which could be discovered from the values.