### PR TITLE
Simple Fix of SketchMap's non-commutative (issue-1122)

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/SketchMap.scala
@@ -18,6 +18,7 @@ package com.twitter.algebird
 
 import algebra.CommutativeMonoid
 import com.twitter.algebird.matrix.AdaptiveMatrix
+import com.twitter.algebird.matrix.DenseMatrix
 
 /**
  * A Sketch Map is a generalized version of the Count-Min Sketch that is an approximation of Map[K, V] that
@@ -50,7 +51,10 @@ class SketchMapMonoid[K, V](val params: SketchMapParams[K])(implicit
     SketchMap(AdaptiveMatrix.fill(params.depth, params.width)(monoid.zero), Nil, monoid.zero)
 
   override def plus(left: SketchMap[K, V], right: SketchMap[K, V]): SketchMap[K, V] = {
-    val newValuesTable = Monoid.plus(left.valuesTable, right.valuesTable)
+    val newValuesTable = right.valuesTable match {
+      case DenseMatrix(_, _, _) => Monoid.plus(right.valuesTable, left.valuesTable)
+      case _                    => Monoid.plus(left.valuesTable, right.valuesTable)
+    }
     val newHeavyHitters = left.heavyHitterKeys.toSet ++ right.heavyHitterKeys
 
     SketchMap(


### PR DESCRIPTION
This PR introduces a simple fix to SketchMap's non-commutative, as illustrated in https://github.com/twitter/algebird/issues/1122 

The fix is simply to always put the DenseMatrix as the first param so that the update to it is correct.
