### PR TITLE
Update ring.md

### DIFF
--- a/docs/src/main/mdoc/typeclasses/ring.md
+++ b/docs/src/main/mdoc/typeclasses/ring.md
@@ -21,7 +21,7 @@ Notes on rings:
 - A ring does not necessarily have an identity under `*` (called the *multiplicative identity*).
 - A ring is not necessarily commutitive under `*`.
 - A ring does not necessarily satisfy the inverse property under `*`.
-- There is not necessarily any special property of the additive identity under multiplication.
+- For any x &isin; R, `0*x = x*0 = 0`.
 
 A few other types of rings:
 


### PR DESCRIPTION
The previous version of the documentation omitted an important property of rings concerning the additive identity and multiplication. Specifically, it is a fundamental property of rings that multiplying any element by the additive identity (0) results in the additive identity (0). This change ensures the documentation accurately reflects this property, enhancing both the correctness and comprehensiveness of the material. This property is critical for understanding how elements within a ring interact under multiplication, especially in educational contexts where learners are building foundational knowledge of algebraic structures.
