### PR TITLE
Add an efficient reservoir sampling aggregator

### DIFF
--- a/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/ReservoirSamplingBenchmark.scala
+++ b/algebird-benchmark/src/main/scala/com/twitter/algebird/benchmark/ReservoirSamplingBenchmark.scala
@@ -1,0 +1,42 @@
+package com.twitter.algebird.benchmark
+
+import com.twitter.algebird.mutable.ReservoirSamplingToListAggregator
+import com.twitter.algebird.{Aggregator, Preparer}
+import org.openjdk.jmh.annotations.{Benchmark, Param, Scope, State}
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.util.Random
+
+object ReservoirSamplingBenchmark {
+  @State(Scope.Benchmark)
+  class BenchmarkState {
+    @Param(Array("100", "10000", "1000000"))
+    var collectionSize: Int = 0
+
+    @Param(Array("0.001", "0.01", "0.1"))
+    var sampleRate: Double = 0.0
+
+    def samples: Int = (sampleRate * collectionSize).ceil.toInt
+  }
+
+  val rng = new Random()
+  implicit val randomSupplier: () => Random = () => rng
+}
+
+class ReservoirSamplingBenchmark {
+  import ReservoirSamplingBenchmark._
+
+  private def prioQueueSampler[T](count: Int) =
+    Preparer[T]
+      .map(rng.nextDouble() -> _)
+      .monoidAggregate(Aggregator.sortByTake(count)(_._1))
+      .andThenPresent(_.map(_._2))
+
+  @Benchmark
+  def timeAlgorithmL(state: BenchmarkState, bh: Blackhole): Unit =
+    bh.consume(new ReservoirSamplingToListAggregator[Int](state.samples).apply(0 until state.collectionSize))
+
+  @Benchmark
+  def timePriorityQeueue(state: BenchmarkState, bh: Blackhole): Unit =
+    bh.consume(prioQueueSampler(state.samples).apply(0 until state.collectionSize))
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala
@@ -1,5 +1,7 @@
 package com.twitter.algebird
 
+import com.twitter.algebird.mutable.{Reservoir, ReservoirSamplingToListAggregator}
+
 import java.util.PriorityQueue
 import scala.collection.compat._
 import scala.collection.generic.CanBuildFrom
@@ -286,12 +288,9 @@ object Aggregator extends java.io.Serializable {
   def reservoirSample[T](
       count: Int,
       seed: Int = DefaultSeed
-  ): MonoidAggregator[T, PriorityQueue[(Double, T)], Seq[T]] = {
-    val rng = new java.util.Random(seed)
-    Preparer[T]
-      .map(rng.nextDouble() -> _)
-      .monoidAggregate(sortByTake(count)(_._1))
-      .andThenPresent(_.map(_._2))
+  ): MonoidAggregator[T, Reservoir[T], Seq[T]] = {
+    val rng = new scala.util.Random(seed)
+    new ReservoirSamplingToListAggregator[T](count)(() => rng)
   }
 
   /**

--- a/algebird-core/src/main/scala/com/twitter/algebird/mutable/ReservoirSampling.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/mutable/ReservoirSampling.scala
@@ -1,0 +1,298 @@
+package com.twitter.algebird.mutable
+
+import com.twitter.algebird.{Monoid, MonoidAggregator}
+
+import scala.collection.mutable
+import scala.util.Random
+
+/**
+ * A reservoir of the currently sampled items.
+ *
+ * @param capacity
+ *   the reservoir capacity
+ * @tparam T
+ *   the element type
+ */
+sealed abstract class Reservoir[T](val capacity: Int) {
+  require(capacity > 0, "reservoir size must be positive")
+
+  def size: Int
+  def isEmpty: Boolean = size == 0
+  def isFull: Boolean = size == capacity
+
+  // When the reservoir is full, w is the threshold for accepting an element into the reservoir, and
+  // the following invariant holds: The maximum score of the elements in the reservoir is w,
+  // and the remaining elements are distributed as U[0, w].
+  // Scores are not kept explicitly, only their distribution is tracked and sampled from.
+  // (w = 1 when the reservoir is not full.)
+  def w: Double = 1
+
+  private[algebird] def toSeq: mutable.IndexedSeq[T]
+
+  /**
+   * Add an element to the reservoir. If the reservoir is full then the element will replace a random element
+   * in the reservoir, and the threshold <pre>w</pre> is updated.
+   *
+   * When adding multiple elements, [[append]] should be used to take advantage of exponential jumps.
+   *
+   * @param x
+   *   the element to add
+   * @param rng
+   *   the random source
+   */
+  private[algebird] def accept(x: T, rng: Random): Reservoir[T]
+
+  // The number of items to skip before accepting the next item is geometrically distributed
+  // with probability of success w / prior. The prior will be 1 when adding to a single reservoir,
+  // but when merging reservoirs it will be the threshold of the reservoir being pulled from,
+  // and in this case we require that w < prior.
+  private def nextAcceptTime(rng: Random, prior: Double): Int =
+    (-rng.self.nextExponential / Math.log1p(-w / prior)).toInt
+
+  /**
+   * Add multiple elements to the reservoir.
+   *
+   * @param xs
+   *   the elements to add
+   * @param rng
+   *   the random source
+   * @param prior
+   *   the threshold of the elements being added, such that the added element's value is distributed as
+   *   <pre>U[0, prior]</pre>
+   * @return
+   *   this reservoir
+   */
+  def append(xs: TraversableOnce[T], rng: Random, prior: Double = 1.0): Reservoir[T] =
+    xs match {
+      case seq: IndexedSeq[T] => Reservoir.append(this, seq, rng, prior)
+      case _                  => Reservoir.append(this, xs, rng, prior)
+    }
+}
+
+private[algebird] case class Empty[T](k: Int) extends Reservoir[T](k) {
+  override val size: Int = 0
+  override val isEmpty: Boolean = true
+  override val isFull: Boolean = false
+
+  override def toSeq: mutable.IndexedSeq[T] = mutable.IndexedSeq()
+
+  override def accept(x: T, rng: Random): Reservoir[T] =
+    Singleton(k, x, if (capacity == 1) rng.nextDouble else 1)
+
+  override def toString: String = s"Empty($capacity)"
+}
+
+// A reservoir with one element (but possibly higher capacity), optimizing the common case of sampling a
+// single element.
+private[algebird] case class Singleton[T](k: Int, x: T, w1: Double) extends Reservoir[T](k) {
+  override val size: Int = 1
+  override val isEmpty: Boolean = false
+  override val isFull: Boolean = capacity == 1
+  override val w: Double = w1
+
+  override def toSeq: mutable.IndexedSeq[T] = mutable.IndexedSeq(x)
+
+  override def accept(y: T, rng: Random): Reservoir[T] =
+    if (isFull)
+      Singleton(k, y, w * rng.nextDouble)
+    else
+      new ArrayReservoir(k).accept(x, rng).accept(y, rng)
+
+  override def toString: String = s"Singleton($capacity, $w, $x)"
+}
+
+// A reservoir backed by a mutable buffer - will mutate by aggregation!
+private[algebird] class ArrayReservoir[T](val k: Int) extends Reservoir[T](k) {
+  private val reservoir: mutable.ArrayBuffer[T] = new mutable.ArrayBuffer(k)
+  private var w1: Double = 1
+  private val kInv: Double = 1d / capacity
+
+  override def size: Int = reservoir.size
+  override def w: Double = w1
+  override def toSeq: mutable.IndexedSeq[T] = reservoir
+
+  override def accept(x: T, rng: Random): Reservoir[T] = {
+    if (isFull) {
+      reservoir(rng.nextInt(capacity)) = x
+    } else {
+      reservoir.append(x)
+    }
+    if (isFull) {
+      w1 *= Math.pow(rng.nextDouble, kInv)
+    }
+    this
+  }
+
+  override def toString: String = s"ArrayReservoir($capacity, $w, ${reservoir.toList})"
+}
+
+object Reservoir {
+  def apply[T](capacity: Int): Reservoir[T] = Empty(capacity)
+
+  private[algebird] def append[T](
+      self: Reservoir[T],
+      xs: TraversableOnce[T],
+      rng: Random,
+      prior: Double
+  ): Reservoir[T] = {
+    var res = self
+    var skip = if (res.isFull) res.nextAcceptTime(rng, prior) else 0
+    for (x <- xs) {
+      if (!res.isFull) {
+        // keep adding until reservoir is full
+        res = res.accept(x, rng)
+        if (res.isFull) {
+          skip = res.nextAcceptTime(rng, prior)
+        }
+      } else if (skip > 0) {
+        skip -= 1
+      } else {
+        res = res.accept(x, rng)
+        skip = res.nextAcceptTime(rng, prior)
+      }
+    }
+    res
+  }
+
+  /**
+   * Add multiple elements to the reservoir. This overload is optimized for indexed sequences, where we can
+   * skip over multiple indexes without accessing the elements.
+   *
+   * @param xs
+   *   the elements to add
+   * @param rng
+   *   the random source
+   * @param prior
+   *   the threshold of the elements being added, such that the added element's value is distributed as
+   *   <pre>U[0, prior]</pre>
+   * @return
+   *   this reservoir
+   */
+  private[algebird] def append[T](
+      self: Reservoir[T],
+      xs: IndexedSeq[T],
+      rng: Random,
+      prior: Double
+  ): Reservoir[T] = {
+    var res = self
+    var i = xs.size.min(res.capacity - res.size)
+    for (j <- 0 until i) {
+      res = res.accept(xs(j), rng)
+    }
+
+    val end = xs.size
+    assert(res.isFull || i == end)
+    while (i >= 0 && i < end) {
+      i += res.nextAcceptTime(rng, prior)
+      // the addition can overflow, in which case i < 0
+      if (i >= 0 && i < end) {
+        // element enters the reservoir
+        res = res.accept(xs(i), rng)
+        i += 1
+      }
+    }
+    res
+  }
+}
+
+/**
+ * This is the "Algorithm L" reservoir sampling algorithm [1], with modifications to act as a monoid by
+ * merging reservoirs.
+ *
+ * [1] Kim-Hung Li, "Reservoir-Sampling Algorithms of Time Complexity O(n(1+log(N/n)))", 1994
+ *
+ * @tparam T
+ *   the item type
+ */
+class ReservoirMonoid[T](val capacity: Int)(implicit val randomSupplier: () => Random)
+    extends Monoid[Reservoir[T]] {
+
+  override def zero: Reservoir[T] = Reservoir(capacity)
+  override def isNonZero(r: Reservoir[T]): Boolean = !r.isEmpty
+
+  /**
+   * Merge two reservoirs. NOTE: This mutates one or both of the reservoirs. They should not be used after
+   * this operation, except when using the return value for further aggregation.
+   */
+  override def plus(left: Reservoir[T], right: Reservoir[T]): Reservoir[T] =
+    if (left.isEmpty) right
+    else if (left.size + right.size <= left.capacity) {
+      // the sum of the sizes is less than the reservoir size, so we can just merge
+      left.append(right.toSeq, randomSupplier())
+    } else {
+      val (s1, s2) = if (left.w < right.w) (left, right) else (right, left)
+      val xs = s2.toSeq
+      val rng = randomSupplier()
+      if (s2.isFull) {
+        assert(s1.isFull)
+        // The highest score in s2 is w, and the other scores are distributed as U[0, w].
+        // Since s1.w < s2.w, we have to drop the single (sampled) element with the highest score
+        // unconditionally. The other elements enter the reservoir with probability s1.w / s2.w.
+        val i = rng.nextInt(xs.size)
+        xs(i) = xs.head
+        s1.append(xs.drop(1), rng, s2.w)
+      } else {
+        s1.append(xs, rng)
+      }
+    }
+}
+
+/**
+ * An aggregator that uses reservoir sampling to sample k elements from a stream of items. Because the
+ * reservoir is mutable, it is a good idea to copy the result to an immutable view before using it, as is done
+ * by [[ReservoirSamplingToListAggregator]].
+ *
+ * @param capacity
+ *   the number of elements to sample
+ * @param randomSupplier
+ *   the random generator
+ * @tparam T
+ *   the item type
+ * @tparam C
+ *   the result type
+ */
+abstract class ReservoirSamplingAggregator[T, +C](capacity: Int)(implicit val randomSupplier: () => Random)
+    extends MonoidAggregator[T, Reservoir[T], C] {
+  override val monoid: ReservoirMonoid[T] = new ReservoirMonoid(capacity)
+  override def prepare(x: T): Reservoir[T] = Reservoir(capacity).accept(x, randomSupplier())
+
+  override def apply(xs: TraversableOnce[T]): C = present(agg(xs))
+
+  override def applyOption(inputs: TraversableOnce[T]): Option[C] =
+    if (inputs.isEmpty) None else Some(apply(inputs))
+
+  override def append(r: Reservoir[T], t: T): Reservoir[T] = r.append(Seq(t), randomSupplier())
+
+  override def appendAll(r: Reservoir[T], xs: TraversableOnce[T]): Reservoir[T] =
+    r.append(xs, randomSupplier())
+
+  override def appendAll(xs: TraversableOnce[T]): Reservoir[T] = agg(xs)
+
+  private def agg(xs: TraversableOnce[T]): Reservoir[T] =
+    appendAll(monoid.zero, xs)
+}
+
+class ReservoirSamplingToListAggregator[T](capacity: Int)(implicit randomSupplier: () => Random)
+    extends ReservoirSamplingAggregator[T, List[T]](capacity)(randomSupplier) {
+  override def present(r: Reservoir[T]): List[T] =
+    randomSupplier().shuffle(r.toSeq).toList
+
+  override def andThenPresent[D](f: List[T] => D): MonoidAggregator[T, Reservoir[T], D] =
+    new AndThenPresent(this, f)
+}
+
+/**
+ * Monoid that implements [[andThenPresent]] without ruining the optimized behavior of the aggregator.
+ */
+private[algebird] class AndThenPresent[-A, B, C, +D](val agg: MonoidAggregator[A, B, C], f: C => D)
+    extends MonoidAggregator[A, B, D] {
+  override val monoid: Monoid[B] = agg.monoid
+  override def prepare(a: A): B = agg.prepare(a)
+  override def present(b: B): D = f(agg.present(b))
+
+  override def apply(xs: TraversableOnce[A]): D = f(agg(xs))
+  override def applyOption(xs: TraversableOnce[A]): Option[D] = agg.applyOption(xs).map(f)
+  override def append(b: B, a: A): B = agg.append(b, a)
+  override def appendAll(b: B, as: TraversableOnce[A]): B = agg.appendAll(b, as)
+  override def appendAll(as: TraversableOnce[A]): B = agg.appendAll(as)
+}

--- a/algebird-test/src/main/scala/com/twitter/algebird/RandomSamplingLaws.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/RandomSamplingLaws.scala
@@ -1,0 +1,123 @@
+package com.twitter.algebird
+
+import com.twitter.algebird.scalacheck.Distribution._
+import org.scalacheck.{Gen, Prop}
+
+object RandomSamplingLaws {
+
+  def sampleOneUniformly[T](newSampler: Int => Aggregator[Int, T, Seq[Int]]): Prop = {
+    val n = 100
+
+    "sampleOne" |: forAllSampled(10000, Gen.choose(1, 20))(_ => uniform(n)) { k =>
+      newSampler(k).andThenPresent(_.head).apply(0 until n)
+    }
+  }
+
+  def reservoirSizeOne[T](newSampler: Int => Aggregator[Int, T, Seq[Int]]): Prop = {
+    val n = 100
+
+    "reservoirSizeOne" |: forAllSampled(10000)(uniform(n)) {
+      newSampler(1).andThenPresent(_.head).apply(0 until n)
+    }
+  }
+
+  def reservoirSizeTwo[T](newSampler: Int => Aggregator[Int, T, Seq[Int]]): Prop = {
+    val n = 10
+    val tuples = for {
+      i <- 0 until n
+      j <- 0 until n
+      if i != j
+    } yield (i, j)
+
+    "reservoirSizeTwo" |: forAllSampled(10000)(tuples.map(_ -> 1d).toMap) {
+      newSampler(2).andThenPresent(xs => (xs(0), xs(1))).apply(0 until n)
+    }
+  }
+
+  def sampleSpecificItem[T](newSampler: Int => Aggregator[Int, T, Seq[Int]]): Prop = {
+    val sizeAndIndex: Gen[(Int, Int)] = for {
+      k <- Gen.choose(1, 10)
+      i <- Gen.choose(0, k - 1)
+    } yield (k, i)
+
+    val n = 100
+
+    "sampleAnyItem" |: forAllSampled(10000, sizeAndIndex)(_ => uniform(n)) { case (k, i) =>
+      newSampler(k).andThenPresent(_(i)).apply(0 until n)
+    }
+  }
+
+  def sampleTwoItems[T](newSampler: Int => Aggregator[Int, T, Seq[Int]]): Prop = {
+    val sizeAndIndexes: Gen[(Int, Int, Int)] = for {
+      k <- Gen.choose(1, 10)
+      i <- Gen.choose(0, k - 1)
+      j <- Gen.choose(0, k - 1)
+      if i != j
+    } yield (k, i, j)
+
+    val n = 20
+
+    "sampleTwoItems" |: forAllSampled(10000, sizeAndIndexes)(_ =>
+      (for {
+        i <- 0 until n
+        j <- 0 until n
+        if i != j
+      } yield (i, j)).map(_ -> 1d).toMap
+    ) { case (k, i, j) =>
+      newSampler(k).andThenPresent(xs => (xs(i), xs(j))).apply(0 until n)
+    }
+  }
+
+  def appendPiecewise[T](newSampler: Int => MonoidAggregator[Int, T, Seq[Int]]): Prop =
+    "sampleOne" |: forAllSampled(10000, Gen.choose(1, 20))(k => uniform(k + 1)) { k =>
+      val agg = newSampler(k)
+      val res = agg.appendAll(agg.monoid.zero, 0 until k)
+      agg.present(agg.appendAll(res, List(k))).head
+    }
+
+  def aggregateHierarchy[T](newSampler: Int => MonoidAggregator[Int, T, Seq[Int]]): Prop =
+    "aggregateHierarchy" |: forAllSampled(10000, Gen.choose(1, 20))(k => uniform(6 * k)) { k =>
+      val agg = newSampler(k)
+      val r1 = agg.reduce((0 until 2 * k).map(agg.prepare))
+      val r2 = agg.reduce((2 * k until 3 * k).map(agg.prepare))
+      val r3 = agg.reduce((3 * k until 4 * k).map(agg.prepare))
+      val r4 = agg.reduce((4 * k until 6 * k).map(agg.prepare))
+      val s1 = agg.monoid.plus(r1, r2)
+      val s2 = agg.monoid.plus(r3, r4)
+      val res = agg.monoid.plus(s1, s2)
+      agg.present(res).head
+    }
+
+  def imbalancedSplit[T](newSampler: Int => MonoidAggregator[Int, T, Seq[Int]]): Prop =
+    "imbalancedSplit" |: forAllSampled(10000, Gen.choose(10, 30))(uniform) { k =>
+      val agg = newSampler(2)
+      val r1 = agg.appendAll(agg.monoid.zero, Seq(0, 1))
+      val r2 = agg.appendAll(agg.monoid.zero, 2 until k)
+      val res = agg.monoid.plus(r1, r2)
+      agg.present(res).head
+    }
+
+  def aggregateNonFullReservoirs[T](newSampler: Int => MonoidAggregator[Int, T, Seq[Int]]): Prop =
+    "aggregateNonFullReservoirs" |: forAllSampled(10000, Gen.choose(1, 10))(k => uniform(6 * k)) { k =>
+      val agg = newSampler(2 * k).andThenPresent(_.head)
+      val r1 = agg.appendAll(agg.monoid.zero, 0 until 2 * k)
+      val r2 = agg.appendAll(agg.monoid.zero, 2 * k until 3 * k)
+      val r3 = agg.appendAll(agg.monoid.zero, 3 * k until 4 * k)
+      val r4 = agg.appendAll(agg.monoid.zero, 4 * k until 6 * k)
+      val s1 = agg.monoid.plus(r1, r2)
+      val s2 = agg.monoid.plus(r3, r4)
+      val res = agg.monoid.plus(s1, s2)
+      agg.present(res)
+    }
+
+  def randomSamplingDistributions[T](newSampler: Int => MonoidAggregator[Int, T, Seq[Int]]): Prop =
+    sampleOneUniformly(newSampler) &&
+      reservoirSizeOne(newSampler) &&
+      reservoirSizeTwo(newSampler) &&
+      sampleSpecificItem(newSampler) &&
+      sampleTwoItems(newSampler) &&
+      appendPiecewise(newSampler) &&
+      aggregateHierarchy(newSampler) &&
+      imbalancedSplit(newSampler) &&
+      aggregateNonFullReservoirs(newSampler)
+}

--- a/algebird-test/src/main/scala/com/twitter/algebird/scalacheck/Distribution.scala
+++ b/algebird-test/src/main/scala/com/twitter/algebird/scalacheck/Distribution.scala
@@ -1,0 +1,154 @@
+package com.twitter.algebird.scalacheck
+
+import org.apache.commons.statistics.inference.{ChiSquareTest, SignificanceResult}
+import org.scalacheck.Prop.forAllNoShrink
+import org.scalacheck.{Gen, Prop}
+
+import scala.collection.mutable
+
+/**
+ * ScalaCheck properties for probabilistic testing.
+ *
+ * For randomized algorithms, we want to verify that the output follows the expected distribution. The
+ * [[forAllSampled]] properties execute the test code a speecified number of times, collect results and
+ * perform a chi-squared test.
+ *
+ * These properties do not shrink their input generators, as this is less useful for probabilistic tests.
+ *
+ * @param expectedFreq
+ *   A map of outputs (results of the test code) to their expected frequencies. Frequencies do not have to add
+ *   up to 1, only their relative size matters. They can all be equal to 1 if a uniform distribution is
+ *   expected.
+ *
+ * @param alpha
+ *   the significance level for the chi-squared test
+ *
+ * @tparam T
+ *   the result type of the test code
+ */
+class Distribution[T](val expectedFreq: Map[T, Double], val alpha: Double) {
+  private val samples: mutable.Map[T, Long] = mutable.Map().withDefaultValue(0)
+
+  def collect(t: T): Unit = samples(t) += 1
+
+  def isNotRejected: Boolean = !chiSquareTest.reject(alpha)
+
+  private def chiSquareTest: SignificanceResult = {
+    val (expected, observed) = expectedFreq.toSeq.map { case (k, v) => (v, samples(k)) }.toArray.unzip
+    ChiSquareTest.withDefaults.test(expected, observed)
+  }
+}
+
+object Distribution {
+  private val defaultSigLevel = 0.001
+
+  implicit def propFromDistribution[T](d: Distribution[T]): Prop =
+    d.isNotRejected || Prop.falsified :| s"\u03a7\u00b2 test rejected the null hypothesis at \u03b1=${d.alpha} (p=${d.chiSquareTest.getPValue})"
+
+  def uniform(n: Int): Map[Int, Double] = (0 until n).map(_ -> 1d).toMap
+
+  /**
+   * Runs the code block for the specified number of trials and verifies that the output follows the expected
+   * distribution. The propoerty passes if a chi-squared test fails to reject the null hypothesis that the
+   * distribution is the expected one at the given significance level.
+   *
+   * @param trials
+   *   the number of iterations
+   * @param alpha
+   *   the significance level
+   * @param expect
+   *   A function computing the map of outputs (possible results) to their expected frequencies. For the
+   *   overloaded versions of this method taking generator parameters, this function takes the generated
+   *   values as input.
+   * @param f
+   *   the test code
+   * @tparam T
+   *   the result type
+   * @return
+   *   a [[Distribution]] object that can be used as a ScalaCheck property
+   */
+  def forAllSampled[T](trials: Int, alpha: Double = defaultSigLevel)(
+      expect: Map[T, Double]
+  )(f: => T): Prop = {
+    val d = new Distribution(expect, alpha)
+    (0 until trials).foreach { _ =>
+      d.collect(f)
+    }
+    d
+  }
+
+  def forAllSampled[T1, T](trials: Int, g1: Gen[T1])(expect: T1 => Map[T, Double])(f: T1 => T): Prop =
+    forAllNoShrink(g1)(t1 => forAllSampled(trials)(expect(t1))(f(t1)))
+
+  def forAllSampled[T1, T2, T](trials: Int, g1: Gen[T1], g2: Gen[T2])(expect: (T1, T2) => Map[T, Double])(
+      f: (T1, T2) => T
+  ): Prop = forAllNoShrink(g1)(t1 => forAllSampled(trials, g2)(expect(t1, _: T2))(f(t1, _: T2)))
+
+  def forAllSampled[T1, T2, T3, T](trials: Int, g1: Gen[T1], g2: Gen[T2], g3: Gen[T3])(
+      expect: (T1, T2, T3) => Map[T, Double]
+  )(f: (T1, T2, T3) => T): Prop =
+    forAllNoShrink(g1, g2)((t1, t2) => forAllSampled(trials, g3)(expect(t1, t2, _: T3))(f(t1, t2, _: T3)))
+
+  def forAllSampled[T1, T2, T3, T4, T](trials: Int, g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4])(
+      expect: (T1, T2, T3, T4) => Map[T, Double]
+  )(f: (T1, T2, T3, T4) => T): Prop = forAllNoShrink(g1, g2, g3)((t1, t2, t3) =>
+    forAllSampled(trials, g4)(expect(t1, t2, t3, _: T4))(f(t1, t2, t3, _: T4))
+  )
+
+  def forAllSampled[T1, T2, T3, T4, T5, T](
+      trials: Int,
+      g1: Gen[T1],
+      g2: Gen[T2],
+      g3: Gen[T3],
+      g4: Gen[T4],
+      g5: Gen[T5]
+  )(expect: (T1, T2, T3, T4, T5) => Map[T, Double])(f: (T1, T2, T3, T4, T5) => T): Prop =
+    forAllNoShrink(g1, g2, g3, g4)((t1, t2, t3, t4) =>
+      forAllSampled(trials, g5)(expect(t1, t2, t3, t4, _: T5))(f(t1, t2, t3, t4, _: T5))
+    )
+
+  def forAllSampled[T1, T2, T3, T4, T5, T6, T](
+      trials: Int,
+      g1: Gen[T1],
+      g2: Gen[T2],
+      g3: Gen[T3],
+      g4: Gen[T4],
+      g5: Gen[T5],
+      g6: Gen[T6]
+  )(expect: (T1, T2, T3, T4, T5, T6) => Map[T, Double])(f: (T1, T2, T3, T4, T5, T6) => T): Prop =
+    forAllNoShrink(g1, g2, g3, g4, g5)((t1, t2, t3, t4, t5) =>
+      forAllSampled(trials, g6)(expect(t1, t2, t3, t4, t5, _: T6))(f(t1, t2, t3, t4, t5, _: T6))
+    )
+
+  def forAllSampled[T1, T2, T3, T4, T5, T6, T7, T](
+      trials: Int,
+      g1: Gen[T1],
+      g2: Gen[T2],
+      g3: Gen[T3],
+      g4: Gen[T4],
+      g5: Gen[T5],
+      g6: Gen[T6],
+      g7: Gen[T7]
+  )(expect: (T1, T2, T3, T4, T5, T6, T7) => Map[T, Double])(f: (T1, T2, T3, T4, T5, T6, T7) => T): Prop =
+    forAllNoShrink(g1, g2, g3, g4, g5, g6)((t1, t2, t3, t4, t5, t6) =>
+      forAllSampled(trials, g7)(expect(t1, t2, t3, t4, t5, t6, _: T7))(f(t1, t2, t3, t4, t5, t6, _: T7))
+    )
+
+  def forAllSampled[T1, T2, T3, T4, T5, T6, T7, T8, T](
+      trials: Int,
+      g1: Gen[T1],
+      g2: Gen[T2],
+      g3: Gen[T3],
+      g4: Gen[T4],
+      g5: Gen[T5],
+      g6: Gen[T6],
+      g7: Gen[T7],
+      g8: Gen[T8]
+  )(expect: (T1, T2, T3, T4, T5, T6, T7, T8) => Map[T, Double])(
+      f: (T1, T2, T3, T4, T5, T6, T7, T8) => T
+  ): Prop = forAllNoShrink(g1, g2, g3, g4, g5, g6, g7)((t1, t2, t3, t4, t5, t6, t7) =>
+    forAllSampled(trials, g8)(expect(t1, t2, t3, t4, t5, t6, t7, _: T8))(
+      f(t1, t2, t3, t4, t5, t6, t7, _: T8)
+    )
+  )
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/mutable/ReservoirMonoidTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/mutable/ReservoirMonoidTest.scala
@@ -1,0 +1,32 @@
+package com.twitter.algebird.mutable
+
+import com.twitter.algebird.CheckProperties
+import com.twitter.algebird.scalacheck.Distribution.{forAllSampled, uniform}
+import org.scalacheck.Gen
+
+import scala.util.Random
+
+class ReservoirMonoidTest extends CheckProperties {
+  val rng = new Random()
+  implicit val randomSupplier: () => Random = () => rng
+
+  property("adding empty is no-op") {
+    val mon: ReservoirMonoid[Int] = new ReservoirMonoid(1)
+    val a = mon.zero.accept(1, rng)
+    val b = mon.zero.accept(1, rng)
+    val z = mon.zero
+    (mon.plus(a, z) == a) &&
+    (mon.plus(z, b) == b)
+  }
+
+  property("plus produces correct distribution") {
+    forAllSampled(10000, Gen.choose(1, 20))(n => uniform(2 * n)) { n =>
+      val mon: ReservoirMonoid[Int] = new ReservoirMonoid(n)
+      val a = (0 until n).foldLeft(mon.zero)((r, x) => r.accept(x, rng))
+      val b = (n until 2 * n).foldLeft(mon.zero)((r, x) => r.accept(x, rng))
+
+      val c = mon.plus(a, b)
+      c.toSeq(rng.nextInt(c.size))
+    }
+  }
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/mutable/ReservoirSamplingTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/mutable/ReservoirSamplingTest.scala
@@ -1,0 +1,66 @@
+package com.twitter.algebird.mutable
+
+import com.twitter.algebird.RandomSamplingLaws._
+import com.twitter.algebird.scalacheck.Distribution.{forAllSampled, uniform}
+import com.twitter.algebird.{Aggregator, CheckProperties, Preparer}
+import org.scalacheck.Gen
+
+import scala.util.Random
+
+// These tests are probabilistic and expected to fail at a rate of 0.1% per example (multiple examples are run per test)
+class ReservoirSamplingTest extends CheckProperties {
+
+  val rng = new Random()
+  implicit val randomSupplier: () => Random = () => rng
+
+  property("reservoir sampling with Algorithm L works") {
+    randomSamplingDistributions(new ReservoirSamplingToListAggregator[Int](_))
+  }
+
+  private def prioQueueSampler[T](count: Int) =
+    Preparer[T]
+      .map(rng.nextDouble() -> _)
+      .monoidAggregate(Aggregator.sortByTake(count)(_._1))
+      .andThenPresent(_.map(_._2))
+
+  property("reservoir sampling with priority queue works") {
+    randomSamplingDistributions(prioQueueSampler)
+  }
+
+  property("sampling from non-indexed Seq") {
+    val n = 100
+    forAllSampled(10000, Gen.choose(1, 20))(_ => uniform(n)) { k =>
+      new ReservoirSamplingToListAggregator[Int](k).apply((0 until n).asInstanceOf[Seq[Int]]).head
+    }
+  }
+
+  property("append piecewise (Seq)") {
+    forAllSampled(10000, Gen.choose(1, 20))(k => uniform(k + 1)) { k =>
+      val agg = new ReservoirSamplingToListAggregator[Int](k)
+      val r1 = agg.appendAll(agg.monoid.zero, 0 until k)
+      val r2 = agg.append(r1, k)
+      agg.present(r2).head
+    }
+  }
+
+  property("append piecewise (IndexedSeq)") {
+    forAllSampled(10000, Gen.choose(1, 20))(k => uniform(k + 1)) { k =>
+      val agg = new ReservoirSamplingToListAggregator[Int](k)
+      val r1 = agg.appendAll(agg.monoid.zero, 0 until k)
+      val r2 = agg.appendAll(r1, IndexedSeq(k))
+      agg.present(r2).head
+    }
+  }
+
+  property("append piecewise 2 (IndexedSeq)") {
+    forAllSampled(10000, Gen.choose(1, 20), Gen.choose(1, 5), Gen.choose(1, 5))((k, l, m) =>
+      uniform(k + l + m)
+    ) { (k, l, m) =>
+      val agg = new ReservoirSamplingToListAggregator[Int](k)
+      val r1 = agg.appendAll(agg.monoid.zero, 0 until k)
+      val r2 = agg.appendAll(r1, k until k + l)
+      val r3 = agg.appendAll(r2, k + l until k + l + m)
+      agg.present(r3).head
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -240,6 +240,7 @@ lazy val algebirdTest = module("test")
       Seq(
         "org.scalacheck" %% "scalacheck" % scalacheckVersion,
         "org.scalatest" %% "scalatest" % scalaTestVersion,
+        "org.apache.commons" % "commons-statistics-inference" % "1.1",
         "org.scalatestplus" %% "scalatestplus-scalacheck" % scalaTestPlusVersion % "test"
       ) ++ {
         if (isScala213x(scalaVersion.value)) {


### PR DESCRIPTION
This aggregator uses Li's "Algorithm L", a simple yet efficient
sampling method, with modifications to support a monoidal setting.

A JMH benchmark was added for both this and the old priority-queue
algoritm. In a single-threaded benchmark on an Intel Core i9-10885H,
this algorithm can outperform the old one by an order of magnitude or
more, depending on the parameters.

Because of this, the new algorithm was made the default for
Aggregtor.reservoirSample().

Unit tests were added for both algorithms. These are probabilistic and
are expected to fail on some 0.1% of times, per test case (p-value is
set to 0.001).